### PR TITLE
Support turboquant on musa

### DIFF
--- a/docs/vllm_musa/README.md
+++ b/docs/vllm_musa/README.md
@@ -63,6 +63,7 @@ Registers a Mooncake-based KV connector (`mooncake_connector.py`) for disaggrega
 
 - `v1/attention/backends/mla/` – FlashMLA attention backend (`MUSAFlashMLABackend`) with MLA-specific metadata and common utilities.
 - `v1/attention/backends/flash_attn.py` - FlashAttn attention backend (`MUSAFlashAttentionBackend`) with FLASH_ATTN functions.
+- `v1/attention/backends/turboquant.py` – TurboQuant KV-cache backend wrapper. The `turboquant_4bit_nc` preset is validated on MUSA; `turboquant_k8v4` is rejected because current MUSA Triton lacks the FP8 key-storage conversions used by upstream.
 - `v1/attention/ops/flashmla.py` – Low-level FlashMLA forward ops and capability detection.
 
 ### `_custom_ops.py` – Python Wrappers for C++ Ops

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -122,6 +122,58 @@ class TestMUSAPlatformBase:
         result = MUSAPlatformBase.get_static_graph_wrapper_cls()
         assert result == "vllm.compilation.cuda_graph.CUDAGraphWrapper"
 
+    def test_register_attention_backends_overrides_turboquant(self):
+        from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        from vllm_musa.platform import register_attention_backends
+
+        AttentionBackendEnum.TURBOQUANT.clear_override()
+        register_attention_backends()
+
+        assert (
+            AttentionBackendEnum.TURBOQUANT.get_path()
+            == "vllm_musa.v1.attention.backends.turboquant.MUSATurboQuantAttentionBackend"
+        )
+
+    def test_get_valid_backends_includes_turboquant_for_non_mla(self):
+        from vllm.platforms.interface import DeviceCapability
+        from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        from vllm_musa.platform import _get_backend_priorities
+
+        priorities = _get_backend_priorities(
+            use_mla=False,
+            device_capability=DeviceCapability(3, 1),
+        )
+
+        assert AttentionBackendEnum.TURBOQUANT in priorities
+        assert AttentionBackendEnum.TURBOQUANT not in _get_backend_priorities(
+            use_mla=True,
+            device_capability=DeviceCapability(3, 1),
+        )
+
+    def test_turboquant_rejects_k8v4_on_musa(self):
+        import torch
+        from vllm.platforms.interface import DeviceCapability
+
+        from vllm_musa.v1.attention.backends.turboquant import (
+            MUSATurboQuantAttentionBackend,
+        )
+
+        reason = MUSATurboQuantAttentionBackend.supports_combination(
+            head_size=128,
+            dtype=torch.float16,
+            kv_cache_dtype="turboquant_k8v4",
+            block_size=16,
+            use_mla=False,
+            has_sink=False,
+            use_sparse=False,
+            device_capability=DeviceCapability(3, 1),
+        )
+
+        assert reason is not None
+        assert "Triton float8 conversions" in reason
+
 
 class TestNonMtmlMUSAPlatform:
     """Tests for NonMtmlMUSAPlatform class."""

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -4,6 +4,7 @@
 import functools
 
 import torch
