### PR TITLE
support fa3 dcp

### DIFF
--- a/tests/test_flash_attn_dcp.py
+++ b/tests/test_flash_attn_dcp.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+try:
+    from vllm_musa.v1.attention.backends import flash_attn as flash_attn_module
+    from vllm_musa.v1.attention.backends.flash_attn import (
+        FlashAttentionImpl,
+        FlashAttentionMetadata,
+    )
+except (ImportError, ModuleNotFoundError) as exc:
+    pytest.skip(f"requires full vllm-musa runtime: {exc}", allow_module_level=True)
+
+
+class _FakeDCPGroup:
+    world_size = 2
+    rank_in_group = 0
+
+    def all_gather(self, tensor: torch.Tensor, dim: int) -> torch.Tensor:
+        return torch.cat((tensor, tensor + 1), dim=dim)
+
+
+def _make_impl(**kwargs) -> FlashAttentionImpl:
+    defaults = dict(
+        num_heads=2,
+        head_size=4,
+        scale=1.0,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+    )
+    defaults.update(kwargs)
+    impl = FlashAttentionImpl(**defaults)
+    impl.dcp_world_size = 2
+    return impl
+
+
+def _make_metadata(**kwargs) -> FlashAttentionMetadata:
+    defaults = dict(
+        num_actual_tokens=3,
+        max_query_len=2,
+        query_start_loc=torch.tensor([0, 1, 3], dtype=torch.int32),
+        max_seq_len=8,
+        seq_lens=torch.tensor([4, 5], dtype=torch.int32),
+        block_table=torch.zeros((2, 2), dtype=torch.int32),
+        slot_mapping=torch.arange(3, dtype=torch.int64),
+        num_decodes=0,
+        num_decode_tokens=0,
+        decode_query_start_loc=None,
+        decode_seq_lens=None,
+        decode_block_table=None,
+        num_prefills=2,
+        num_prefill_tokens=3,
+        prefill_query_start_loc=torch.tensor([0, 1, 3], dtype=torch.int32),
+        prefill_max_seq_len=2,
+        cu_seqlens_k=None,
+        use_cascade=False,
+        common_prefix_len=0,
+        cu_prefix_query_lens=None,
+        prefix_kv_lens=None,
+        suffix_kv_lens=None,
+        max_dcp_context_kv_len=4,
+        dcp_context_kv_lens=torch.tensor([3, 3], dtype=torch.int32),
+        scheduler_metadata=None,
+        prefix_scheduler_metadata=None,
+        max_num_splits=0,
+        causal=True,
+    )
+    defaults.update(kwargs)
+    return FlashAttentionMetadata(**defaults)
+
+
+def test_forward_dispatches_to_dcp_path(monkeypatch):
+    impl = _make_impl()
+    metadata = _make_metadata(num_actual_tokens=1)
+    called = {}
+
+    def fake_forward_with_dcp(*args, **kwargs):
+        called["kwargs"] = kwargs
+        args[5].fill_(7)
+
+    monkeypatch.setattr(impl, "_forward_with_dcp", fake_forward_with_dcp)
+
+    layer = SimpleNamespace(
+        _q_scale=torch.ones((1, 1)),
+        _k_scale=torch.ones((1, 1)),
+        _v_scale=torch.ones((1, 1)),
+    )
+    output = torch.zeros((1, 2, 4))
+    result = impl.forward(
+        layer,
+        torch.zeros((1, 2, 4)),
+        torch.zeros((1, 1, 4)),
+        torch.zeros((1, 1, 4)),
+        torch.zeros((2, 1, 16, 1, 4)),
+        metadata,
+        output,
+    )
+
+    assert result is output
+    assert torch.all(output == 7)
+    assert set(called["kwargs"]) == {"q_descale", "k_descale", "v_descale"}
+
+
+def test_forward_with_dcp_runs_context_suffix_and_merge(monkeypatch):
+    calls = []
+    merged_lses = {}
+
+    def fake_merge_attn_states(
+        output,
+        prefix_output,
+        prefix_lse,
+        suffix_output,
+        suffix_lse,
+    ):
+        assert prefix_output.shape == suffix_output.shape == output.shape
+        assert prefix_lse.shape == suffix_lse.shape == (2, 3)
+        merged_lses["prefix"] = prefix_lse.clone()
+        merged_lses["suffix"] = suffix_lse.clone()
+        output.copy_(prefix_output + suffix_output)
+
+    def fake_flash_attn_varlen_func(**kwargs):
+        calls.append(kwargs)
+        q = kwargs["q"]
+        num_tokens, num_heads, head_size = q.shape
+        lse = torch.arange(
+            num_heads * num_tokens, dtype=q.dtype, device=q.device
+        ).view(num_heads, num_tokens)
+        if num_heads == 4:
+            out = torch.ones(
+                (num_tokens, num_heads, head_size), dtype=q.dtype, device=q.device
+            )
+            return out.reshape(num_tokens, num_heads * head_size), lse
+        out = torch.full(
+            (num_tokens, 1, num_heads, head_size),
+            2,
+            dtype=q.dtype,
+            device=q.device,
+        )
+        return out, lse
+
+    def fake_dcp_combine(context_out, context_lse, group, return_lse=False):
+        assert return_lse is True
+        assert group.world_size == 2
+        assert context_out.shape == (3, 4, 4)
+        assert context_lse.shape == (3, 4)
+        expected_lse = torch.arange(12, dtype=context_lse.dtype).view(4, 3)
+        assert torch.equal(context_lse, expected_lse.transpose(0, 1))
+        return context_out[:, :2, :].contiguous(), context_lse[:, :2].contiguous()
+
+    monkeypatch.setattr(flash_attn_module, "get_dcp_group", lambda: _FakeDCPGroup())
+    monkeypatch.setattr(
+        flash_attn_module, "merge_attn_states", fake_merge_attn_states
+    )
+    monkeypatch.setattr(
+        flash_attn_module,
+        "flash_attn_varlen_func",
+        fake_flash_attn_varlen_func,
+        raising=False,
+    )
+
+    impl = _make_impl()
+    impl.dcp_combine = fake_dcp_combine
+    output = torch.empty((3, 2, 4))
+
+    impl._forward_with_dcp(
+        torch.zeros((3, 2, 4)),
+        torch.zeros((3, 1, 4)),
+        torch.zeros((3, 1, 4)),
+        torch.zeros((2, 16, 1, 4)),
+        torch.zeros((2, 16, 1, 4)),
+        output,
+        _make_metadata(),
+    )
+
+    assert len(calls) == 2
+    assert calls[0]["causal"] is False
+    assert calls[0]["seqused_k"].shape == (2,)
+    assert calls[0]["max_seqlen_k"] == 4
+    assert calls[0]["block_table"].shape == (2, 2)
+    assert calls[1]["causal"] is True
+    assert calls[1]["cu_seqlens_k"].tolist() == [0, 1, 3]
+    for call in calls:
+        assert "out" not in call
+        assert "fa_version" not in call
+        assert "alibi_slopes" not in call
+        assert "s_aux" not in call
+
+    assert torch.equal(merged_lses["prefix"], torch.arange(12.0).view(4, 3)[:2])
+    assert torch.equal(merged_lses["suffix"], torch.arange(6.0).view(2, 3))
+    assert torch.all(output == 3)
+
+
+def test_lse_layout_helpers_accept_mate_and_tokens_heads_layouts():
+    lse_heads_tokens = torch.arange(12.0).view(4, 3)
+    lse_tokens_heads = lse_heads_tokens.transpose(0, 1).contiguous()
+
+    assert torch.equal(
+        FlashAttentionImpl._lse_to_tokens_heads(lse_heads_tokens, 3, 4),
+        lse_tokens_heads,
+    )
+    assert torch.equal(
+        FlashAttentionImpl._lse_to_heads_tokens(lse_tokens_heads, 3, 4),
+        lse_heads_tokens,
+    )
+    assert torch.equal(
+        FlashAttentionImpl._lse_to_tokens_heads(lse_heads_tokens.unsqueeze(-1), 3, 4),
+        lse_tokens_heads,
+    )
+
+
+@pytest.mark.parametrize("has_device_group", [True, False])
+def test_musa_dcp_reduce_scatter_uses_torch_dist(monkeypatch, has_device_group):
+    class Group:
+        world_size = 2
+        rank_in_group = 1
+
+    group = Group()
+    if has_device_group:
+        group.device_group = object()
+
+    captured = {}
+
+    def fake_reduce_scatter(output, chunks, group=None):
+        captured["group"] = group
+        captured["chunks"] = [chunk.clone() for chunk in chunks]
+        output.copy_(chunks[1])
+
+    monkeypatch.setattr(torch.distributed, "reduce_scatter", fake_reduce_scatter)
+
+    tensor = torch.arange(2 * 4 * 3, dtype=torch.float32).view(2, 4, 3)
+    result = flash_attn_module._torch_reduce_scatter_dim(tensor, group, dim=1)
+
+    assert captured["group"] is (group.device_group if has_device_group else group)
+    assert torch.equal(captured["chunks"][0], tensor[:, :2, :])
+    assert torch.equal(captured["chunks"][1], tensor[:, 2:, :])
+    assert torch.equal(result, tensor[:, 2:, :])
+
+
+def test_a2a_backend_selects_a2a_lse_reduce(monkeypatch):
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=2,
+            dcp_comm_backend="a2a",
+        )
+    )
+    monkeypatch.setattr(
+        flash_attn_module, "get_current_vllm_config_or_none", lambda: config
+    )
+
+    impl = _make_impl()
+
+    assert impl.dcp_combine is flash_attn_module.dcp_a2a_lse_reduce
+
+
+@pytest.mark.parametrize(
+    ("attr", "value", "message"),
+    [
+        ("sinks", torch.ones(2), "attention sinks"),
+        ("alibi_slopes", torch.ones(2), "ALiBi"),
+    ],
+)
+def test_forward_with_dcp_rejects_unsupported_features(attr, value, message):
+    impl = _make_impl()
+    setattr(impl, attr, value)
+
+    with pytest.raises(NotImplementedError, match=message):
+        impl._forward_with_dcp(
+            torch.zeros((3, 2, 4)),
+            torch.zeros((3, 1, 4)),
+            torch.zeros((3, 1, 4)),
+            torch.zeros((2, 16, 1, 4)),
+            torch.zeros((2, 16, 1, 4)),
+            torch.empty((3, 2, 4)),
+            _make_metadata(),
+        )

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -39,9 +39,11 @@ if is_flash_attn_varlen_func_available():
 from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
