### PR TITLE
Fix TurboQuant FP8 dtype selection on MUSA

### DIFF
--- a/docs/vllm_musa/README.md
+++ b/docs/vllm_musa/README.md
@@ -63,7 +63,7 @@ Registers a Mooncake-based KV connector (`mooncake_connector.py`) for disaggrega
 
 - `v1/attention/backends/mla/` – FlashMLA attention backend (`MUSAFlashMLABackend`) with MLA-specific metadata and common utilities.
 - `v1/attention/backends/flash_attn.py` - FlashAttn attention backend (`MUSAFlashAttentionBackend`) with FLASH_ATTN functions.
-- `v1/attention/backends/turboquant.py` – TurboQuant KV-cache backend wrapper. The `turboquant_4bit_nc` preset is validated on MUSA; `turboquant_k8v4` is rejected because current MUSA Triton lacks the FP8 key-storage conversions used by upstream.
+- `v1/attention/backends/turboquant.py` – TurboQuant KV-cache backend wrapper. The `turboquant_k8v4`, `turboquant_4bit_nc`, `turboquant_k3v4_nc`, and `turboquant_3bit_nc` presets are supported on MUSA.
 - `v1/attention/ops/flashmla.py` – Low-level FlashMLA forward ops and capability detection.
 
 ### `_custom_ops.py` – Python Wrappers for C++ Ops

--- a/tests/test_flash_attn_dcp.py
+++ b/tests/test_flash_attn_dcp.py
@@ -128,9 +128,9 @@ def test_forward_with_dcp_runs_context_suffix_and_merge(monkeypatch):
         calls.append(kwargs)
         q = kwargs["q"]
         num_tokens, num_heads, head_size = q.shape
