### PR TITLE
Fix torch 2.9 fused moe failed and incorrect use flash_attn_varlen_func

### DIFF
--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -3,6 +3,7 @@ from vllm.model_executor.layers.fused_moe import (
     UnquantizedFusedMoEMethod,
     fused_experts,
 )
+from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 
 @UnquantizedFusedMoEMethod.register_oot
@@ -15,13 +16,14 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         topk_ids: torch.Tensor,
         shared_experts_input: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        is_inplace = not is_torch_equal_or_newer("2.9")
         result = fused_experts(
             hidden_states=x,
             w1=layer.w13_weight,
             w2=layer.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
-            inplace=True,
+            inplace=is_inplace,
             activation=layer.activation,
             quant_config=self.moe_quant_config,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,

--- a/vllm_musa/model_executor/layers/quantization/fp8.py
+++ b/vllm_musa/model_executor/layers/quantization/fp8.py
@@ -1,5 +1,6 @@
 import torch
 from vllm.model_executor.layers.fused_moe import FusedMoE, fused_experts
+from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 
 def apply(
@@ -11,13 +12,14 @@ def apply(
     shared_experts_input: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     if layer.ep_size != None and layer.ep_size <= 1:
+        is_inplace = not is_torch_equal_or_newer("2.9")
         return fused_experts(
             hidden_states=x,
             w1=layer.w13_weight,
             w2=layer.w2_weight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
-            inplace=True,
+            inplace=is_inplace,
             activation=layer.activation,
             global_num_experts=layer.global_num_experts,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,

--- a/vllm_musa/v1/attention/backends/mla/common.py
+++ b/vllm_musa/v1/attention/backends/mla/common.py
@@ -7,7 +7,6 @@ from typing import Generic, TypeVar
 
 import torch
 from tqdm import tqdm
-from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import get_current_vllm_config
 from vllm.distributed.parallel_state import get_dcp_group, is_global_first_rank
@@ -36,6 +35,7 @@ from vllm.platforms import current_platform
 from vllm.v1.attention.backend import AttentionLayer
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 
+from vllm import _custom_ops as ops
 from vllm_musa.v1.attention.backends.fa_utils import get_flash_attn_version
 
 try:
@@ -52,7 +52,7 @@ except ImportError:
 try:
     from flash_attn_interface import flash_attn_varlen_func
 
-    is_vllm_fa = False
+    is_vllm_fa = True
 except ImportError as e:
     raise ImportError(
         "MUSA platform requires MATE and flash_attn_3 to be installed. Please install them first."


### PR DESCRIPTION
1. On torch 2.9 and above, using inplace fused_experts may result in accuracy issues. For details, please refer to: https://github.com/vllm-project/vllm/issues/26378
2. The is_vllm_fa variable is set incorrectly to False, and when prefill chunked, flash_tttn_varlen_func does not return a tuple, resulting in a none type error