### PR TITLE
Fix build vllm kernel for the first time may encounter failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "torch",
     "torch_musa",
-    "torchada>=0.1.44",
+    "torchada>=0.1.49",
     "mate",
     "mthreads-ml-py>=2.2.11",
     "numpy<2.0",

--- a/setup.py
+++ b/setup.py
@@ -404,24 +404,6 @@ class _CustomBuildExt(BuildExtension):
                 print(f"Error applying file override {file_path}: {e}")
 
     @staticmethod
-    def _apply_directory_overrides(repo_path):
-        """Copy local MUSA-specific directories to third-party vLLM csrc."""
-        local_csrc = Path(root) / "csrc"
-        vllm_csrc = Path(repo_path) / "csrc"
-
-        # Copy attention_musa directory
-        attention_musa_src = local_csrc / "attention_musa"
-        attention_musa_dst = vllm_csrc / "attention_musa"
-
-        if attention_musa_src.exists():
-            print(f"Copying MUSA attention directory: attention_musa")
-            if attention_musa_dst.exists():
-                shutil.rmtree(attention_musa_dst)
-            shutil.copytree(attention_musa_src, attention_musa_dst)
-        else:
-            print(f"Warning: attention_musa directory not found in local csrc/")
-
-    @staticmethod
     def _apply_text_patches():
         """Apply inline text replacements to upstream source files."""
         for file_path, replacement_rules in CSRC_TEXT_PATCHES.items():
@@ -475,7 +457,6 @@ class _CustomBuildExt(BuildExtension):
         _ensure_numpy_compatible()
 
         self._apply_file_overrides(_VLLM_REPO.source_dir)
-        self._apply_directory_overrides(_VLLM_REPO.source_dir)
         self._apply_text_patches()
 
         super().run()

--- a/setup.py
+++ b/setup.py
@@ -469,7 +469,7 @@ setup(
     # Force these dependencies even with --no-build-isolation
     # (pyproject.toml dependencies aren't processed with --no-build-isolation)
     install_requires=[
-        "torchada>=0.1.44",
+        "torchada>=0.1.49",
         "mthreads-ml-py>=2.2.11",
         "numpy<2",
         "openai>=2.24.0",


### PR DESCRIPTION
fixed: https://github.com/MooreThreads/vllm-musa/issues/14

This issue has been fixed in torchada. For details, please refer to https://github.com/MooreThreads/torchada/pull/54

The _apply_directory_overrides function in the original setup.py was an attempt to fix this issue, but it did not fully work. After the fix by torchada, this function was removed