+    get_current_vllm_config_or_none,
     get_layers_from_vllm_config,
 )
 from vllm.config.cache import CacheDType
+from vllm.distributed.parallel_state import get_dcp_group
 from vllm.logger import init_logger
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.math_utils import cdiv, round_up
@@ -55,11 +57,72 @@ from vllm.v1.attention.backends.utils import (
     get_kv_cache_layout,
     split_decodes_and_prefills,
 )
+from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
 from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
+
+
+def _torch_reduce_scatter_dim(
+    input_: torch.Tensor,
+    group,
+    dim: int,
+) -> torch.Tensor:
+    world_size = group.world_size
+    if world_size == 1:
+        return input_
+    if dim < 0:
+        dim += input_.dim()
+    if input_.shape[dim] % world_size != 0:
+        raise RuntimeError(
+            "DCP reduce-scatter dimension must be divisible by world size, "
+            f"got shape={tuple(input_.shape)}, dim={dim}, world_size={world_size}."
+        )
+
+    chunks = [chunk.contiguous() for chunk in input_.chunk(world_size, dim=dim)]
+    output = torch.empty_like(chunks[group.rank_in_group])
+    torch.distributed.reduce_scatter(
+        output,
+        chunks,
+        group=getattr(group, "device_group", group),
+    )
+    return output
+
+
+class _DCPGroupWithTorchReduceScatter:
+    def __init__(self, group) -> None:
+        self._group = group
+        self.world_size = group.world_size
+        self.rank_in_group = group.rank_in_group
+
+    def all_gather(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        return self._group.all_gather(tensor, dim=dim)
+
+    def reduce_scatter(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        return _torch_reduce_scatter_dim(tensor, self._group, dim)
+
+
+def _musa_cp_lse_ag_out_rs(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    cp_group,
+    ctx=None,
+    return_lse: bool = False,
+    is_lse_base_on_e=True,
+):
+
+    safe_group = _DCPGroupWithTorchReduceScatter(cp_group)
+    return cp_lse_ag_out_rs(
+        cp_attn_out,
+        cp_attn_lse,
+        safe_group,
+        ctx=ctx,
+        return_lse=return_lse,
+        is_lse_base_on_e=is_lse_base_on_e,
+    )
 
 
 @register_backend(AttentionBackendEnum.FLASH_ATTN)
@@ -724,6 +787,16 @@ class FlashAttentionImpl(AttentionImpl):
 
         self.supports_quant_query_input = False
 
+        vllm_config = get_current_vllm_config_or_none()
+        dcp_a2a = (
+            vllm_config is not None
+            and vllm_config.parallel_config.decode_context_parallel_size > 1
+            and vllm_config.parallel_config.dcp_comm_backend == "a2a"
+        )
+        # ==================== MUSA ADAPTATION ====================
+        self.dcp_combine = dcp_a2a_lse_reduce if dcp_a2a else _musa_cp_lse_ag_out_rs
+        # ========================== END ==========================
+
     def forward(
         self,
         layer: torch.nn.Module,
@@ -817,8 +890,19 @@ class FlashAttentionImpl(AttentionImpl):
             v_descale = layer._v_scale.expand(descale_shape)
 
             if self.dcp_world_size > 1:
-                # XXX (MUSA): Implement _forward_with_dcp
-                raise NotImplementedError
+                self._forward_with_dcp(
+                    query[:num_actual_tokens],
+                    key[:num_actual_tokens],
+                    value[:num_actual_tokens],
+                    key_cache,
+                    value_cache,
+                    output[:num_actual_tokens],
+                    attn_metadata,
+                    q_descale=q_descale,
+                    k_descale=k_descale,
+                    v_descale=v_descale,
+                )
+                return output
             else:
                 sliding_window_size = (
                     list(self.sliding_window)
@@ -889,6 +973,196 @@ class FlashAttentionImpl(AttentionImpl):
             k_descale=layer._k_scale,
             v_descale=layer._v_scale,
             s_aux=self.sinks,
+        )
+        return output
+
+    @staticmethod
+    def _view_attn_output(
+        attn_output: torch.Tensor,
+        num_tokens: int,
+        num_heads: int,
+        head_size: int,
+    ) -> torch.Tensor:
+        if attn_output.dim() == 3 and attn_output.shape == (
+            num_tokens,
+            num_heads,
+            head_size,
+        ):
+            return attn_output
+        if attn_output.dim() == 4 and attn_output.shape[1] == 1:
+            return attn_output.squeeze(1)
+        return attn_output.view(num_tokens, num_heads, head_size)
+
+    @staticmethod
+    def _lse_to_tokens_heads(
+        lse: torch.Tensor,
+        num_tokens: int,
+        num_heads: int,
+    ) -> torch.Tensor:
+        if lse.shape == (num_heads, num_tokens):
+            return lse.transpose(0, 1).contiguous()
+        if lse.shape == (num_tokens, num_heads):
+            return lse.contiguous()
+        if lse.dim() == 3 and lse.shape[-1] == 1:
+            return FlashAttentionImpl._lse_to_tokens_heads(
+                lse.squeeze(-1), num_tokens, num_heads
+            )
+        raise RuntimeError(
+            "Unexpected FlashAttention LSE shape "
+            f"{tuple(lse.shape)} for tokens={num_tokens}, heads={num_heads}."
+        )
+
+    @staticmethod
+    def _lse_to_heads_tokens(
+        lse: torch.Tensor,
+        num_tokens: int,
+        num_heads: int,
+    ) -> torch.Tensor:
+        if lse.shape == (num_heads, num_tokens):
+            return lse.contiguous()
+        if lse.shape == (num_tokens, num_heads):
+            return lse.transpose(0, 1).contiguous()
+        if lse.dim() == 3 and lse.shape[-1] == 1:
+            return FlashAttentionImpl._lse_to_heads_tokens(
+                lse.squeeze(-1), num_tokens, num_heads
+            )
+        raise RuntimeError(
+            "Unexpected FlashAttention LSE shape "
+            f"{tuple(lse.shape)} for tokens={num_tokens}, heads={num_heads}."
+        )
+
+    def _forward_with_dcp(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        output: torch.Tensor,
+        attn_metadata: FlashAttentionMetadata,
+        q_descale: torch.Tensor | None = None,
+        k_descale: torch.Tensor | None = None,
+        v_descale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # ==================== MUSA ADAPTATION ====================
+        assert (
+            self.vllm_flash_attn_version is not None
+        ), "FlashAttention version not detected."
+        if attn_metadata.dcp_context_kv_lens is None:
+            raise RuntimeError("DCP metadata is missing dcp_context_kv_lens.")
+        if attn_metadata.max_dcp_context_kv_len is None:
+            raise RuntimeError("DCP metadata is missing max_dcp_context_kv_len.")
+        if self.sinks is not None:
+            raise NotImplementedError(
+                "MUSA FlashAttention DCP does not support attention sinks."
+            )
+        if self.alibi_slopes is not None:
+            raise NotImplementedError("MUSA FlashAttention DCP does not support ALiBi.")
+        if not is_quantized_kv_cache(self.kv_cache_dtype):
+            q_descale = None
+            k_descale = None
+            v_descale = None
+        # ========================== END ==========================
+
+        num_tokens = query.shape[0]
+        cu_seqlens_q = attn_metadata.query_start_loc
+        max_seqlen_q = attn_metadata.max_query_len
+        sliding_window_size = (
+            list(self.sliding_window) if self.sliding_window is not None else None
+        )
+
+        query = query.view(num_tokens, self.num_heads, self.head_size).contiguous()
+        key = key.view(num_tokens, self.num_kv_heads, self.head_size).to(query.dtype)
+        value = value.view(num_tokens, self.num_kv_heads, self.head_size).to(
+            query.dtype
+        )
+
+        dcp_group = get_dcp_group()
+        query_across_dcp = dcp_group.all_gather(query, dim=1)
+        context_attn_out, context_lse = flash_attn_varlen_func(
+            q=query_across_dcp,
+            k=key_cache,
+            v=value_cache,
+            cu_seqlens_q=cu_seqlens_q,
+            max_seqlen_q=max_seqlen_q,
+            seqused_k=attn_metadata.dcp_context_kv_lens,
+            max_seqlen_k=attn_metadata.max_dcp_context_kv_len,
+            softmax_scale=self.scale,
+            causal=False,
+            window_size=sliding_window_size,
+            block_table=attn_metadata.block_table,
+            softcap=self.logits_soft_cap,
+            return_softmax_lse=True,
+            scheduler_metadata=attn_metadata.scheduler_metadata,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale,
+            num_splits=attn_metadata.max_num_splits,
+        )
+        # ==================== MUSA ADAPTATION ====================
+        context_attn_out = self._view_attn_output(
+            context_attn_out,
+            num_tokens,
+            self.num_heads * self.dcp_world_size,
+            self.head_size,
+        )
+        context_lse = self._lse_to_tokens_heads(
+            context_lse,
+            num_tokens,
+            self.num_heads * self.dcp_world_size,
+        )
+        context_attn_out, context_lse = self.dcp_combine(
+            context_attn_out,
+            context_lse,
+            dcp_group,
+            return_lse=True,
+        )
+        context_lse = self._lse_to_heads_tokens(
+            context_lse,
+            num_tokens,
+            self.num_heads,
+        )
+        # ========================== END ==========================
+
+        query_attn_out, query_lse = flash_attn_varlen_func(
+            q=query,
+            k=key,
+            v=value,
+            cu_seqlens_q=cu_seqlens_q,
+            max_seqlen_q=max_seqlen_q,
+            cu_seqlens_k=cu_seqlens_q,
+            max_seqlen_k=max_seqlen_q,
+            softmax_scale=self.scale,
+            causal=attn_metadata.causal,
+            window_size=sliding_window_size,
+            softcap=self.logits_soft_cap,
+            return_softmax_lse=True,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale,
+            num_splits=attn_metadata.max_num_splits,
+        )
+        # ==================== MUSA ADAPTATION ====================
+        query_attn_out = self._view_attn_output(
+            query_attn_out,
+            num_tokens,
+            self.num_heads,
+            self.head_size,
+        )
+        query_lse = self._lse_to_heads_tokens(
+            query_lse,
+            num_tokens,
+            self.num_heads,
+        )
+
+        output_view = output.view(num_tokens, self.num_heads, self.head_size)
+        # ========================== END ==========================
+        merge_attn_states(
+            output_view,
+            context_attn_out,
+            context_lse,
+            query_attn_out,
+            query_lse,
         )
         return output
 


### PR DESCRIPTION
## Motivation
This PR completes the integration of flash_attn in vllm-musa by adding DCP support.

Previously, when self.dcp_world_size > 1, the execution path directly returned NotImplementedError, which prevented flash_attn from being used in DCP-enabled multi-GPU inference scenarios.

This PR implements the missing _forward_with_dcp function and enables the flash_attn backend to work correctly under DCP execution mode. The goal is to make the flash_attn integration feature-complete for distributed inference workloads and unblock further functionality verification and performance optimization work on multi-GPU environments.

## Modifications

- add _forward_with_dcp to flash_attn.py
- implements dcp communication
- add test file

## Test 
- Run test file passed
- Run qwen model with dcp params passed
- Run --dcp-comm-backend with a2a and ag_rs

```
vllm serve /home/dist/Qwen3-30B-A3B-Instruct-2507 \
  --served-model-name qwen-dcp \
  --gpu-memory-utilization 0.7 \
  --max-model-len 2048 \
  --max-num-seqs 2 \
  --max-num-batched-tokens 1024 \
  -tp 8 \
  -dcp 2 \
  --dcp-comm-backend a2a \
  --dcp-kv-cache-interleave-size 16 \
  -ac.backend FLASH_ATTN
```