### PR TITLE
Fix nvmlDeviceGetHandleByIndex not supported physical device ids

### DIFF
--- a/vllm_musa/musa.py
+++ b/vllm_musa/musa.py
@@ -462,7 +462,7 @@ class MtmlMUSAPlatform(MUSAPlatformBase):
     @with_mtml_context
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
         try:
-            # XXX (MUSA): CUDA uses physical device ids( cls.device_id_to_physical_device_id(device_id) ), 
+            # XXX (MUSA): CUDA uses physical device ids (cls.device_id_to_physical_device_id(device_id)), 
             # but torch.musa.get_device_capability uses logical device ids when MUSA_VISIBLE_DEVICES is set. 
             # Since pymtml doesn't do remapping, so we can only use device_id here.
             handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)

--- a/vllm_musa/musa.py
+++ b/vllm_musa/musa.py
@@ -462,6 +462,9 @@ class MtmlMUSAPlatform(MUSAPlatformBase):
     @with_mtml_context
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
         try:
+            # XXX (MUSA): CUDA uses physical device ids( cls.device_id_to_physical_device_id(device_id) ), 
+            # but torch.musa.get_device_capability uses logical device ids when MUSA_VISIBLE_DEVICES is set. 
+            # Since pymtml doesn't do remapping, so we can only use device_id here.
             handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
             major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
             return DeviceCapability(major=major, minor=minor)

--- a/vllm_musa/musa.py
+++ b/vllm_musa/musa.py
@@ -462,8 +462,7 @@ class MtmlMUSAPlatform(MUSAPlatformBase):
     @with_mtml_context
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
         try:
-            physical_device_id = cls.device_id_to_physical_device_id(device_id)
-            handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+            handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
             major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
             return DeviceCapability(major=major, minor=minor)
         except RuntimeError:


### PR DESCRIPTION
CUDA uses physical device ids( cls.device_id_to_physical_device_id(device_id) ), but torch.musa.get_device_capability uses logical device ids when MUSA_VISIBLE_DEVICES is set.  Since pymtml doesn't do remapping, so we can only use device_id here. 