-        lse = torch.arange(
-            num_heads * num_tokens, dtype=q.dtype, device=q.device
-        ).view(num_heads, num_tokens)
+        lse = torch.arange(num_heads * num_tokens, dtype=q.dtype, device=q.device).view(
+            num_heads, num_tokens
+        )
         if num_heads == 4:
             out = torch.ones(
                 (num_tokens, num_heads, head_size), dtype=q.dtype, device=q.device
@@ -154,9 +154,7 @@ def test_forward_with_dcp_runs_context_suffix_and_merge(monkeypatch):
         return context_out[:, :2, :].contiguous(), context_lse[:, :2].contiguous()
 
     monkeypatch.setattr(flash_attn_module, "get_dcp_group", lambda: _FakeDCPGroup())
-    monkeypatch.setattr(
-        flash_attn_module, "merge_attn_states", fake_merge_attn_states
-    )
+    monkeypatch.setattr(flash_attn_module, "merge_attn_states", fake_merge_attn_states)
     monkeypatch.setattr(
         flash_attn_module,
         "flash_attn_varlen_func",

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -89,8 +89,9 @@ class TestMUSAPlatformBase:
 
     def test_supports_fp8_for_musa_3_1(self):
         """Test that FP8 is supported on MUSA capability 3.1."""
-        from vllm_musa.platform import MUSAPlatformBase
         from vllm.platforms.interface import DeviceCapability
+
+        from vllm_musa.platform import MUSAPlatformBase
 
         with patch.object(
             MUSAPlatformBase,
@@ -101,8 +102,9 @@ class TestMUSAPlatformBase:
 
     def test_supports_fp8_rejects_pre_3_1(self):
         """Test that pre-3.1 MUSA capability does not support FP8."""
-        from vllm_musa.platform import MUSAPlatformBase
         from vllm.platforms.interface import DeviceCapability
+
+        from vllm_musa.platform import MUSAPlatformBase
 
         with patch.object(
             MUSAPlatformBase,
@@ -177,7 +179,25 @@ class TestMUSAPlatformBase:
             device_capability=DeviceCapability(3, 1),
         )
 
-    def test_turboquant_rejects_k8v4_on_musa(self):
+    def test_turboquant_forces_fp8_e4b15_off_on_musa(self):
+        from vllm.v1.attention.backends import turboquant_attn
+        from vllm.v1.attention.ops import (
+            triton_turboquant_decode,
+            triton_turboquant_store,
+        )
+
+        import vllm_musa.v1.attention.backends.turboquant  # noqa: F401
+
+        assert triton_turboquant_decode._use_fp8_e4b15(0) == 0
+        assert triton_turboquant_store._use_fp8_e4b15(0) == 0
+        assert turboquant_attn._use_fp8_e4b15(0) == 0
+        assert (
+            triton_turboquant_store._use_fp8_e4b15
+            is triton_turboquant_decode._use_fp8_e4b15
+        )
+        assert turboquant_attn._use_fp8_e4b15 is triton_turboquant_decode._use_fp8_e4b15
+
+    def test_turboquant_supports_k8v4_on_musa(self):
         import torch
         from vllm.platforms.interface import DeviceCapability
 
@@ -196,8 +216,7 @@ class TestMUSAPlatformBase:
             device_capability=DeviceCapability(3, 1),
         )
 
-        assert reason is not None
-        assert "Triton float8 conversions" in reason
+        assert reason is None
 
 
 class TestNativeGemvSource:

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -271,7 +271,7 @@ class TestCompilationCachingPatch:
                 new_source = "\n".join(new for _, new in patches)
 
                 assert "GraphPickler, Options" in old_source
-                assert "getattr(_vllm_graph_pickler, \"Options\", None)" in new_source
+                assert 'getattr(_vllm_graph_pickler, "Options", None)' in new_source
                 assert "_musa_graph_pickler_dumps" in new_source
                 break
         else:
@@ -381,6 +381,7 @@ class TestMUSAFlashAttentionReshapeCache:
     def _load_fa_utils_with_musa_platform(self, monkeypatch, musa_ops_namespace):
         import vllm
         import vllm.platforms as vllm_platforms
+
         import vllm_musa
 
         monkeypatch.setenv("VLLM_MUSA_RESHAPE_CACHE_FLASH", "1")
@@ -402,9 +403,7 @@ class TestMUSAFlashAttentionReshapeCache:
         monkeypatch.setattr(vllm, "_custom_ops", vllm_ops, raising=False)
 
         musa_custom_ops = ModuleType("vllm_musa._custom_ops")
-        musa_custom_ops.musa_reshape_and_cache_flash_nhd = (
-            lambda *args, **kwargs: None
-        )
+        musa_custom_ops.musa_reshape_and_cache_flash_nhd = lambda *args, **kwargs: None
         monkeypatch.setitem(sys.modules, "vllm_musa._custom_ops", musa_custom_ops)
         monkeypatch.setattr(vllm_musa, "_custom_ops", musa_custom_ops, raising=False)
 
@@ -591,6 +590,7 @@ class TestMUSAPlatformDefaults:
 
     def test_tp4_disables_musa_cudagraph_capture(self):
         from vllm.config import CUDAGraphMode
+
         from vllm_musa.platform import MUSAPlatformBase
 
         vllm_config = self._make_vllm_config(
@@ -608,6 +608,7 @@ class TestMUSAPlatformDefaults:
 
     def test_tp2_keeps_musa_cudagraph_capture(self):
         from vllm.config import CUDAGraphMode
+
         from vllm_musa.platform import MUSAPlatformBase
 
         vllm_config = self._make_vllm_config(
@@ -684,9 +685,7 @@ class TestMUSAFusedMoEFP8Scales:
 class TestMUSAFp8MoEPadding:
     """Tests for MUSA FP8 MoE TP padding helpers."""
 
-    def test_musa_fp8_moe_tp_padding_rounds_partition_to_block_lcm(
-        self, monkeypatch
-    ):
+    def test_musa_fp8_moe_tp_padding_rounds_partition_to_block_lcm(self, monkeypatch):
         from vllm_musa.model_executor.layers.quantization import fp8 as musa_fp8
 
         monkeypatch.setattr(
@@ -697,8 +696,7 @@ class TestMUSAFp8MoEPadding:
         monkeypatch.setattr(
             musa_fp8,
             "_ORIGINAL_FP8_MOE_MAYBE_ROUNDUP_SIZES",
-            lambda self, hidden_size, intermediate_size_per_partition, act_dtype,
-            moe_parallel_config: (
+            lambda self, hidden_size, intermediate_size_per_partition, act_dtype, moe_parallel_config: (
                 hidden_size,
                 intermediate_size_per_partition,
             ),
@@ -741,14 +739,10 @@ class TestMUSAFp8MoEPadding:
 
         def fake_create_weights(self, layer, **kwargs):
             layer.w13_weight = SimpleNamespace(
-                data=torch.full((8,), 42, dtype=torch.uint8).view(
-                    torch.float8_e4m3fn
-                )
+                data=torch.full((8,), 42, dtype=torch.uint8).view(torch.float8_e4m3fn)
             )
             layer.w2_weight = SimpleNamespace(
-                data=torch.full((8,), 43, dtype=torch.uint8).view(
-                    torch.float8_e4m3fn
-                )
+                data=torch.full((8,), 43, dtype=torch.uint8).view(torch.float8_e4m3fn)
             )
 
         monkeypatch.setattr(
@@ -807,8 +801,7 @@ class TestScaledMMKernelPatch:
 
     def test_musa_swiglu_uses_custom_op_for_compile(self):
         source = (
-            Path(__file__).parents[1]
-            / "vllm_musa/model_executor/layers/activation.py"
+            Path(__file__).parents[1] / "vllm_musa/model_executor/layers/activation.py"
         ).read_text()
 
         assert "torch.ops.vllm.musa_swish_glu_op" in source
@@ -821,7 +814,9 @@ class TestScaledMMKernelPatch:
             MUSAPerTensorTorchFP8ScaledMMLinearKernel,
         )
 
-        assert MUSAPerTensorTorchFP8ScaledMMLinearKernel.get_output_padding(None) is None
+        assert (
+            MUSAPerTensorTorchFP8ScaledMMLinearKernel.get_output_padding(None) is None
+        )
 
     def test_musa_unquantized_gemm_materializes_plain_parameter_for_compile(self):
         source = (

--- a/vllm_musa/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/quick_all_reduce.py
@@ -25,7 +25,6 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
-
 from vllm.logger import init_logger
 
 # vllm.logger.init_logger returns a Logger with info_once / warning_once
@@ -101,9 +100,7 @@ class QuickAllReduce:
         # IPC handle exchange via the process group.
         try:
             my_handle: torch.Tensor = torch.ops._C_quick_ar.get_handle(self.fptr)
-            all_handles = [
-                torch.empty_like(my_handle) for _ in range(world_size)
-            ]
+            all_handles = [torch.empty_like(my_handle) for _ in range(world_size)]
             dist.all_gather(all_handles, my_handle, group=group)
             # Pass the full handle list (length == world_size). The C++
             # DeviceComms::open_ipc_handles asserts size() == world_size
@@ -115,7 +112,8 @@ class QuickAllReduce:
         except Exception as exc:
             logger.warning(
                 "MUSA-0088: QuickAllReduce IPC handle exchange failed "
-                "(%s); disabling.", exc,
+                "(%s); disabling.",
+                exc,
             )
             self.disabled = True
             self._safe_destroy()
@@ -140,7 +138,9 @@ class QuickAllReduce:
     ) -> Optional[torch.Tensor]:
         """vllm-upstream API alias: returns the all-reduced output tensor
         directly (in-place via a fresh output buffer)."""
-        return self.all_reduce(input_, output=None, quant_level=quant_level, cast_bf2half=cast_bf2half)
+        return self.all_reduce(
+            input_, output=None, quant_level=quant_level, cast_bf2half=cast_bf2half
+        )
 
     def all_reduce(
         self,

--- a/vllm_musa/kernels/musa_ops.py
+++ b/vllm_musa/kernels/musa_ops.py
@@ -15,9 +15,9 @@ the pure-PyTorch native rms_norm. With the "musa" provider plus a
 priority override in `vllm_musa.platform`, the dispatcher / Inductor
 lowering picks the MUSA kernel.
 """
+
 import torch
 from torch import Tensor
-
 from vllm import ir
 from vllm.platforms import current_platform
 

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -136,9 +136,7 @@ def _musa_deepgemm_fp8_op(
     q_input, input_scale = per_token_group_quant_fp8(
         input,
         group_size=group_size,
-        column_major_scales=not _use_row_major_activation_scales(
-            use_deep_gemm_e8m0
-        ),
+        column_major_scales=not _use_row_major_activation_scales(use_deep_gemm_e8m0),
         use_ue8m0=use_deep_gemm_e8m0,
     )
     output = torch.empty(

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -46,11 +46,7 @@ def _maybe_expand_fp8_moe_per_tensor_scale(
     [expert, output_block, input_block]. Static FP8 checkpoints store one
     weight scale per expert, so materialize the equivalent block view here.
     """
-    if (
-        scale is None
-        or weight.dtype != torch.float8_e4m3fn
-        or scale.dim() >= 3
-    ):
+    if scale is None or weight.dtype != torch.float8_e4m3fn or scale.dim() >= 3:
         return scale
 
     num_experts, output_size, input_size = weight.shape

--- a/vllm_musa/model_executor/layers/fused_moe/moe_config_bridge.py
+++ b/vllm_musa/model_executor/layers/fused_moe/moe_config_bridge.py
@@ -27,6 +27,7 @@ torchada dir or an unwritable vLLM dir logs a warning and is otherwise
 a no-op — vLLM then falls back to its default config, i.e. exactly the
 pre-bridge behaviour).
 """
+
 import glob
 import os
 import shutil

--- a/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
@@ -60,7 +60,8 @@ try:
 except ImportError as exc:  # pragma: no cover
     _log.debug(
         "MUSA-0090 eagle patch: cannot import vllm.v1.spec_decode.eagle "
-        "(probably an unsupported vllm version). Skipping: %s", exc,
+        "(probably an unsupported vllm version). Skipping: %s",
+        exc,
     )
     EagleProposer = None  # type: ignore
 
@@ -120,11 +121,10 @@ def _maybe_init_runner(proposer, args, kwargs) -> None:
             hidden_size = int(proposer.model.config.hidden_size)
         except Exception:
             hidden_size = 4096  # M2.5 default; will surface in capture if wrong.
-        _log.warning(
-            "MUSA-0090: hidden_size probe fell back to %d", hidden_size
-        )
+        _log.warning("MUSA-0090: hidden_size probe fell back to %d", hidden_size)
 
     import torch
+
     device = getattr(proposer, "device", None) or torch.device("cuda")
 
     runner = EagleFullLoopRunner(
@@ -151,7 +151,9 @@ def _maybe_init_runner(proposer, args, kwargs) -> None:
     _log.info(
         "MUSA-0090: EagleFullLoopRunner installed (N=%d, capture_sizes=%s, "
         "hidden_size=%d, buffer_footprint=%.2f MiB)",
-        num_speculative_tokens, cudagraph_capture_sizes, hidden_size,
+        num_speculative_tokens,
+        cudagraph_capture_sizes,
+        hidden_size,
         runner.memory_footprint_bytes() / 1024 / 1024,
     )
 
@@ -168,6 +170,7 @@ def _make_dispatched_propose(_original_propose):
     """
 
     import os
+
     _RUNNER_ENABLED = os.environ.get("VLLM_MUSA_EAGLE_RUNNER", "0") == "1"
 
     def _musa_dispatched_propose(self, *args, **kwargs):
@@ -176,6 +179,7 @@ def _make_dispatched_propose(_original_propose):
         # Only dispatch on MUSA. On CUDA, fall through to the original.
         try:
             from vllm.platforms import current_platform
+
             if not current_platform.is_musa():
                 return _original_propose(self, *args, **kwargs)
         except Exception:
@@ -214,9 +218,7 @@ def _make_dispatched_propose(_original_propose):
                 else args[2]
             )
             next_token_ids = (
-                kwargs.get("next_token_ids")
-                if "next_token_ids" in kwargs
-                else args[3]
+                kwargs.get("next_token_ids") if "next_token_ids" in kwargs else args[3]
             )
             # token_indices_to_sample may be None (proposer computes from
             # query_start_loc) — that's fine; runner.replay() handles it.
@@ -231,9 +233,7 @@ def _make_dispatched_propose(_original_propose):
                 else args[5]
             )
         except (IndexError, KeyError):
-            _log.debug(
-                "MUSA-0090: propose() signature mismatch; fallback to original"
-            )
+            _log.debug("MUSA-0090: propose() signature mismatch; fallback to original")
             return _original_propose(self, *args, **kwargs)
 
         batch_size = int(next_token_ids.shape[0])
@@ -253,7 +253,8 @@ def _make_dispatched_propose(_original_propose):
         except Exception as exc:
             _log.warning(
                 "MUSA-0090: runner.replay failed (%s); falling back to "
-                "vLLM iterative path for this call", exc,
+                "vLLM iterative path for this call",
+                exc,
             )
             return _original_propose(self, *args, **kwargs)
 

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -165,6 +165,7 @@ class MUSAPlatformBase(Platform):
             import vllm_musa.kernels  # noqa: F401
         except ImportError as exc:
             from vllm.logger import init_logger
+
             init_logger(__name__).info(
                 "vllm_musa.kernels unavailable (%s); MUSA IR providers "
                 "will not be registered. Upstream providers remain "
@@ -202,9 +203,7 @@ class MUSAPlatformBase(Platform):
         from vllm.config.kernel import IrOpPriorityConfig
 
         cc = vllm_config.compilation_config
-        using_inductor = (
-            cc.backend == "inductor" and cc.mode != CompilationMode.NONE
-        )
+        using_inductor = cc.backend == "inductor" and cc.mode != CompilationMode.NONE
         if using_inductor:
             # Let Inductor fuse the native reference impl. Keep the
             # `musa` custom-op provider out of the priority here — it is
@@ -385,6 +384,7 @@ class MUSAPlatformBase(Platform):
         # have been observed working on torch_musa 2.9.0; values >= 232
         # trigger MUSA-0082's illegal memory access at capture_end.
         import os as _os
+
         try:
             MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE = int(
                 _os.getenv("VLLM_MUSA_MAX_CUDAGRAPH_CAPTURE_SIZE", "8")
@@ -393,6 +393,7 @@ class MUSAPlatformBase(Platform):
             MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE = 8
         if cudagraph_mode is not None:
             from vllm.config import CUDAGraphMode
+
             if cudagraph_mode != CUDAGraphMode.NONE:
                 max_size = compilation_config.max_cudagraph_capture_size or 0
                 if max_size > MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE:
@@ -402,14 +403,16 @@ class MUSAPlatformBase(Platform):
                         "memory access at musa_graph.capture_end on "
                         "torch_musa 2.9.0; investigation pending). "
                         "Override with VLLM_MUSA_MAX_CUDAGRAPH_CAPTURE_SIZE.",
-                        max_size, MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE,
+                        max_size,
+                        MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE,
                     )
                     compilation_config.max_cudagraph_capture_size = (
                         MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE
                     )
                     if compilation_config.cudagraph_capture_sizes:
                         compilation_config.cudagraph_capture_sizes = [
-                            s for s in compilation_config.cudagraph_capture_sizes
+                            s
+                            for s in compilation_config.cudagraph_capture_sizes
                             if s <= MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE
                         ]
 

--- a/vllm_musa/v1/attention/backends/fa_utils.py
+++ b/vllm_musa/v1/attention/backends/fa_utils.py
@@ -13,6 +13,7 @@ if current_platform.is_musa():
         get_scheduler_metadata,
     )
     from vllm import _custom_ops as ops
+
     from vllm_musa import _custom_ops as musa_ops
     from vllm_musa.utils.environ import envs
 
@@ -60,10 +61,7 @@ if current_platform.is_musa():
             and key_cache.stride(2) == key_cache.shape[3]
             and value_cache.stride(2) == value_cache.shape[3]
             and key_cache.stride(1) == key_cache.shape[2] * key_cache.shape[3]
-            and (
-                value_cache.stride(1)
-                == value_cache.shape[2] * value_cache.shape[3]
-            )
+            and (value_cache.stride(1) == value_cache.shape[2] * value_cache.shape[3])
         )
 
     def reshape_and_cache_flash(

--- a/vllm_musa/v1/attention/backends/tree_attn.py
+++ b/vllm_musa/v1/attention/backends/tree_attn.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 import torch
-
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger

--- a/vllm_musa/v1/attention/backends/turboquant.py
+++ b/vllm_musa/v1/attention/backends/turboquant.py
@@ -13,9 +13,20 @@ from vllm.config.cache import CacheDType
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backends import turboquant_attn as _turboquant_attn
 from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
+from vllm.v1.attention.ops import triton_turboquant_decode as _turboquant_decode
+from vllm.v1.attention.ops import triton_turboquant_store as _turboquant_store
 
 from vllm_musa.v1.attention.backends import fa_utils as _musa_fa_utils
 
+
+def _musa_use_fp8_e4b15(device: int = 0) -> int:
+    # XXX (MUSA): The e4b15 dtype is supported in later Triton versions, please refer to JIRA#79331
+    return 0
+
+
+_turboquant_decode._use_fp8_e4b15 = _musa_use_fp8_e4b15
+_turboquant_store._use_fp8_e4b15 = _musa_use_fp8_e4b15
+_turboquant_attn._use_fp8_e4b15 = _musa_use_fp8_e4b15
 _turboquant_attn.get_flash_attn_version = _musa_fa_utils.get_flash_attn_version
 _turboquant_attn.is_flash_attn_varlen_func_available = (
     _musa_fa_utils.is_flash_attn_varlen_func_available
@@ -89,11 +100,6 @@ class MUSATurboQuantAttentionBackend(_turboquant_attn.TurboQuantAttentionBackend
             return "TurboQuant is not supported with attention sinks on MUSA"
         if use_sparse:
             return "TurboQuant is not supported for sparse attention on MUSA"
-        if kv_cache_dtype == "turboquant_k8v4":
-            return (
-                "TurboQuant k8v4 uses FP8 key storage, which requires Triton float8 "
-                "conversions that are not supported on MUSA"
-            )
         return super().supports_combination(
             head_size=head_size,
             dtype=dtype,

--- a/vllm_musa/v1/spec_decode/attn_backend_array.py
+++ b/vllm_musa/v1/spec_decode/attn_backend_array.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import Any
 
-import torch
-
 from .spec_info import EagleDraftBuffers
 
 
@@ -85,9 +83,13 @@ def build_per_step_attn_metadata_array(
             # (slot_mapping, seq_lens, max_seq_len), then build per-layer
             # metadata. The per-layer call returns a dict-shaped object
             # that the model reads via get_forward_context().
-            base_metadata.slot_mapping = buffers.slot_mapping_per_step[step_idx, :batch_size]
+            base_metadata.slot_mapping = buffers.slot_mapping_per_step[
+                step_idx, :batch_size
+            ]
             base_metadata.seq_lens = buffers.seq_lens_per_step[step_idx, :batch_size]
-            base_metadata.max_seq_len = int(getattr(base_metadata, "max_seq_len", 0)) + (1 if step_idx > 0 else 0)
+            base_metadata.max_seq_len = int(
+                getattr(base_metadata, "max_seq_len", 0)
+            ) + (1 if step_idx > 0 else 0)
             try:
                 _, per_layer = proposer.build_per_group_and_layer_attn_metadata(
                     base_metadata, draft_index=step_idx
@@ -124,7 +126,9 @@ def build_per_step_attn_metadata_array(
     # produce real `FlashAttentionMetadata` via the builder.
     metadata_array: list[Any] = []
     base_max_seq_len = int(getattr(base_metadata, "max_seq_len", 0))
-    base_max_model_len = int(getattr(base_metadata, "max_model_len", base_max_seq_len + buffers.num_steps))
+    base_max_model_len = int(
+        getattr(base_metadata, "max_model_len", base_max_seq_len + buffers.num_steps)
+    )
 
     # MUSA-0090 step 5l (2026-05-16): use vllm's first-party
     # `proposer.build_per_group_and_layer_attn_metadata(common_attn_metadata,
@@ -240,8 +244,12 @@ class StepMetadataIndexing:
         return cls(
             num_steps=len(metadata_array),
             base_max_seq_len=int(getattr(metadata_array[0], "max_seq_len", 0)),
-            per_step_max_seq_lens=[int(getattr(m, "max_seq_len", 0)) for m in metadata_array],
-            slot_mapping_data_ptrs=[int(m.slot_mapping.data_ptr()) for m in metadata_array],
+            per_step_max_seq_lens=[
+                int(getattr(m, "max_seq_len", 0)) for m in metadata_array
+            ],
+            slot_mapping_data_ptrs=[
+                int(m.slot_mapping.data_ptr()) for m in metadata_array
+            ],
             seq_lens_data_ptrs=[int(m.seq_lens.data_ptr()) for m in metadata_array],
         )
 
@@ -257,8 +265,7 @@ class StepMetadataIndexing:
             )
         if len(set(self.seq_lens_data_ptrs)) != self.num_steps:
             raise RuntimeError(
-                f"seq_lens views are not all distinct: "
-                f"{self.seq_lens_data_ptrs}"
+                f"seq_lens views are not all distinct: " f"{self.seq_lens_data_ptrs}"
             )
         # max_seq_lens should be monotonically non-decreasing across steps
         for i in range(1, self.num_steps):

--- a/vllm_musa/v1/spec_decode/eagle_full_loop_runner.py
+++ b/vllm_musa/v1/spec_decode/eagle_full_loop_runner.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import torch
 
@@ -100,8 +100,11 @@ class EagleFullLoopRunner:
             "MUSA-0090 EagleFullLoopRunner: configured for "
             "num_speculative_tokens=%d, capture_sizes=%s, max_bs=%d, "
             "hidden_size=%d, topk=%d",
-            self.num_steps, self.capture_sizes, self.max_bs,
-            self.hidden_size, self.topk,
+            self.num_steps,
+            self.capture_sizes,
+            self.max_bs,
+            self.hidden_size,
+            self.topk,
         )
 
     # ---- dispatcher predicate ----
@@ -153,6 +156,7 @@ class EagleFullLoopRunner:
         pool = None
         try:
             from vllm.platforms import current_platform
+
             pool = current_platform.get_global_graph_pool()
         except Exception as exc:
             logger.warning(
@@ -188,13 +192,15 @@ class EagleFullLoopRunner:
                 logger.info(
                     "MUSA-0090 captured Eagle3 full-loop graph for bs=%d "
                     "(buffer footprint %.2f MiB)",
-                    bs, ctx.memory_footprint_bytes() / 1024 / 1024,
+                    bs,
+                    ctx.memory_footprint_bytes() / 1024 / 1024,
                 )
             except Exception as exc:
                 logger.exception(
                     "MUSA-0090 graph capture FAILED at bs=%d: %s. "
                     "Falling back to iterative path for this size.",
-                    bs, exc,
+                    bs,
+                    exc,
                 )
                 # Don't propagate — the patch will fall back to vLLM's
                 # iterative path when can_run(bs) returns False for this size.
@@ -221,9 +227,7 @@ class EagleFullLoopRunner:
         Phase 5: wrap and return context
         """
         if batch_size <= 0 or batch_size > self.max_bs:
-            raise ValueError(
-                f"batch_size {batch_size} out of range [1, {self.max_bs}]"
-            )
+            raise ValueError(f"batch_size {batch_size} out of range [1, {self.max_bs}]")
 
         # Phase 1: allocate buffers for this batch size.
         # block_table_tensor is held as a reference (not copied); we read it
@@ -332,7 +336,10 @@ class EagleFullLoopRunner:
         #
         #   # End of context manager = graph capture complete.
         graph = self._capture_n_step_loop(
-            buffers, attn_metadata_array, batch_size, pool,
+            buffers,
+            attn_metadata_array,
+            batch_size,
+            pool,
         )
 
         # Phase 5: wrap up and return.
@@ -349,11 +356,15 @@ class EagleFullLoopRunner:
     def replay(
         self,
         target_hidden_states: torch.Tensor,  # bf16 [bs, hidden_size] OR [num_tokens, hidden_size]
-        next_token_ids: torch.Tensor,        # int32 [bs] (the bonus from verify)
-        common_attn_metadata: Any,            # for assertion + step-0 metadata seeding
+        next_token_ids: torch.Tensor,  # int32 [bs] (the bonus from verify)
+        common_attn_metadata: Any,  # for assertion + step-0 metadata seeding
         batch_size: int,
-        target_positions: torch.Tensor | None = None,  # int64 [num_tokens] (the verify pass's positions)
-        token_indices_to_sample: torch.Tensor | None = None,  # int [bs] (idx in num_tokens of last token per seq)
+        target_positions: (
+            torch.Tensor | None
+        ) = None,  # int64 [num_tokens] (the verify pass's positions)
+        token_indices_to_sample: (
+            torch.Tensor | None
+        ) = None,  # int [bs] (idx in num_tokens of last token per seq)
     ) -> EagleFullLoopReplayResult:
         """Replay the captured graph for this batch size.
 
@@ -429,7 +440,10 @@ class EagleFullLoopRunner:
             target_hidden_states = self.proposer.model.combine_hidden_states(
                 target_hidden_states
             )
-        if target_hidden_states.dim() >= 1 and target_hidden_states.shape[0] != batch_size:
+        if (
+            target_hidden_states.dim() >= 1
+            and target_hidden_states.shape[0] != batch_size
+        ):
             selected_hidden = target_hidden_states[token_indices_to_sample]
         else:
             selected_hidden = target_hidden_states[:batch_size]
@@ -611,9 +625,11 @@ class EagleFullLoopRunner:
         statically-allocates everything ahead of time.
         """
         # Lazy imports to avoid pulling vLLM internals at module-load time.
-        from vllm.forward_context import set_forward_context
         from vllm.config import CUDAGraphMode
-        from vllm.v1.spec_decode.utils import eagle_step_update_slot_mapping_and_metadata
+        from vllm.forward_context import set_forward_context
+        from vllm.v1.spec_decode.utils import (
+            eagle_step_update_slot_mapping_and_metadata,
+        )
 
         proposer = self.proposer
         # Step-0 seed: copy the input carry-over into the per-step buffers.
@@ -705,9 +721,7 @@ class EagleFullLoopRunner:
             # Update state for step+1 if not the last step.
             if step + 1 < self.num_steps:
                 # Stage next step's input.
-                buffers.input_ids_per_step[step + 1, :batch_size].copy_(
-                    draft_token_ids
-                )
+                buffers.input_ids_per_step[step + 1, :batch_size].copy_(draft_token_ids)
                 buffers.hidden_states_per_step[step + 1, :batch_size].copy_(
                     next_hidden[:batch_size]
                 )

--- a/vllm_musa/v1/spec_decode/spec_info.py
+++ b/vllm_musa/v1/spec_decode/spec_info.py
@@ -10,7 +10,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -140,18 +140,34 @@ class EagleDraftBuffers:
         )
 
         return cls(
-            input_ids_per_step=torch.zeros((num_steps, max_bs), dtype=i32, device=device),
-            positions_per_step=torch.zeros((num_steps, max_bs), dtype=i64, device=device),
-            slot_mapping_per_step=torch.zeros((num_steps, max_bs), dtype=i64, device=device),
-            seq_lens_per_step=torch.zeros((num_steps, max_bs), dtype=i32, device=device),
+            input_ids_per_step=torch.zeros(
+                (num_steps, max_bs), dtype=i32, device=device
+            ),
+            positions_per_step=torch.zeros(
+                (num_steps, max_bs), dtype=i64, device=device
+            ),
+            slot_mapping_per_step=torch.zeros(
+                (num_steps, max_bs), dtype=i64, device=device
+            ),
+            seq_lens_per_step=torch.zeros(
+                (num_steps, max_bs), dtype=i32, device=device
+            ),
             hidden_states_per_step=torch.zeros(
                 (num_steps, max_bs, hidden_size), dtype=bf16, device=device
             ),
-            topk_p_per_step=torch.zeros((num_steps, max_bs, topk), dtype=f32, device=device),
-            topk_index_per_step=torch.zeros((num_steps, max_bs, topk), dtype=i32, device=device),
-            draft_token_ids_out=torch.zeros((max_bs, num_steps), dtype=i32, device=device),
+            topk_p_per_step=torch.zeros(
+                (num_steps, max_bs, topk), dtype=f32, device=device
+            ),
+            topk_index_per_step=torch.zeros(
+                (num_steps, max_bs, topk), dtype=i32, device=device
+            ),
+            draft_token_ids_out=torch.zeros(
+                (max_bs, num_steps), dtype=i32, device=device
+            ),
             bonus_token_ids_in=torch.zeros((max_bs,), dtype=i32, device=device),
-            target_hidden_states_in=torch.zeros((max_bs, hidden_size), dtype=bf16, device=device),
+            target_hidden_states_in=torch.zeros(
+                (max_bs, hidden_size), dtype=bf16, device=device
+            ),
             # MUSA-0090 step 5k: step-0 input metadata buffers.
             positions_in=torch.zeros((max_bs,), dtype=i64, device=device),
             slot_mapping_in=torch.zeros((max_bs,), dtype=i64, device=device),

--- a/vllm_musa/v1/spec_decode/utils.py
+++ b/vllm_musa/v1/spec_decode/utils.py
@@ -69,7 +69,6 @@ def eagle_prepare_next_token_padded_kernel(
 
 
 import torch
-
 import vllm.v1.spec_decode.utils
 
 vllm.v1.spec_decode.utils.eagle_prepare_next_token_padded_kernel = (
@@ -88,6 +87,7 @@ vllm.v1.spec_decode.utils.eagle_prepare_next_token_padded_kernel = (
 #
 # Workaround: replace this function with an eager (no torch.compile) version.
 # The function does only 5-6 small tensor ops on small tensors — eager is fine.
+
 
 def _musa_update_num_computed_tokens_for_batch_change(
     num_computed_tokens: torch.Tensor,


### PR DESCRIPTION
## Motivation
This PR is intended to support the turboquant_k8v4 KV cache dtype.

## Modifications
The main change is adding the _musa_use_fp8_e4b15 function in turboquant.py to patch vLLM.

Since the current MUSA platform does not support the float8e4b15 dtype, this function directly returns 0.

## Test
run Qwen3-8B with `--kv-cache-dtype turboquant_k8v4` passed