### PR TITLE
Fix deepseek R1  mtp

### DIFF
--- a/vllm_musa/v1/__init__.py
+++ b/vllm_musa/v1/__init__.py
@@ -1,2 +1,3 @@
 import vllm_musa.v1.attention.backends.mla.common
 import vllm_musa.v1.attention.backends.mla.flashmla
+import vllm_musa.v1.spec_decode.utils

--- a/vllm_musa/v1/spec_decode/utils.py
+++ b/vllm_musa/v1/spec_decode/utils.py
@@ -1,0 +1,75 @@
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def eagle_prepare_next_token_padded_kernel(
+    sampled_token_ids_ptr,  # [num_reqs, num_sampled_tokens_per_req]
+    discard_request_mask_ptr,  # [num_reqs]
+    backup_next_token_ids_ptr,  # [num_reqs]
+    next_token_ids_ptr,  # [num_reqs] (output)
+    valid_sampled_tokens_count_ptr,  # [num_reqs] (output)
+    vocab_size,  # tl.int32
+    num_sampled_tokens_per_req,  # tl.int32 (num_spec_tokens + 1)
+    num_reqs,  # tl.int32
+    stride_sampled_token_ids,  # tl.int32 (stride for dim 0)
+    BLOCK_SIZE_TOKENS: tl.constexpr,  # Power-of-2 >= num_sampled_tokens_per_req
+):
+    """
+    Fused kernel for Eagle prepare_next_token_ids_padded. This kernel computes the
+    number of valid (1 + accepted) tokens for each request, and the corresponding
+    "next" token id to sample from during speculative decoding. This is the
+    "last accepted token" from the sampled tokens, or the backup token if no
+    tokens were accepted or if the request is marked as discarded.
+    """
+    req_idx = tl.program_id(axis=0)
+    if req_idx >= num_reqs:
+        return
+
+    # Check if this request is discarded.
+    is_discarded = tl.load(discard_request_mask_ptr + req_idx)
+
+    if is_discarded:
+        backup_token = tl.load(backup_next_token_ids_ptr + req_idx)
+        # ==================== MUSA ADAPTATION ====================
+        valid_count = tl.full((), 0, dtype=tl.int32)
+        # ========================== END ==========================
+        tl.store(next_token_ids_ptr + req_idx, backup_token)
+        tl.store(valid_sampled_tokens_count_ptr + req_idx, valid_count)
+    else:
+        # Count the number of valid tokens among the sampled tokens.
+        token_offs = tl.arange(0, BLOCK_SIZE_TOKENS)
+        token_mask = token_offs < num_sampled_tokens_per_req
+
+        row_ptr = sampled_token_ids_ptr + req_idx * stride_sampled_token_ids
+        token_ids = tl.load(row_ptr + token_offs, mask=token_mask, other=-1)
+
+        # Rejected tokens are -1, valid tokens are in [0, vocab_size)
+        is_valid_mask = (token_ids != -1) & (token_ids < vocab_size) & token_mask
+        # ==================== MUSA ADAPTATION ====================
+        valid_count = tl.sum(is_valid_mask.to(tl.int32))
+        # ========================== END ==========================
+
+        if valid_count > 0:
+            # Guaranteed to be well-defined since
+            # valid_count > 0 implies is_valid_mask is not empty
+            last_valid_index = tl.max(tl.where(is_valid_mask, token_offs, -1))
+
+            # Select the token at that index, using a sum trick since
+            # we don't want to load again to access token_ids[last_valid_index].
+            last_valid_token = tl.sum(
+                tl.where(token_offs == last_valid_index, token_ids, 0)
+            )
+            tl.store(next_token_ids_ptr + req_idx, last_valid_token)
+        else:
+            # No valid tokens found, use backup token
+            backup_token = tl.load(backup_next_token_ids_ptr + req_idx)
+            tl.store(next_token_ids_ptr + req_idx, backup_token)
+
+        tl.store(valid_sampled_tokens_count_ptr + req_idx, valid_count)
+
+
+import vllm.v1.spec_decode.utils
+
+vllm.v1.spec_decode.utils.eagle_prepare_next_token_padded_kernel = (
+    eagle_prepare_next_token_padded_kernel
+)

--- a/vllm_musa/worker.py
+++ b/vllm_musa/worker.py
@@ -26,3 +26,9 @@ class MTGPUWorker(Worker):
             distributed_init_method=distributed_init_method,
             is_driver_worker=is_driver_worker,
         )
+
+    def execute_dummy_batch(self) -> None:
+        self.model_runner._dummy_run(
+            self.model_runner.uniform_decode_query_len,
+            uniform_decode=True,
+        )


### PR DESCRIPTION
1 The valid_count is not unified into the same Triton scalar type in the two control flow branches witch causes an error in triton. We should standardize it to int32 here.
2 When MTP and graph are both enabled, running a dummy run with 1 token still results in a mismatch in the uniform batch constructed based on this length. Here, using uniform_decode_query_len instead of 1 ensures that the dummy run does not encounter errors when MTP is enabled