### PR TITLE
Fix duplicate custom op registration after runtime patching

### DIFF
--- a/vllm_musa/patches/__init__.py
+++ b/vllm_musa/patches/__init__.py
@@ -8,8 +8,6 @@ to ensure compatibility with the MUSA Triton version.
 """
 
 import importlib.util
-import re
-import sys
 from pathlib import Path
 
 from vllm.logger import init_logger
@@ -111,13 +109,12 @@ def apply_patches():
                     patched_source = patched_source.replace(old, new)
                     applied_count += 1
 
-            # Write back the patched source
+            # Write back the patched source. Do not evict an already-imported
+            # module from sys.modules: some vLLM modules register torch custom
+            # ops at import time, and re-importing them would register the same
+            # schema twice in the current process.
             with open(spec.origin, "w") as f:
                 f.write(patched_source)
-
-            # Remove from cache to force reload
-            if module_name in sys.modules:
-                del sys.modules[module_name]
 
             logger.info(f"Applied {applied_count} patch(es) to {module_name}")
 


### PR DESCRIPTION
## Motivation

- Stop removing patched vLLM modules from `sys.modules` after runtime source patching.
 
- Avoid re-importing modules that register torch custom ops at import time.

- Fix first-start failure after reinstall caused by duplicate registration of `vllm::triton_per_token_group_quant_fp8`.

error log:
```
RuntimeError: Tried to register an operator (vllm::triton_per_token_group_quant_fp8(Tensor x, SymInt group_size) -> (Tensor, Tensor)) with the same name and     
overload name multiple times. Each overload's schema should only be registered with a single call to def(). Duplicate registration: registered at /dev/null:241. Original registration: registered at              
/dev/null:241
```

## Modifications

Keep already-imported modules in `sys.modules` after writing patched source files. This preserves current-process module state and prevents duplicate custom op registration. The patched source still takes effect on subsequent process startup.

## Test

- Reinstall `vllm-musa` passed

- Start vLLM service passed for the first time after reinstall 

- Run model passed  