### PR TITLE
Optimize the performance of Qwen3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "numpy<2.0",
     "openai>=2.24.0",
     "transformers==5.5.3",
+    "tilelang_musa>=0.1.8"
 ]
 
 [project.optional-dependencies]

--- a/vllm_musa/jit_kernel/__init__.py
+++ b/vllm_musa/jit_kernel/__init__.py
@@ -1,0 +1,5 @@
+"""MUSA TileLang JIT kernels."""
+
+from vllm_musa.jit_kernel.tilelang.rope import rotary_embedding
+
+__all__ = ["rotary_embedding"]

--- a/vllm_musa/jit_kernel/tilelang/__init__.py
+++ b/vllm_musa/jit_kernel/tilelang/__init__.py
@@ -1,0 +1,5 @@
+"""MUSA TileLang JIT kernels."""
+
+from vllm_musa.jit_kernel.tilelang.rope import rotary_embedding
+
+__all__ = ["rotary_embedding"]

--- a/vllm_musa/jit_kernel/tilelang/rope.py
+++ b/vllm_musa/jit_kernel/tilelang/rope.py
@@ -1,0 +1,421 @@
+"""MUSA TileLang rotary embedding kernels."""
+
+import functools
+from typing import Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from vllm_musa.jit_kernel.tilelang.utils import (
+    MUSA_COMMON_PASS_CONFIGS,
+    MUSA_COMPILE_FLAGS,
+    layout_strides,
+    storage_window,
+    tilelang_dtype,
+)
+
+_ROPE_PASS_CONFIGS = dict(MUSA_COMMON_PASS_CONFIGS)
+for _key, _value in (
+    ("TL_DISABLE_SAFE_COPY_PREDICATION", True),
+    ("TL_DISABLE_SAFE_ROBUST_COPY_PREDICATION", True),
+    ("TL_CONFIG_INDEX_BITWIDTH", 32),
+):
+    if hasattr(tilelang.PassConfigKey, _key):
+        _ROPE_PASS_CONFIGS[getattr(tilelang.PassConfigKey, _key)] = _value
+
+
+@functools.lru_cache(maxsize=64)
+@tilelang.jit(
+    out_idx=[],
+    target="musa",
+    pass_configs=_ROPE_PASS_CONFIGS,
+    compile_flags=MUSA_COMPILE_FLAGS,
+)
+def _rotary_embedding_decode_kernel(
+    dtype: str,
+    head_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    rot_dim: int,
+    query_storage_size: int,
+    key_storage_size: int,
+    seq_len: int,
+    query_batch_stride: int,
+    key_batch_stride: int,
+    query_stride: int,
+    key_stride: int,
+    query_head_stride: int,
+    key_head_stride: int,
+    query_dim_stride: int,
+    key_dim_stride: int,
+    is_neox: bool,
+    has_key: bool,
+    block_pairs: int,
+):
+    num_tokens = T.symbolic("num_tokens")
+    max_position = T.symbolic("max_position")
+    half_rot_dim = rot_dim // 2
+    max_head_pairs = max(num_heads, num_kv_heads) * half_rot_dim
+
+    @T.prim_func
+    def sglang_musa_rotary_embedding_decode_kernel(
+        positions: T.Tensor((num_tokens,), "int64"),
+        query: T.Tensor((query_storage_size,), dtype),
+        key: T.Tensor((key_storage_size,), dtype),
+        cos_sin_cache: T.Tensor((max_position, rot_dim), dtype),
+    ):
+        with T.Kernel(
+            num_tokens,
+            T.ceildiv(max_head_pairs, block_pairs),
+            threads=block_pairs,
+        ) as (token_idx, pair_block):
+            pos = positions[token_idx]
+            for i in T.Parallel(block_pairs):
+                pair_idx = pair_block * block_pairs + i
+
+                if pair_idx < num_heads * half_rot_dim:
+                    q_head_idx = pair_idx // half_rot_dim
+                    q_rot_offset = pair_idx - q_head_idx * half_rot_dim
+                    if seq_len > 0:
+                        q_batch_idx = token_idx // seq_len
+                        q_seq_idx = token_idx - q_batch_idx * seq_len
+                        q_token_base = (
+                            q_batch_idx * query_batch_stride + q_seq_idx * query_stride
+                        )
+                    else:
+                        q_token_base = token_idx * query_stride
+                    q_base = q_token_base + q_head_idx * query_head_stride
+                    if is_neox:
+                        q_x_idx = q_rot_offset
+                        q_y_idx = half_rot_dim + q_rot_offset
+                    else:
+                        q_x_idx = 2 * q_rot_offset
+                        q_y_idx = q_x_idx + 1
+
+                    q_cos = cos_sin_cache[pos, q_rot_offset]
+                    q_sin = cos_sin_cache[pos, half_rot_dim + q_rot_offset]
+                    q_x_offset = q_base + q_x_idx * query_dim_stride
+                    q_y_offset = q_base + q_y_idx * query_dim_stride
+                    q_x = query[q_x_offset].astype("float32")
+                    q_y = query[q_y_offset].astype("float32")
+                    q_cos_f = q_cos.astype("float32")
+                    q_sin_f = q_sin.astype("float32")
+                    query[q_x_offset] = (q_x * q_cos_f - q_y * q_sin_f).astype(dtype)
+                    query[q_y_offset] = (q_y * q_cos_f + q_x * q_sin_f).astype(dtype)
+
+                if has_key and pair_idx < num_kv_heads * half_rot_dim:
+                    k_head_idx = pair_idx // half_rot_dim
+                    k_rot_offset = pair_idx - k_head_idx * half_rot_dim
+                    if seq_len > 0:
+                        k_batch_idx = token_idx // seq_len
+                        k_seq_idx = token_idx - k_batch_idx * seq_len
+                        k_token_base = (
+                            k_batch_idx * key_batch_stride + k_seq_idx * key_stride
+                        )
+                    else:
+                        k_token_base = token_idx * key_stride
+                    k_base = k_token_base + k_head_idx * key_head_stride
+                    if is_neox:
+                        k_x_idx = k_rot_offset
+                        k_y_idx = half_rot_dim + k_rot_offset
+                    else:
+                        k_x_idx = 2 * k_rot_offset
+                        k_y_idx = k_x_idx + 1
+
+                    k_cos = cos_sin_cache[pos, k_rot_offset]
+                    k_sin = cos_sin_cache[pos, half_rot_dim + k_rot_offset]
+                    k_x_offset = k_base + k_x_idx * key_dim_stride
+                    k_y_offset = k_base + k_y_idx * key_dim_stride
+                    k_x = key[k_x_offset].astype("float32")
+                    k_y = key[k_y_offset].astype("float32")
+                    k_cos_f = k_cos.astype("float32")
+                    k_sin_f = k_sin.astype("float32")
+                    key[k_x_offset] = (k_x * k_cos_f - k_y * k_sin_f).astype(dtype)
+                    key[k_y_offset] = (k_y * k_cos_f + k_x * k_sin_f).astype(dtype)
+
+    return sglang_musa_rotary_embedding_decode_kernel
+
+
+_rotary_embedding_decode_kernel.mode = "lazy"
+
+
+@functools.lru_cache(maxsize=64)
+@tilelang.jit(out_idx=[], target="musa", pass_configs=_ROPE_PASS_CONFIGS)
+def _rotary_embedding_prefill_kernel(
+    dtype: str,
+    head_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    rot_dim: int,
+    query_storage_size: int,
+    key_storage_size: int,
+    seq_len: int,
+    query_batch_stride: int,
+    key_batch_stride: int,
+    query_stride: int,
+    key_stride: int,
+    query_head_stride: int,
+    key_head_stride: int,
+    query_dim_stride: int,
+    key_dim_stride: int,
+    is_neox: bool,
+    has_key: bool,
+    block_pairs: int,
+    vec_size: int,
+):
+    num_tokens = T.symbolic("num_tokens")
+    max_position = T.symbolic("max_position")
+    half_rot_dim = rot_dim // 2
+    max_head_pairs = max(num_heads, num_kv_heads) * half_rot_dim
+    pair_blocks = T.ceildiv(max_head_pairs, block_pairs * vec_size)
+    cache_blocks = T.ceildiv(rot_dim, block_pairs)
+
+    @T.prim_func
+    def sglang_musa_rotary_embedding_prefill_kernel(
+        positions: T.Tensor((num_tokens,), "int64"),
+        query: T.Tensor((query_storage_size,), dtype),
+        key: T.Tensor((key_storage_size,), dtype),
+        cos_sin_cache: T.Tensor((max_position, rot_dim), dtype),
+    ):
+        with T.Kernel(num_tokens, threads=block_pairs) as token_idx:
+            pos = positions[token_idx]
+            cache_shared = T.alloc_shared((rot_dim,), dtype)
+            for cache_block in T.serial(cache_blocks):
+                for i in T.Parallel(block_pairs):
+                    cache_idx = cache_block * block_pairs + i
+                    if cache_idx < rot_dim:
+                        cache_shared[cache_idx] = cos_sin_cache[pos, cache_idx]
+            T.sync_threads()
+
+            for pair_block in T.serial(pair_blocks):
+                for i in T.Parallel(block_pairs):
+                    pair_base = (pair_block * block_pairs + i) * vec_size
+                    for v in T.vectorized(vec_size):
+                        pair_idx = pair_base + v
+
+                        if pair_idx < num_heads * half_rot_dim:
+                            q_head_idx = pair_idx // half_rot_dim
+                            q_rot_offset = pair_idx - q_head_idx * half_rot_dim
+                            if seq_len > 0:
+                                q_batch_idx = token_idx // seq_len
+                                q_seq_idx = token_idx - q_batch_idx * seq_len
+                                q_token_base = (
+                                    q_batch_idx * query_batch_stride
+                                    + q_seq_idx * query_stride
+                                )
+                            else:
+                                q_token_base = token_idx * query_stride
+                            q_base = q_token_base + q_head_idx * query_head_stride
+                            if is_neox:
+                                q_x_idx = q_rot_offset
+                                q_y_idx = half_rot_dim + q_rot_offset
+                            else:
+                                q_x_idx = 2 * q_rot_offset
+                                q_y_idx = q_x_idx + 1
+
+                            q_cos = cache_shared[q_rot_offset]
+                            q_sin = cache_shared[half_rot_dim + q_rot_offset]
+                            q_x_offset = q_base + q_x_idx * query_dim_stride
+                            q_y_offset = q_base + q_y_idx * query_dim_stride
+                            q_x = query[q_x_offset].astype("float32")
+                            q_y = query[q_y_offset].astype("float32")
+                            q_cos_f = q_cos.astype("float32")
+                            q_sin_f = q_sin.astype("float32")
+                            query[q_x_offset] = (q_x * q_cos_f - q_y * q_sin_f).astype(
+                                dtype
+                            )
+                            query[q_y_offset] = (q_y * q_cos_f + q_x * q_sin_f).astype(
+                                dtype
+                            )
+
+                        if has_key and pair_idx < num_kv_heads * half_rot_dim:
+                            k_head_idx = pair_idx // half_rot_dim
+                            k_rot_offset = pair_idx - k_head_idx * half_rot_dim
+                            if seq_len > 0:
+                                k_batch_idx = token_idx // seq_len
+                                k_seq_idx = token_idx - k_batch_idx * seq_len
+                                k_token_base = (
+                                    k_batch_idx * key_batch_stride
+                                    + k_seq_idx * key_stride
+                                )
+                            else:
+                                k_token_base = token_idx * key_stride
+                            k_base = k_token_base + k_head_idx * key_head_stride
+                            if is_neox:
+                                k_x_idx = k_rot_offset
+                                k_y_idx = half_rot_dim + k_rot_offset
+                            else:
+                                k_x_idx = 2 * k_rot_offset
+                                k_y_idx = k_x_idx + 1
+
+                            k_cos = cache_shared[k_rot_offset]
+                            k_sin = cache_shared[half_rot_dim + k_rot_offset]
+                            k_x_offset = k_base + k_x_idx * key_dim_stride
+                            k_y_offset = k_base + k_y_idx * key_dim_stride
+                            k_x = key[k_x_offset].astype("float32")
+                            k_y = key[k_y_offset].astype("float32")
+                            k_cos_f = k_cos.astype("float32")
+                            k_sin_f = k_sin.astype("float32")
+                            key[k_x_offset] = (k_x * k_cos_f - k_y * k_sin_f).astype(
+                                dtype
+                            )
+                            key[k_y_offset] = (k_y * k_cos_f + k_x * k_sin_f).astype(
+                                dtype
+                            )
+
+    return sglang_musa_rotary_embedding_prefill_kernel
+
+
+_rotary_embedding_prefill_kernel.mode = "lazy"
+
+
+def rotary_embedding(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: Optional[torch.Tensor],
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> None:
+    num_tokens = positions.numel()
+    positions_ndim = positions.dim()
+    if positions_ndim not in (1, 2):
+        raise ValueError(
+            "positions must have shape [num_tokens] or [batch_size, seq_len]"
+        )
+    if positions_ndim == 1:
+        if query.size(0) != positions.size(0) or (
+            key is not None and key.size(0) != positions.size(0)
+        ):
+            raise ValueError(
+                "query, key and positions must have the same number of tokens"
+            )
+    else:
+        if (
+            query.size(0) != positions.size(0)
+            or query.size(1) != positions.size(1)
+            or (key is not None and key.size(0) != positions.size(0))
+            or (key is not None and key.size(1) != positions.size(1))
+        ):
+            raise ValueError(
+                "query, key and positions must have the same batch_size and seq_len"
+            )
+
+    query_hidden_size = query.numel() // num_tokens
+    key_hidden_size = key.numel() // num_tokens if key is not None else 0
+    if query_hidden_size % head_size != 0:
+        raise ValueError("query hidden size must be divisible by head_size")
+    if key is not None and key_hidden_size % head_size != 0:
+        raise ValueError("key hidden size must be divisible by head_size")
+
+    num_heads = query_hidden_size // head_size
+    num_kv_heads = key_hidden_size // head_size if key is not None else num_heads
+    if num_heads % num_kv_heads != 0:
+        raise ValueError("num_heads must be divisible by num_kv_heads")
+
+    rot_dim = cos_sin_cache.size(1)
+    if rot_dim % 2 != 0 or rot_dim > head_size:
+        raise ValueError("rot_dim must be even and no larger than head_size")
+    if positions.dtype != torch.long:
+        raise TypeError("positions must be torch.int64")
+    if query.dtype != cos_sin_cache.dtype or (
+        key is not None and key.dtype != query.dtype
+    ):
+        raise TypeError("query, key and cos_sin_cache must have the same dtype")
+    if not positions.is_contiguous():
+        positions = positions.contiguous()
+    if not cos_sin_cache.is_contiguous():
+        cos_sin_cache = cos_sin_cache.contiguous()
+
+    (
+        query_batch_stride,
+        query_stride,
+        query_head_stride,
+        query_dim_stride,
+    ) = layout_strides(query, positions_ndim, head_size)
+    if key is not None:
+        (
+            key_batch_stride,
+            key_stride,
+            key_head_stride,
+            key_dim_stride,
+        ) = layout_strides(key, positions_ndim, head_size)
+    else:
+        key_batch_stride = query_batch_stride
+        key_stride = query_stride
+        key_head_stride = query_head_stride
+        key_dim_stride = query_dim_stride
+
+    seq_len = positions.size(1) if positions_ndim == 2 else 0
+    query_arg = storage_window(query)
+    key_arg = storage_window(key) if key is not None else query_arg
+    split_block_pairs = min(512, max(32, num_heads * rot_dim // 2))
+    loop_block_pairs = min(512, max(32, num_heads * rot_dim // 2))
+    if (
+        num_tokens > 16384
+        and query.is_contiguous()
+        and (key is None or key.is_contiguous())
+    ):
+        loop_block_pairs = min(256, max(32, num_heads * rot_dim // 2))
+    prefill_block_pairs = loop_block_pairs
+    prefill_vec_size = 1
+    if (
+        128 < num_tokens <= 16384
+        and positions_ndim == 1
+        and query_dim_stride == 1
+        and key_dim_stride == 1
+    ):
+        prefill_vec_size = 2
+
+    if num_tokens <= 128:
+        kernel = _rotary_embedding_decode_kernel(
+            tilelang_dtype(query.dtype),
+            int(head_size),
+            int(num_heads),
+            int(num_kv_heads),
+            int(rot_dim),
+            int(query_arg.numel()),
+            int(key_arg.numel()),
+            int(seq_len),
+            int(query_batch_stride),
+            int(key_batch_stride),
+            int(query_stride),
+            int(key_stride),
+            int(query_head_stride),
+            int(key_head_stride),
+            int(query_dim_stride),
+            int(key_dim_stride),
+            bool(is_neox),
+            key is not None,
+            int(split_block_pairs),
+        )
+    else:
+        kernel = _rotary_embedding_prefill_kernel(
+            tilelang_dtype(query.dtype),
+            int(head_size),
+            int(num_heads),
+            int(num_kv_heads),
+            int(rot_dim),
+            int(query_arg.numel()),
+            int(key_arg.numel()),
+            int(seq_len),
+            int(query_batch_stride),
+            int(key_batch_stride),
+            int(query_stride),
+            int(key_stride),
+            int(query_head_stride),
+            int(key_head_stride),
+            int(query_dim_stride),
+            int(key_dim_stride),
+            bool(is_neox),
+            key is not None,
+            int(prefill_block_pairs),
+            int(prefill_vec_size),
+        )
+    kernel(
+        positions.reshape(-1),
+        query_arg,
+        key_arg,
+        cos_sin_cache,
+    )

--- a/vllm_musa/jit_kernel/tilelang/utils.py
+++ b/vllm_musa/jit_kernel/tilelang/utils.py
@@ -1,0 +1,88 @@
+"""Shared helpers for MUSA TileLang kernels."""
+
+import tilelang
+import torch
+
+tilelang.set_log_level("WARNING")
+
+# if hasattr(torch, "musa") and torch.musa.is_available():
+#     tilelang.disable_cache()
+
+MUSA_COMMON_PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+}
+if hasattr(tilelang.PassConfigKey, "TL_DISABLE_FAST_MATH"):
+    MUSA_COMMON_PASS_CONFIGS[tilelang.PassConfigKey.TL_DISABLE_FAST_MATH] = True
+elif hasattr(tilelang.PassConfigKey, "TL_ENABLE_FAST_MATH"):
+    MUSA_COMMON_PASS_CONFIGS[tilelang.PassConfigKey.TL_ENABLE_FAST_MATH] = False
+for _key, _value in (
+    ("TL_DISABLE_THREAD_STORAGE_SYNC", True),
+    ("TL_ENABLE_MUSA_BURST", True),
+    ("TL_ENABLE_REDUCE_BURST", True),
+    ("TL_DISABLE_SAFE_MEMORY_ACCESS", True),
+    ("TL_DISABLE_INDEX_TYPE_PROMOTION", True),
+):
+    if hasattr(tilelang.PassConfigKey, _key):
+        MUSA_COMMON_PASS_CONFIGS[getattr(tilelang.PassConfigKey, _key)] = _value
+
+MUSA_COMPILE_FLAGS = [
+    "-Od3",
+    "-fno-signed-zeros",
+    "-fmusa-flush-denormals-to-zero",
+    "-mllvm",
+    "-misched=mtgpu-max-ilp",
+    "-mllvm",
+    "-mtgpu-if-convert=1",
+    "-mllvm",
+    "-mtgpu-tiny-offset-hint=1",
+    "-mllvm",
+    "-mtgpu-enable-postra-sched=0",
+    "-mllvm",
+    "-misched-recompute-slotindex=1",
+    "-mllvm",
+    "-mtgpu-combine-fop-instr=1",
+]
+
+
+def tilelang_dtype(dtype: torch.dtype) -> str:
+    if dtype is torch.float16:
+        return "float16"
+    if dtype is torch.bfloat16:
+        return "bfloat16"
+    if dtype is torch.float32:
+        return "float32"
+    raise TypeError(f"Unsupported dtype for TileLang MUSA kernel: {dtype}")
+
+
+def storage_window(tensor: torch.Tensor) -> torch.Tensor:
+    storage_size = 1
+    for size, stride in zip(tensor.shape, tensor.stride()):
+        if stride < 0:
+            raise ValueError("tensor must not have negative strides")
+        if size == 0:
+            return tensor.reshape(-1)
+        storage_size += (size - 1) * stride
+    return tensor.as_strided((storage_size,), (1,))
+
+
+def layout_strides(
+    tensor: torch.Tensor,
+    positions_ndim: int,
+    head_size: int,
+) -> tuple[int, int, int, int]:
+    if tensor.dim() not in (positions_ndim + 1, positions_ndim + 2):
+        raise ValueError(
+            "tensor must have shape [..., hidden_size] "
+            "or [..., num_heads, head_size]"
+        )
+
+    batch_stride = tensor.stride(0) if positions_ndim == 2 else 0
+    token_stride = tensor.stride(positions_ndim - 1)
+    if tensor.dim() == positions_ndim + 2:
+        head_stride = tensor.stride(-2)
+        dim_stride = tensor.stride(-1)
+    else:
+        dim_stride = tensor.stride(-1)
+        head_stride = head_size * dim_stride
+    return batch_stride, token_stride, head_stride, dim_stride

--- a/vllm_musa/model_executor/__init__.py
+++ b/vllm_musa/model_executor/__init__.py
@@ -6,5 +6,6 @@ import vllm_musa.model_executor.layers.fused_moe.unquantized_fused_moe_method
 import vllm_musa.model_executor.layers.layernorm
 import vllm_musa.model_executor.layers.quantization.fp8
 import vllm_musa.model_executor.layers.quantization.utils.fp8_utils
+import vllm_musa.model_executor.layers.rotary_embedding.base
 import vllm_musa.model_executor.layers.utils
 import vllm_musa.model_executor.warmup.deep_gemm_warmup

--- a/vllm_musa/model_executor/layers/rotary_embedding/base.py
+++ b/vllm_musa/model_executor/layers/rotary_embedding/base.py
@@ -1,0 +1,25 @@
+import torch
+from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
+
+from vllm_musa.jit_kernel import rotary_embedding
+
+
+@RotaryEmbedding.register_oot
+class MusaRotaryEmbedding(RotaryEmbedding):
+    def forward_oot(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        self.cos_sin_cache = self.cos_sin_cache.to(query.device, dtype=query.dtype)
+
+        rotary_embedding(
+            positions,
+            query,
+            key,
+            self.head_size,
+            self.cos_sin_cache,
+            self.is_neox_style,
+        )
+        return query, key

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -165,6 +165,7 @@ class MUSAPlatformBase(Platform):
             import vllm_musa.kernels  # noqa: F401
         except ImportError as exc:
             from vllm.logger import init_logger
+
             init_logger(__name__).info(
                 "vllm_musa.kernels unavailable (%s); MUSA IR providers "
                 "will not be registered. Upstream providers remain "
@@ -202,9 +203,7 @@ class MUSAPlatformBase(Platform):
         from vllm.config.kernel import IrOpPriorityConfig
 
         cc = vllm_config.compilation_config
-        using_inductor = (
-            cc.backend == "inductor" and cc.mode != CompilationMode.NONE
-        )
+        using_inductor = cc.backend == "inductor" and cc.mode != CompilationMode.NONE
         if using_inductor:
             # Let Inductor fuse the native reference impl. Keep the
             # `musa` custom-op provider out of the priority here — it is
@@ -356,62 +355,6 @@ class MUSAPlatformBase(Platform):
                 "with multimodal-bidirectional attention."
             )
             scheduler_config.disable_chunked_mm_input = True
-
-        compilation_config = vllm_config.compilation_config
-        cudagraph_mode = getattr(compilation_config, "cudagraph_mode", None)
-        # MUSA-0076: the TP>2 cudagraph force-disable was added in
-        # MUSA-0061/0063 under the (incorrect) belief that "MCCL is
-        # incompatible with MUSA stream capture at the platform level".
-        # The actual root cause was that custom_all_reduce was disabled
-        # on torch >= 2.9 (MUSA-0069 gate), causing
-        # cuda_communicator.all_reduce to fall through to
-        # torch.distributed.all_reduce, whose MCCL ProcessGroup watchdog
-        # made CUDA API calls during the capture window. MUSA-0075 fixed
-        # the underlying CAR kernel-alignment issue and re-enabled CAR
-        # at TP>2 on torch 2.9; the dispatcher now hits ca_comm
-        # (captureable, stream-bound) instead of torch.distributed.
-        #
-        # However, on torch_musa 2.9.0, capturing graphs at LARGE shapes
-        # (>= ~232 tokens / 51-size default capture) triggers an
-        # `illegal memory access` at musa_graph.capture_end() — a
-        # separate torch_musa-side bug. Until that bug is fixed
-        # upstream, cap max_cudagraph_capture_size to a safe value so
-        # only the small (decode-relevant) graphs are captured. Single-
-        # batch decode only needs size=1 anyway.
-        # MUSA-0081: allow overriding the safe-cap via env var for
-        # spec-decode / Eagle3 perf experiments. Setting
-        # ``VLLM_MUSA_MAX_CUDAGRAPH_CAPTURE_SIZE`` overrides the default
-        # ``MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE=8``. Values up to 224
-        # have been observed working on torch_musa 2.9.0; values >= 232
-        # trigger MUSA-0082's illegal memory access at capture_end.
-        import os as _os
-        try:
-            MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE = int(
-                _os.getenv("VLLM_MUSA_MAX_CUDAGRAPH_CAPTURE_SIZE", "8")
-            )
-        except ValueError:
-            MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE = 8
-        if cudagraph_mode is not None:
-            from vllm.config import CUDAGraphMode
-            if cudagraph_mode != CUDAGraphMode.NONE:
-                max_size = compilation_config.max_cudagraph_capture_size or 0
-                if max_size > MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE:
-                    logger.warning(
-                        "MUSA-0076: capping max_cudagraph_capture_size "
-                        "from %d to %d (larger sizes trigger an illegal "
-                        "memory access at musa_graph.capture_end on "
-                        "torch_musa 2.9.0; investigation pending). "
-                        "Override with VLLM_MUSA_MAX_CUDAGRAPH_CAPTURE_SIZE.",
-                        max_size, MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE,
-                    )
-                    compilation_config.max_cudagraph_capture_size = (
-                        MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE
-                    )
-                    if compilation_config.cudagraph_capture_sizes:
-                        compilation_config.cudagraph_capture_sizes = [
-                            s for s in compilation_config.cudagraph_capture_sizes
-                            if s <= MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE
-                        ]
 
     @classmethod
     def get_current_memory_usage(

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -34,6 +34,7 @@ if is_flash_attn_varlen_func_available():
         flash_attn_varlen_func,
         get_scheduler_metadata,
         reshape_and_cache_flash,
+        flash_attn_with_kvcache,
     )
 
 from vllm.config import (
@@ -911,37 +912,70 @@ class FlashAttentionImpl(AttentionImpl):
                 )
 
                 # ==================== MUSA ADAPTATION ====================
-                # Use MATE's varlen paged-cache path for target-model attention.
-                # Speculative decoding can send more than one query token per
-                # request (bonus + draft verification tokens), so splitting all
-                # decode requests through flash_attn_with_kvcache corrupts the
-                # verifier logits. The varlen path matches vLLM upstream and
-                # handles query_start_loc/max_query_len directly.
-                flash_attn_varlen_func(
-                    q=query[:num_actual_tokens].view(
-                        -1, self.num_heads, self.head_size
-                    ),
-                    k=key_cache,
-                    v=value_cache,
-                    out=output[:num_actual_tokens].view(
-                        -1, self.num_heads, self.head_size
-                    ),
-                    cu_seqlens_q=cu_seqlens_q,
-                    max_seqlen_q=max_seqlen_q,
-                    seqused_k=seqused_k,
-                    max_seqlen_k=max_seqlen_k,
-                    softmax_scale=self.scale,
-                    causal=attn_metadata.causal,
-                    window_size=sliding_window_size,
-                    block_table=block_table,
-                    softcap=self.logits_soft_cap,
-                    scheduler_metadata=scheduler_metadata,
-                    q_descale=q_descale,
-                    k_descale=k_descale,
-                    v_descale=v_descale,
-                    num_splits=attn_metadata.max_num_splits,
-                    s_aux=self.sinks,
+                num_decodes = attn_metadata.num_decodes
+                num_decode_tokens = attn_metadata.num_decode_tokens
+                num_prefills = attn_metadata.num_prefills
+                use_decode_fast_path = (
+                    num_prefills == 0
+                    and num_decodes > 0
+                    and num_decode_tokens <= num_decodes
+                    and max_seqlen_q == 1
+                    and self.sinks is None
+                    and attn_metadata.decode_block_table is not None
+                    and attn_metadata.decode_seq_lens is not None
+                    and attn_metadata.decode_query_start_loc is not None
                 )
+
+                if use_decode_fast_path:
+                    decode_descale_shape = (num_decodes, self.num_kv_heads)
+                    decode_output = flash_attn_with_kvcache(
+                        q=query[:num_decode_tokens].view(
+                            -1, self.num_heads, self.head_size
+                        ),
+                        k_cache=key_cache,
+                        v_cache=value_cache,
+                        page_table=attn_metadata.decode_block_table,
+                        cache_seqlens=attn_metadata.decode_seq_lens,
+                        cu_seqlens_q=attn_metadata.decode_query_start_loc,
+                        max_seqlen_q=1,
+                        softmax_scale=self.scale,
+                        causal=attn_metadata.causal,
+                        window_size=sliding_window_size,
+                        softcap=self.logits_soft_cap,
+                        k_descale=layer._k_scale.expand(decode_descale_shape),
+                        v_descale=layer._v_scale.expand(decode_descale_shape),
+                        num_splits=attn_metadata.max_num_splits,
+                    )
+                    output[:num_decode_tokens] = decode_output
+                else:
+                    # Eagle verifier and mixed/extend batches may have multiple
+                    # query tokens per request, so they must attend through the
+                    # paged KV cache with the original query_start_loc layout.
+                    flash_attn_varlen_func(
+                        q=query[:num_actual_tokens].view(
+                            -1, self.num_heads, self.head_size
+                        ),
+                        k=key_cache,
+                        v=value_cache,
+                        out=output[:num_actual_tokens].view(
+                            -1, self.num_heads, self.head_size
+                        ),
+                        cu_seqlens_q=cu_seqlens_q,
+                        max_seqlen_q=max_seqlen_q,
+                        seqused_k=seqused_k,
+                        max_seqlen_k=max_seqlen_k,
+                        softmax_scale=self.scale,
+                        causal=attn_metadata.causal,
+                        window_size=sliding_window_size,
+                        block_table=block_table,
+                        softcap=self.logits_soft_cap,
+                        scheduler_metadata=scheduler_metadata,
+                        q_descale=q_descale,
+                        k_descale=k_descale,
+                        v_descale=v_descale,
+                        num_splits=attn_metadata.max_num_splits,
+                        s_aux=self.sinks,
+                    )
                 # ========================== END ==========================
 
                 return output


### PR DESCRIPTION
1.Separate the prefill and decode of the flash attention backend and support eagle3
2.Add tilelang rope to reducee tpot
3.Delete MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE, this env causes memory exception issues when compiling with graph. It should be addressed in a positive way, rather than limiting the capture size