+from vllm import _custom_ops as ops
 from vllm.model_executor.layers.fused_moe.config import _get_config_dtype_str
 from vllm.model_executor.layers.fused_moe.fused_moe import (
     _get_config_quant_dtype,
@@ -25,7 +26,6 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl
 
-from vllm import _custom_ops as ops
 from vllm_musa import _custom_ops as musa_ops
 
 

--- a/vllm_musa/patches/vllm__v1__attention__ops__triton_turboquant_decode.patch.py
+++ b/vllm_musa/patches/vllm__v1__attention__ops__triton_turboquant_decode.patch.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+PATCHES = [
+    (
+        "(n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)",
+        "((n_lo | (n_hi << 8)) & 0xFFFF).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32)",
+    ),
+    (
+        "(sc_lo | (sc_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)",
+        "((sc_lo | (sc_hi << 8)) & 0xFFFF).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32)",
+    ),
+    (
+        "(zr_lo | (zr_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)",
+        "((zr_lo | (zr_hi << 8)) & 0xFFFF).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32)",
+    ),
+]

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -9,7 +9,11 @@ from collections.abc import Callable
 from functools import cache, wraps
 from typing import TYPE_CHECKING, TypeVar
 
+# isort: off
+import torchada  # noqa: F401
 import torch
+
+# isort: on
 from typing_extensions import ParamSpec
 from vllm.logger import init_logger
 from vllm.platforms.interface import DeviceCapability, Platform, PlatformEnum
@@ -24,7 +28,6 @@ else:
     CacheDType = None
 
 import pymtml as pynvml
-import torchada  # noqa: F401
 
 logger = init_logger(__name__)
 
@@ -39,8 +42,6 @@ def _get_backend_priorities(
     num_heads: int | None = None,
 ) -> list[AttentionBackendEnum]:
     """Get backend priorities with lazy import to avoid circular dependency."""
-    # MUSA platform prioritizes Triton-based backends since FlashAttention
-    # and other CUDA-specific backends may not be available.
     if use_mla:
         return [
             AttentionBackendEnum.FLASHMLA,
@@ -50,6 +51,7 @@ def _get_backend_priorities(
         return [
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.TRITON_ATTN,
+            AttentionBackendEnum.TURBOQUANT,
         ]
 
 
@@ -77,6 +79,13 @@ def register_attention_backends() -> None:
     register_backend(
         AttentionBackendEnum.FLASH_ATTN,
         class_path="vllm_musa.v1.attention.backends.flash_attn.MUSAFlashAttentionBackend",
+    )
+    register_backend(
+        AttentionBackendEnum.TURBOQUANT,
+        class_path=(
+            "vllm_musa.v1.attention.backends.turboquant."
+            "MUSATurboQuantAttentionBackend"
+        ),
     )
 
 

--- a/vllm_musa/v1/attention/backends/fa_utils.py
+++ b/vllm_musa/v1/attention/backends/fa_utils.py
@@ -38,4 +38,4 @@ def flash_attn_supports_mla():
 
 
 def is_flash_attn_varlen_func_available() -> bool:
-    return True
+    return "flash_attn_varlen_func" in globals()

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -254,11 +254,12 @@ class FlashAttentionMetadata:
 def _get_sliding_window_configs(
     vllm_config: VllmConfig,
 ) -> set[tuple[int, int] | None]:
-    """Get the set of all sliding window configs used in the model."""
+    """Get the set of FlashAttention sliding window configs used in the model."""
     sliding_window_configs: set[tuple[int, int] | None] = set()
     layers = get_layers_from_vllm_config(vllm_config, Attention)
     for layer in layers.values():
-        assert isinstance(layer.impl, FlashAttentionImpl)
+        if not isinstance(layer.impl, FlashAttentionImpl):
+            continue
         sliding_window_configs.add(layer.impl.sliding_window)
     return sliding_window_configs
 

--- a/vllm_musa/v1/attention/backends/turboquant.py
+++ b/vllm_musa/v1/attention/backends/turboquant.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA TurboQuant attention backend."""
+
+from typing import ClassVar
+
+# isort: off
+import torchada  # noqa: F401
+import torch
+
+# isort: on
+from vllm.config.cache import CacheDType
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backends import turboquant_attn as _turboquant_attn
+from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
+
+from vllm_musa.v1.attention.backends import fa_utils as _musa_fa_utils
+
+_turboquant_attn.get_flash_attn_version = _musa_fa_utils.get_flash_attn_version
+_turboquant_attn.is_flash_attn_varlen_func_available = (
+    _musa_fa_utils.is_flash_attn_varlen_func_available
+)
+_turboquant_attn._HAS_FLASH_ATTN = _musa_fa_utils.is_flash_attn_varlen_func_available()
+
+
+class MUSATurboQuantAttentionImpl(_turboquant_attn.TurboQuantAttentionImpl):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fa_version = _musa_fa_utils.get_flash_attn_version(
+            head_size=self.head_size
+        )
+
+    def _flash_attn_varlen(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+    ) -> torch.Tensor:
+        return _musa_fa_utils.flash_attn_varlen_func(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            softmax_scale=self.scale,
+            causal=True,
+        )
+
+
+@register_backend(AttentionBackendEnum.TURBOQUANT)
+class MUSATurboQuantAttentionBackend(_turboquant_attn.TurboQuantAttentionBackend):
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "turboquant_k8v4",
+        "turboquant_4bit_nc",
+        "turboquant_k3v4_nc",
+        "turboquant_3bit_nc",
+    ]
+
+    @staticmethod
+    def get_impl_cls() -> type["MUSATurboQuantAttentionImpl"]:
+        return MUSATurboQuantAttentionImpl
+
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        return capability.major == 3
+
+    @classmethod
+    def supports_combination(
+        cls,
+        head_size: int,
+        dtype: torch.dtype,
+        kv_cache_dtype: CacheDType | None,
+        block_size: int | None,
+        use_mla: bool,
+        has_sink: bool,
+        use_sparse: bool,
+        device_capability: DeviceCapability,
+    ) -> str | None:
+        if use_mla:
+            return "TurboQuant is not supported for MLA attention on MUSA"
+        if has_sink:
+            return "TurboQuant is not supported with attention sinks on MUSA"
+        if use_sparse:
+            return "TurboQuant is not supported for sparse attention on MUSA"
+        if kv_cache_dtype == "turboquant_k8v4":
+            return (
+                "TurboQuant k8v4 uses FP8 key storage, which requires Triton float8 "
+                "conversions that are not supported on MUSA"
+            )
+        return super().supports_combination(
+            head_size=head_size,
+            dtype=dtype,
+            kv_cache_dtype=kv_cache_dtype,
+            block_size=block_size,
+            use_mla=use_mla,
+            has_sink=has_sink,
+            use_sparse=use_sparse,
+            device_capability=device_capability,
+        )


### PR DESCRIPTION
## Motivation

This PR adds MUSA TurboQuant attention backend support for vLLM.

## Modifications

  - Add MUSA TurboQuant attention backend implementation.
  - Register TurboQuant backend selection for supported MUSA attention layers.
  - Patch TurboQuant decode halfword bitcasts for MUSA compatibility.
  - Reject unsupported TurboQuant `k8v4` configurations on MUSA.
  - Import `torchada` before `torch` in platform initialization.
  - Patch `_flash_attn_varlen` parameters for MUSA TurboQuant usage.
  - Document MUSA TurboQuant support and usage constraints.

## Test

- Verified the branch builds on top of the current `support-turboquant` base.
- Confirmed supported MUSA TurboQuant `turboquant_4bit_nc`, `turboquant_k3v4_nc`, `turboquant_3bit_nc` configuration.

```
vllm serve /home/dist/Qwen3-8b \
    --served-model-name qwen \
    --gpu-memory-utilization 0.7 \
    -tp 2 \
    -cc.mode=NONE \
    -cc.cudagraph_mode=FULL \
    --cudagraph-capture-sizes 4 \
    --kv-cache-dtype turboquant_k3v4_nc \
    --data-parallel-size 1
```