### PR TITLE
Add DeepSeek-V4-Flash-Base support for MUSA

### DIFF
--- a/build_utils/ccache.py
+++ b/build_utils/ccache.py
@@ -10,7 +10,6 @@ import shlex
 import shutil
 from pathlib import Path
 
-
 FALSE_VALUES = {"0", "false", "off", "no"}
 WRAPPER_SCRIPT = r"""#!/usr/bin/env bash
 set -euo pipefail
@@ -191,7 +190,9 @@ def _write_musa_compiler_wrapper(wrapper_dir: Path, real_mcc: str) -> Path:
     return wrapper
 
 
-def _link_ccache_wrapper(wrapper_dir: Path, compiler_name: str, ccache_bin: str) -> None:
+def _link_ccache_wrapper(
+    wrapper_dir: Path, compiler_name: str, ccache_bin: str
+) -> None:
     wrapper = wrapper_dir / compiler_name
     try:
         if wrapper.exists() or wrapper.is_symlink():
@@ -199,12 +200,10 @@ def _link_ccache_wrapper(wrapper_dir: Path, compiler_name: str, ccache_bin: str)
         wrapper.symlink_to(ccache_bin)
     except OSError:
         # Some filesystems disallow symlinks; a tiny exec wrapper is good enough.
-        real_compiler = _resolve_executable(
-            compiler_name, excluded_dirs=(wrapper_dir,)
-        )
+        real_compiler = _resolve_executable(compiler_name, excluded_dirs=(wrapper_dir,))
         wrapper.write_text(
             "#!/usr/bin/env bash\n"
-            f"exec {shlex.quote(ccache_bin)} {shlex.quote(real_compiler)} \"$@\"\n",
+            f'exec {shlex.quote(ccache_bin)} {shlex.quote(real_compiler)} "$@"\n',
             encoding="utf-8",
         )
         wrapper.chmod(0o755)

--- a/csrc/musa/attention/deepseek_v4_cache_store.mu
+++ b/csrc/musa/attention/deepseek_v4_cache_store.mu
@@ -1,0 +1,381 @@
+#include <cmath>
+#include <cstdint>
+
+#include <musa_bf16.h>
+#include <musa_fp8.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+namespace {
+
+constexpr int64_t kNopeDim = 448;
+constexpr int64_t kRopeDim = 64;
+constexpr int64_t kHeadDim = kNopeDim + kRopeDim;
+constexpr int64_t kTokenDataBytes = kNopeDim + kRopeDim * 2;
+constexpr int64_t kTokenScaleBytes = 8;
+constexpr int64_t kQuantBlockSize = 64;
+constexpr int kQNormThreads = 256;
+
+constexpr int kIndexInt32 = 1;
+constexpr int kIndexInt64 = 2;
+
+__device__ __forceinline__ int64_t load_index(const void* ptr, int kind,
+                                              int64_t idx) {
+  if (kind == kIndexInt32) {
+    return static_cast<int64_t>(static_cast<const int32_t*>(ptr)[idx]);
+  }
+  return static_cast<int64_t>(static_cast<const int64_t*>(ptr)[idx]);
+}
+
+__global__ void deepseek_v4_qnorm_rope_kernel(
+    __mt_bfloat16* __restrict__ q, const void* __restrict__ positions,
+    int position_kind, const float* __restrict__ cos_sin_cache, float eps,
+    int64_t num_tokens, int64_t num_heads) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x);
+  const int64_t head = static_cast<int64_t>(blockIdx.y);
+  if (token >= num_tokens || head >= num_heads) {
+    return;
+  }
+
+  __shared__ float reduce[kQNormThreads];
+  const int tid = threadIdx.x;
+  __mt_bfloat16* row = q + (token * num_heads + head) * kHeadDim;
+
+  float partial = 0.0f;
+  for (int64_t dim = tid; dim < kHeadDim; dim += blockDim.x) {
+    const float value = __bfloat162float(row[dim]);
+    partial += value * value;
+  }
+  reduce[tid] = partial;
+  __syncthreads();
+
+  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+    if (tid < stride) {
+      reduce[tid] += reduce[tid + stride];
+    }
+    __syncthreads();
+  }
+
+  const float norm = rsqrtf(reduce[0] / static_cast<float>(kHeadDim) + eps);
+  for (int64_t dim = tid; dim < kNopeDim; dim += blockDim.x) {
+    row[dim] = __float2bfloat16(__bfloat162float(row[dim]) * norm);
+  }
+
+  const int64_t pos = load_index(positions, position_kind, token);
+  const float* cos_ptr = cos_sin_cache + pos * kRopeDim;
+  const float* sin_ptr = cos_ptr + kRopeDim / 2;
+  for (int64_t pair = tid; pair < kRopeDim / 2; pair += blockDim.x) {
+    const int64_t even_dim = kNopeDim + pair * 2;
+    const int64_t odd_dim = even_dim + 1;
+    const float even = __bfloat162float(row[even_dim]) * norm;
+    const float odd = __bfloat162float(row[odd_dim]) * norm;
+    const float c = cos_ptr[pair];
+    const float s = sin_ptr[pair];
+    row[even_dim] = __float2bfloat16(even * c - odd * s);
+    row[odd_dim] = __float2bfloat16(even * s + odd * c);
+  }
+}
+
+__global__ void deepseek_v4_kv_rope_pack_kernel(
+    const __mt_bfloat16* __restrict__ kv, uint8_t* __restrict__ cache,
+    const void* __restrict__ slots, int slot_kind,
+    const void* __restrict__ positions, int position_kind,
+    const float* __restrict__ cos_sin_cache, int64_t num_tokens,
+    int64_t num_blocks, int64_t block_size, int64_t block_stride) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x);
+  if (token >= num_tokens) {
+    return;
+  }
+
+  const int64_t slot = load_index(slots, slot_kind, token);
+  if (slot < 0 || slot >= num_blocks * block_size) {
+    return;
+  }
+
+  __shared__ float abs_values[kQuantBlockSize];
+  __shared__ int scale_exponents[kTokenScaleBytes];
+
+  const int tid = threadIdx.x;
+  const int64_t block_idx = slot / block_size;
+  const int64_t pos_in_block = slot - block_idx * block_size;
+  uint8_t* block_ptr = cache + block_idx * block_stride;
+  uint8_t* token_ptr = block_ptr + pos_in_block * kTokenDataBytes;
+  uint8_t* scale_ptr = block_ptr + block_size * kTokenDataBytes +
+                       pos_in_block * kTokenScaleBytes;
+  const __mt_bfloat16* input = kv + token * kHeadDim;
+
+  for (int qblock = 0; qblock < kNopeDim / kQuantBlockSize; ++qblock) {
+    const int64_t start = qblock * kQuantBlockSize;
+    if (tid < kQuantBlockSize) {
+      const float value = __bfloat162float(input[start + tid]);
+      abs_values[tid] = fabsf(value);
+    }
+    __syncthreads();
+
+    for (int stride = kQuantBlockSize / 2; stride > 0; stride >>= 1) {
+      if (tid < stride) {
+        abs_values[tid] = fmaxf(abs_values[tid], abs_values[tid + stride]);
+      }
+      __syncthreads();
+    }
+
+    if (tid == 0) {
+      const float amax = fmaxf(abs_values[0], 1.0e-4f);
+      const int exponent =
+          static_cast<int>(ceilf(log2f(amax / 448.0f)));
+      scale_exponents[qblock] = exponent;
+      const int scale_byte = max(0, min(255, exponent + 127));
+      scale_ptr[qblock] = static_cast<uint8_t>(scale_byte);
+    }
+    __syncthreads();
+
+    if (tid < kQuantBlockSize) {
+      const float value = __bfloat162float(input[start + tid]);
+      const float scaled = fminf(fmaxf(value * exp2f(-scale_exponents[qblock]),
+                                      -448.0f),
+                                448.0f);
+      const __mt_fp8_e4m3 packed(scaled);
+      token_ptr[start + tid] = packed.__x;
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    scale_ptr[kTokenScaleBytes - 1] = 0;
+  }
+
+  const int64_t pos = load_index(positions, position_kind, token);
+  const float* cos_ptr = cos_sin_cache + pos * kRopeDim;
+  const float* sin_ptr = cos_ptr + kRopeDim / 2;
+  __mt_bfloat16* rope_ptr =
+      reinterpret_cast<__mt_bfloat16*>(token_ptr + kNopeDim);
+  for (int64_t pair = tid; pair < kRopeDim / 2; pair += blockDim.x) {
+    const int64_t even_dim = kNopeDim + pair * 2;
+    const int64_t odd_dim = even_dim + 1;
+    const float even = __bfloat162float(input[even_dim]);
+    const float odd = __bfloat162float(input[odd_dim]);
+    const float c = cos_ptr[pair];
+    const float s = sin_ptr[pair];
+    rope_ptr[pair * 2] = __float2bfloat16(even * c - odd * s);
+    rope_ptr[pair * 2 + 1] = __float2bfloat16(even * s + odd * c);
+  }
+}
+
+__global__ void deepseek_v4_store_sparse_kv_kernel(
+    const __mt_bfloat16* __restrict__ normed, uint8_t* __restrict__ cache,
+    const void* __restrict__ slots, const bool* __restrict__ write_mask,
+    int index_kind, int64_t num_tokens, int64_t num_blocks, int64_t block_size,
+    int64_t block_stride) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x);
+  if (token >= num_tokens) {
+    return;
+  }
+
+  const int64_t slot = load_index(slots, index_kind, token);
+  if (!write_mask[token] || slot < 0 || slot >= num_blocks * block_size) {
+    return;
+  }
+
+  __shared__ float abs_values[kQuantBlockSize];
+  __shared__ int scale_exponents[kTokenScaleBytes];
+
+  const int tid = threadIdx.x;
+  const int64_t block_idx = slot / block_size;
+  const int64_t pos_in_block = slot - block_idx * block_size;
+  uint8_t* block_ptr = cache + block_idx * block_stride;
+  uint8_t* token_ptr = block_ptr + pos_in_block * kTokenDataBytes;
+  uint8_t* scale_ptr = block_ptr + block_size * kTokenDataBytes +
+                       pos_in_block * kTokenScaleBytes;
+  const __mt_bfloat16* input = normed + token * kHeadDim;
+
+  for (int qblock = 0; qblock < kNopeDim / kQuantBlockSize; ++qblock) {
+    const int64_t start = qblock * kQuantBlockSize;
+    if (tid < kQuantBlockSize) {
+      const float value = __bfloat162float(input[start + tid]);
+      abs_values[tid] = fabsf(value);
+    }
+    __syncthreads();
+
+    for (int stride = kQuantBlockSize / 2; stride > 0; stride >>= 1) {
+      if (tid < stride) {
+        abs_values[tid] = fmaxf(abs_values[tid], abs_values[tid + stride]);
+      }
+      __syncthreads();
+    }
+
+    if (tid == 0) {
+      const float amax = fmaxf(abs_values[0], 1.0e-4f);
+      const int exponent =
+          static_cast<int>(ceilf(log2f(amax / 448.0f)));
+      scale_exponents[qblock] = exponent;
+      const int scale_byte = max(0, min(255, exponent + 127));
+      scale_ptr[qblock] = static_cast<uint8_t>(scale_byte);
+    }
+    __syncthreads();
+
+    if (tid < kQuantBlockSize) {
+      const float value = __bfloat162float(input[start + tid]);
+      const float scaled = fminf(fmaxf(value * exp2f(-scale_exponents[qblock]),
+                                      -448.0f),
+                                448.0f);
+      const __mt_fp8_e4m3 packed(scaled);
+      token_ptr[start + tid] = packed.__x;
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    scale_ptr[kTokenScaleBytes - 1] = 0;
+  }
+  if (tid < kRopeDim * 2) {
+    const uint8_t* rope_bytes =
+        reinterpret_cast<const uint8_t*>(input + kNopeDim);
+    token_ptr[kNopeDim + tid] = rope_bytes[tid];
+  }
+}
+
+int index_kind(const torch::Tensor& tensor) {
+  if (tensor.scalar_type() == torch::kInt32) {
+    return kIndexInt32;
+  }
+  if (tensor.scalar_type() == torch::kInt64) {
+    return kIndexInt64;
+  }
+  TORCH_CHECK(false, "slot_mapping must be int32 or int64");
+}
+
+}  // namespace
+
+void deepseek_v4_qnorm_rope_kv_insert(
+    torch::Tensor& q,
+    const torch::Tensor& kv,
+    torch::Tensor& kv_cache,
+    const torch::Tensor& slot_mapping,
+    const torch::Tensor& positions,
+    const torch::Tensor& cos_sin_cache,
+    double eps,
+    int64_t cache_block_size) {
+  TORCH_CHECK(q.scalar_type() == torch::kBFloat16, "q must be bfloat16");
+  TORCH_CHECK(kv.scalar_type() == torch::kBFloat16, "kv must be bfloat16");
+  TORCH_CHECK(kv_cache.scalar_type() == torch::kUInt8,
+              "kv_cache must be uint8");
+  TORCH_CHECK(cos_sin_cache.scalar_type() == torch::kFloat32,
+              "cos_sin_cache must be float32");
+  TORCH_CHECK(q.is_contiguous(), "q must be contiguous");
+  TORCH_CHECK(kv.is_contiguous(), "kv must be contiguous");
+  TORCH_CHECK(slot_mapping.is_contiguous(), "slot_mapping must be contiguous");
+  TORCH_CHECK(positions.is_contiguous(), "positions must be contiguous");
+  TORCH_CHECK(q.device() == kv.device() && q.device() == kv_cache.device() &&
+                  q.device() == slot_mapping.device() &&
+                  q.device() == positions.device() &&
+                  q.device() == cos_sin_cache.device(),
+              "all tensors must be on the same device");
+  TORCH_CHECK(q.dim() == 3 && q.size(2) == kHeadDim, "q shape [N, H, 512]");
+  TORCH_CHECK(kv.dim() == 2 && kv.size(1) == kHeadDim,
+              "kv shape [N, 512]");
+  TORCH_CHECK(kv.size(0) == q.size(0), "q and kv row counts must match");
+  TORCH_CHECK(positions.dim() == 1 && positions.numel() == q.size(0),
+              "positions must be [N]");
+  TORCH_CHECK(slot_mapping.dim() == 1, "slot_mapping must be 1D");
+  TORCH_CHECK(slot_mapping.numel() <= q.size(0),
+              "slot_mapping must not exceed q row count");
+  TORCH_CHECK(cos_sin_cache.dim() == 2 && cos_sin_cache.size(1) == kRopeDim,
+              "cos_sin_cache shape [max_pos, 64]");
+  TORCH_CHECK(kv_cache.dim() >= 3,
+              "kv_cache must be [blocks, block_size, ...bytes...]");
+  TORCH_CHECK(kv_cache.size(1) == cache_block_size,
+              "cache_block_size must match kv_cache.size(1)");
+  TORCH_CHECK(kv_cache.stride(-1) == 1,
+              "kv_cache byte dimension must be contiguous");
+  const int64_t logical_block_bytes =
+      cache_block_size * (kTokenDataBytes + kTokenScaleBytes);
+  TORCH_CHECK(kv_cache.stride(0) >= logical_block_bytes,
+              "kv_cache block stride is too small");
+  if (q.size(0) == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(q));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  const dim3 q_grid(static_cast<unsigned int>(q.size(0)),
+                    static_cast<unsigned int>(q.size(1)));
+  const dim3 q_block(kQNormThreads);
+  deepseek_v4_qnorm_rope_kernel<<<q_grid, q_block, 0, stream>>>(
+      static_cast<__mt_bfloat16*>(q.data_ptr()), positions.data_ptr(),
+      index_kind(positions), static_cast<const float*>(cos_sin_cache.data_ptr()),
+      static_cast<float>(eps), q.size(0), q.size(1));
+  auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess, "deepseek_v4_qnorm_rope launch failed: ",
+              musaGetErrorString(err));
+
+  if (slot_mapping.numel() == 0) {
+    return;
+  }
+  const dim3 kv_grid(static_cast<unsigned int>(slot_mapping.numel()));
+  const dim3 kv_block(128);
+  deepseek_v4_kv_rope_pack_kernel<<<kv_grid, kv_block, 0, stream>>>(
+      static_cast<const __mt_bfloat16*>(kv.data_ptr()),
+      static_cast<uint8_t*>(kv_cache.data_ptr()), slot_mapping.data_ptr(),
+      index_kind(slot_mapping), positions.data_ptr(), index_kind(positions),
+      static_cast<const float*>(cos_sin_cache.data_ptr()), slot_mapping.numel(),
+      kv_cache.size(0), cache_block_size, kv_cache.stride(0));
+  err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess, "deepseek_v4_kv_rope_pack launch failed: ",
+              musaGetErrorString(err));
+}
+
+void deepseek_v4_store_sparse_kv(
+    const torch::Tensor& normed,
+    torch::Tensor& kv_cache,
+    const torch::Tensor& slot_mapping,
+    const torch::Tensor& write_mask) {
+  TORCH_CHECK(normed.scalar_type() == torch::kBFloat16,
+              "normed must be bfloat16");
+  TORCH_CHECK(kv_cache.scalar_type() == torch::kUInt8,
+              "kv_cache must be uint8");
+  TORCH_CHECK(write_mask.scalar_type() == torch::kBool,
+              "write_mask must be bool");
+  TORCH_CHECK(normed.is_contiguous(), "normed must be contiguous");
+  TORCH_CHECK(slot_mapping.is_contiguous(), "slot_mapping must be contiguous");
+  TORCH_CHECK(write_mask.is_contiguous(), "write_mask must be contiguous");
+  TORCH_CHECK(normed.device() == kv_cache.device() &&
+                  normed.device() == slot_mapping.device() &&
+                  normed.device() == write_mask.device(),
+              "all tensors must be on the same device");
+  TORCH_CHECK(normed.dim() == 2 && normed.size(1) == kHeadDim,
+              "normed must be [num_tokens, 512]");
+  TORCH_CHECK(kv_cache.dim() >= 2, "kv_cache must include block dimension");
+  TORCH_CHECK(kv_cache.size(0) > 0 && kv_cache.size(1) > 0,
+              "kv_cache must have non-empty blocks");
+  TORCH_CHECK(slot_mapping.numel() == normed.size(0),
+              "slot_mapping must have one entry per normed row");
+  TORCH_CHECK(write_mask.numel() == normed.size(0),
+              "write_mask must have one entry per normed row");
+  TORCH_CHECK(kv_cache.stride(-1) == 1,
+              "kv_cache byte dimension must be contiguous");
+  const int64_t logical_block_bytes =
+      kv_cache.size(1) * (kTokenDataBytes + kTokenScaleBytes);
+  TORCH_CHECK(kv_cache.stride(0) >= logical_block_bytes,
+              "kv_cache block stride is too small");
+
+  if (normed.size(0) == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(normed));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  const dim3 grid(static_cast<unsigned int>(normed.size(0)));
+  const dim3 block(128);
+  deepseek_v4_store_sparse_kv_kernel<<<grid, block, 0, stream>>>(
+      static_cast<const __mt_bfloat16*>(normed.data_ptr()),
+      static_cast<uint8_t*>(kv_cache.data_ptr()), slot_mapping.data_ptr(),
+      static_cast<const bool*>(write_mask.data_ptr()), index_kind(slot_mapping),
+      normed.size(0), kv_cache.size(0), kv_cache.size(1), kv_cache.stride(0));
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess, "deepseek_v4_store_sparse_kv launch failed: ",
+              musaGetErrorString(err));
+}

--- a/csrc/musa/attention/deepseek_v4_cache_utils.mu
+++ b/csrc/musa/attention/deepseek_v4_cache_utils.mu
@@ -1,0 +1,462 @@
+#include <algorithm>
+#include <cstdint>
+#include <tuple>
+
+#include <musa_bf16.h>
+#include <musa_fp8.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+namespace {
+
+constexpr int64_t kNopeDim = 448;
+constexpr int64_t kRopeDim = 64;
+constexpr int64_t kHeadDim = kNopeDim + kRopeDim;
+constexpr int64_t kTokenDataBytes = kNopeDim + kRopeDim * 2;
+constexpr int64_t kTokenScaleBytes = 8;
+constexpr int64_t kQuantBlockSize = 64;
+constexpr int64_t kSparsePrefillTopKAlignment = 128;
+
+constexpr int kIndexInt32 = 1;
+constexpr int kIndexInt64 = 2;
+
+__device__ __forceinline__ int64_t load_index(const void *ptr, int kind,
+                                              int64_t idx) {
+  if (kind == kIndexInt32) {
+    return static_cast<int64_t>(static_cast<const int32_t *>(ptr)[idx]);
+  }
+  return static_cast<int64_t>(static_cast<const int64_t *>(ptr)[idx]);
+}
+
+template <typename T>
+__device__ __forceinline__ int64_t load_typed_index(const T *ptr, int64_t idx) {
+  return static_cast<int64_t>(ptr[idx]);
+}
+
+__device__ __forceinline__ float dequant_fp8_e4m3(uint8_t byte,
+                                                  uint8_t encoded_scale) {
+  __mt_fp8_e4m3 packed;
+  packed.__x = byte;
+  return static_cast<float>(packed) *
+         exp2f(static_cast<float>(encoded_scale) - 127.0f);
+}
+
+int index_kind(const torch::Tensor &tensor, const char *name) {
+  if (tensor.scalar_type() == torch::kInt32) {
+    return kIndexInt32;
+  }
+  if (tensor.scalar_type() == torch::kInt64) {
+    return kIndexInt64;
+  }
+  TORCH_CHECK(false, name, " must be int32 or int64");
+}
+
+int64_t padded_topk(int64_t topk, int64_t window_size) {
+  const int64_t raw = topk + window_size;
+  return ((raw + kSparsePrefillTopKAlignment - 1) /
+          kSparsePrefillTopKAlignment) *
+         kSparsePrefillTopKAlignment;
+}
+
+void check_musa_tensor(const torch::Tensor &tensor, const char *name) {
+  TORCH_CHECK(tensor.device().is_privateuseone(), name,
+              " must be a MUSA tensor");
+}
+
+void check_same_device(const torch::Tensor &a, const torch::Tensor &b,
+                       const char *b_name) {
+  TORCH_CHECK(a.device() == b.device(), b_name, " must be on the same device");
+}
+
+__global__ void deepseek_v4_dequantize_and_gather_k_cache_kernel(
+    __mt_bfloat16 *__restrict__ out, int64_t out_stride0, int64_t out_stride1,
+    const uint8_t *__restrict__ k_cache, const void *__restrict__ seq_lens,
+    int seq_lens_kind, const void *__restrict__ gather_lens,
+    int gather_lens_kind, const void *__restrict__ block_table,
+    int block_table_kind, int64_t block_table_stride, int64_t num_reqs,
+    int64_t num_blocks, int64_t block_size, int64_t block_stride,
+    int64_t offset) {
+  const int64_t req_idx = static_cast<int64_t>(blockIdx.x);
+  if (req_idx >= num_reqs) {
+    return;
+  }
+
+  const int64_t seq_len = load_index(seq_lens, seq_lens_kind, req_idx);
+  const int64_t gather_len =
+      gather_lens == nullptr
+          ? seq_len
+          : load_index(gather_lens, gather_lens_kind, req_idx);
+  const int64_t start_pos = seq_len - gather_len;
+
+  for (int64_t i = threadIdx.x; i < gather_len; i += blockDim.x) {
+    const int64_t pos = start_pos + i;
+    const int64_t block_in_seq = pos / block_size;
+    const int64_t pos_in_block = pos - block_in_seq * block_size;
+    const int64_t physical_block_idx =
+        load_index(block_table, block_table_kind,
+                   req_idx * block_table_stride + block_in_seq);
+    if (physical_block_idx < 0 || physical_block_idx >= num_blocks) {
+      continue;
+    }
+
+    const uint8_t *block_ptr = k_cache + physical_block_idx * block_stride;
+    const uint8_t *token_ptr = block_ptr + pos_in_block * kTokenDataBytes;
+    const uint8_t *scale_ptr = block_ptr + block_size * kTokenDataBytes +
+                               pos_in_block * kTokenScaleBytes;
+    __mt_bfloat16 *output =
+        out + req_idx * out_stride0 + (offset + i) * out_stride1;
+
+    for (int64_t qblock = 0; qblock < kNopeDim / kQuantBlockSize; ++qblock) {
+      const int64_t start = qblock * kQuantBlockSize;
+      const uint8_t scale = scale_ptr[qblock];
+      for (int64_t j = 0; j < kQuantBlockSize; ++j) {
+        output[start + j] =
+            __float2bfloat16(dequant_fp8_e4m3(token_ptr[start + j], scale));
+      }
+    }
+
+    const __mt_bfloat16 *rope =
+        reinterpret_cast<const __mt_bfloat16 *>(token_ptr + kNopeDim);
+    for (int64_t j = 0; j < kRopeDim; ++j) {
+      output[kNopeDim + j] = rope[j];
+    }
+  }
+}
+
+template <typename TopKType, typename ReqType, typename BlockType>
+__global__ void deepseek_v4_compute_global_topk_indices_and_lens_kernel(
+    TopKType *__restrict__ global_topk_indices, int32_t *__restrict__ topk_lens,
+    const TopKType *__restrict__ topk_indices,
+    const ReqType *__restrict__ token_to_req_indices,
+    const BlockType *__restrict__ block_table,
+    const bool *__restrict__ is_valid_token, int64_t topk_stride,
+    int64_t block_table_stride, int64_t num_tokens, int64_t topk,
+    int64_t block_size) {
+  const int64_t token_idx = static_cast<int64_t>(blockIdx.x);
+  if (token_idx >= num_tokens) {
+    return;
+  }
+
+  __shared__ int counts[256];
+  int count = 0;
+  const int64_t req_idx = load_typed_index(token_to_req_indices, token_idx);
+
+  for (int64_t i = threadIdx.x; i < topk; i += blockDim.x) {
+    const int64_t local_idx =
+        load_typed_index(topk_indices, token_idx * topk_stride + i);
+    int64_t slot_id = -1;
+    if (local_idx >= 0) {
+      const int64_t block_idx = local_idx / block_size;
+      const int64_t block_offset = local_idx - block_idx * block_size;
+      const int64_t block_number = load_typed_index(
+          block_table, req_idx * block_table_stride + block_idx);
+      slot_id = block_number * block_size + block_offset;
+      count += 1;
+    }
+    global_topk_indices[token_idx * topk_stride + i] =
+        static_cast<TopKType>(slot_id);
+  }
+
+  counts[threadIdx.x] = count;
+  __syncthreads();
+  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride) {
+      counts[threadIdx.x] += counts[threadIdx.x + stride];
+    }
+    __syncthreads();
+  }
+  if (threadIdx.x == 0) {
+    topk_lens[token_idx] = is_valid_token[token_idx] ? counts[0] : 0;
+  }
+}
+
+template <typename TopKType>
+__global__ void deepseek_v4_combine_topk_swa_indices_kernel(
+    int32_t *__restrict__ combined_indices, int32_t *__restrict__ combined_lens,
+    const TopKType *__restrict__ topk_indices,
+    const void *__restrict__ query_start_loc, int query_start_loc_kind,
+    const void *__restrict__ seq_lens, int seq_lens_kind,
+    const void *__restrict__ gather_lens, int gather_lens_kind,
+    int64_t combined_stride, int64_t topk_stride, int64_t num_reqs,
+    int64_t combined_topk, int64_t window_size, int64_t compress_ratio,
+    int64_t topk, int64_t m, int64_t n) {
+  const int64_t batch_idx = static_cast<int64_t>(blockIdx.x);
+  if (batch_idx >= num_reqs) {
+    return;
+  }
+
+  const int64_t base = load_index(query_start_loc, query_start_loc_kind, 0);
+  const int64_t query_start =
+      load_index(query_start_loc, query_start_loc_kind, batch_idx) - base;
+  const int64_t query_end =
+      load_index(query_start_loc, query_start_loc_kind, batch_idx + 1) - base;
+  const int64_t query_len = query_end - query_start;
+  const int64_t seq_len = load_index(seq_lens, seq_lens_kind, batch_idx);
+  const int64_t gather_len =
+      load_index(gather_lens, gather_lens_kind, batch_idx);
+  const int64_t start_pos = seq_len - query_len;
+  const int64_t gather_start = seq_len - gather_len;
+  const int64_t req_offset = m * batch_idx;
+
+  for (int64_t token_idx = query_start + threadIdx.x; token_idx < query_end;
+       token_idx += blockDim.x) {
+    int32_t *combined_row = combined_indices + token_idx * combined_stride;
+    for (int64_t i = 0; i < combined_topk; ++i) {
+      combined_row[i] = -1;
+    }
+
+    const int64_t token_idx_in_query = token_idx - query_start;
+    const int64_t pos = start_pos + token_idx_in_query;
+    const int64_t raw_topk_len = (pos + 1) / compress_ratio;
+    const int64_t topk_len = raw_topk_len < topk ? raw_topk_len : topk;
+    const int64_t swa_len = (pos + 1) < window_size ? (pos + 1) : window_size;
+
+    for (int64_t i = 0; i < topk_len; ++i) {
+      combined_row[i] = static_cast<int32_t>(
+          load_typed_index(topk_indices, token_idx * topk_stride + i) +
+          req_offset);
+    }
+    for (int64_t i = 0; i < swa_len; ++i) {
+      combined_row[topk_len + i] = static_cast<int32_t>(
+          req_offset + n + i + pos - swa_len + 1 - gather_start);
+    }
+    combined_lens[token_idx] = static_cast<int32_t>(topk_len + swa_len);
+  }
+}
+
+template <typename TopKType, typename ReqType, typename BlockType>
+std::tuple<torch::Tensor, torch::Tensor>
+launch_compute_global_topk_indices_and_lens(
+    const torch::Tensor &topk_indices,
+    const torch::Tensor &token_to_req_indices, const torch::Tensor &block_table,
+    int64_t block_size, const torch::Tensor &is_valid_token,
+    musaStream_t stream) {
+  auto global_topk_indices = torch::empty_like(topk_indices);
+  auto topk_lens = torch::empty({topk_indices.size(0)},
+                                topk_indices.options().dtype(torch::kInt32));
+  if (topk_indices.size(0) == 0) {
+    return std::make_tuple(global_topk_indices, topk_lens);
+  }
+
+  constexpr int kThreads = 256;
+  deepseek_v4_compute_global_topk_indices_and_lens_kernel<<<
+      static_cast<unsigned int>(topk_indices.size(0)), kThreads, 0, stream>>>(
+      static_cast<TopKType *>(global_topk_indices.data_ptr()),
+      static_cast<int32_t *>(topk_lens.data_ptr()),
+      static_cast<const TopKType *>(topk_indices.data_ptr()),
+      static_cast<const ReqType *>(token_to_req_indices.data_ptr()),
+      static_cast<const BlockType *>(block_table.data_ptr()),
+      static_cast<const bool *>(is_valid_token.data_ptr()),
+      topk_indices.stride(0), block_table.stride(0), topk_indices.size(0),
+      topk_indices.size(1), block_size);
+  return std::make_tuple(global_topk_indices, topk_lens);
+}
+
+template <typename TopKType>
+std::tuple<torch::Tensor, torch::Tensor> launch_combine_topk_swa_indices(
+    const torch::Tensor &topk_indices, const torch::Tensor &query_start_loc,
+    const torch::Tensor &seq_lens, const torch::Tensor &gather_lens,
+    int64_t window_size, int64_t compress_ratio, int64_t topk, int64_t m,
+    int64_t n, musaStream_t stream) {
+  const int64_t combined_topk = padded_topk(topk, window_size);
+  auto combined_indices =
+      torch::empty({topk_indices.size(0), combined_topk},
+                   topk_indices.options().dtype(torch::kInt32));
+  auto combined_lens = torch::empty(
+      {topk_indices.size(0)}, topk_indices.options().dtype(torch::kInt32));
+  if (topk_indices.size(0) == 0) {
+    return std::make_tuple(combined_indices, combined_lens);
+  }
+
+  constexpr int kThreads = 256;
+  deepseek_v4_combine_topk_swa_indices_kernel<<<
+      static_cast<unsigned int>(seq_lens.size(0)), kThreads, 0, stream>>>(
+      static_cast<int32_t *>(combined_indices.data_ptr()),
+      static_cast<int32_t *>(combined_lens.data_ptr()),
+      static_cast<const TopKType *>(topk_indices.data_ptr()),
+      query_start_loc.data_ptr(),
+      index_kind(query_start_loc, "query_start_loc"), seq_lens.data_ptr(),
+      index_kind(seq_lens, "seq_lens"), gather_lens.data_ptr(),
+      index_kind(gather_lens, "gather_lens"), combined_indices.stride(0),
+      topk_indices.stride(0), seq_lens.size(0), combined_topk, window_size,
+      compress_ratio, topk, m, n);
+  return std::make_tuple(combined_indices, combined_lens);
+}
+
+} // namespace
+
+void deepseek_v4_dequantize_and_gather_k_cache(
+    torch::Tensor &out, const torch::Tensor &k_cache,
+    const torch::Tensor &seq_lens,
+    const c10::optional<torch::Tensor> &gather_lens,
+    const torch::Tensor &block_table, int64_t block_size, int64_t offset) {
+  check_musa_tensor(out, "out");
+  check_same_device(out, k_cache, "k_cache");
+  check_same_device(out, seq_lens, "seq_lens");
+  check_same_device(out, block_table, "block_table");
+  if (gather_lens.has_value()) {
+    check_same_device(out, *gather_lens, "gather_lens");
+  }
+  TORCH_CHECK(out.scalar_type() == torch::kBFloat16, "out must be bfloat16");
+  TORCH_CHECK(k_cache.scalar_type() == torch::kUInt8, "k_cache must be uint8");
+  TORCH_CHECK(out.dim() == 3 && out.size(2) == kHeadDim,
+              "out must be [num_reqs, max_tokens, 512]");
+  TORCH_CHECK(k_cache.dim() >= 2, "k_cache must include block dimension");
+  TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must be 1-D");
+  TORCH_CHECK(block_table.dim() == 2, "block_table must be 2-D");
+  TORCH_CHECK(block_table.size(0) == seq_lens.size(0),
+              "block_table and seq_lens batch mismatch");
+  TORCH_CHECK(out.size(0) == seq_lens.size(0),
+              "out and seq_lens batch mismatch");
+  TORCH_CHECK(k_cache.stride(-1) == 1,
+              "k_cache byte dimension must be contiguous");
+  TORCH_CHECK(block_size > 0, "block_size must be positive");
+  TORCH_CHECK(k_cache.stride(0) >=
+                  block_size * kTokenDataBytes + block_size * kTokenScaleBytes,
+              "k_cache block stride is too small");
+  if (gather_lens.has_value()) {
+    TORCH_CHECK(gather_lens->dim() == 1, "gather_lens must be 1-D");
+    TORCH_CHECK(gather_lens->size(0) == seq_lens.size(0),
+                "gather_lens and seq_lens batch mismatch");
+  }
+
+  if (seq_lens.size(0) == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(out));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  constexpr int kWorkers = 128;
+  deepseek_v4_dequantize_and_gather_k_cache_kernel<<<
+      static_cast<unsigned int>(seq_lens.size(0)), kWorkers, 0, stream>>>(
+      static_cast<__mt_bfloat16 *>(out.data_ptr()), out.stride(0),
+      out.stride(1), static_cast<const uint8_t *>(k_cache.data_ptr()),
+      seq_lens.data_ptr(), index_kind(seq_lens, "seq_lens"),
+      gather_lens.has_value() ? gather_lens->data_ptr() : nullptr,
+      gather_lens.has_value() ? index_kind(*gather_lens, "gather_lens") : 0,
+      block_table.data_ptr(), index_kind(block_table, "block_table"),
+      block_table.stride(0), seq_lens.size(0), k_cache.size(0), block_size,
+      k_cache.stride(0), offset);
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "deepseek_v4_dequantize_and_gather_k_cache launch failed: ",
+              musaGetErrorString(err));
+}
+
+std::tuple<torch::Tensor, torch::Tensor>
+deepseek_v4_compute_global_topk_indices_and_lens(
+    const torch::Tensor &topk_indices,
+    const torch::Tensor &token_to_req_indices, const torch::Tensor &block_table,
+    int64_t block_size, const torch::Tensor &is_valid_token) {
+  check_musa_tensor(topk_indices, "topk_indices");
+  check_same_device(topk_indices, token_to_req_indices, "token_to_req_indices");
+  check_same_device(topk_indices, block_table, "block_table");
+  check_same_device(topk_indices, is_valid_token, "is_valid_token");
+  TORCH_CHECK(topk_indices.dim() == 2, "topk_indices must be 2-D");
+  TORCH_CHECK(token_to_req_indices.dim() == 1,
+              "token_to_req_indices must be 1-D");
+  TORCH_CHECK(block_table.dim() == 2, "block_table must be 2-D");
+  TORCH_CHECK(is_valid_token.dim() == 1, "is_valid_token must be 1-D");
+  TORCH_CHECK(token_to_req_indices.size(0) >= topk_indices.size(0),
+              "token_to_req_indices is shorter than topk_indices rows");
+  TORCH_CHECK(is_valid_token.size(0) >= topk_indices.size(0),
+              "is_valid_token is shorter than topk_indices rows");
+  TORCH_CHECK(is_valid_token.scalar_type() == torch::kBool,
+              "is_valid_token must be bool");
+  TORCH_CHECK(block_size > 0, "block_size must be positive");
+  index_kind(token_to_req_indices, "token_to_req_indices");
+  index_kind(block_table, "block_table");
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(topk_indices));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+#define DISPATCH_BLOCK(TOPK_CPP, REQ_CPP, BLOCK_CPP)                           \
+  return launch_compute_global_topk_indices_and_lens<TOPK_CPP, REQ_CPP,        \
+                                                     BLOCK_CPP>(               \
+      topk_indices, token_to_req_indices, block_table, block_size,             \
+      is_valid_token, stream)
+
+  if (topk_indices.scalar_type() == torch::kInt32 &&
+      token_to_req_indices.scalar_type() == torch::kInt32 &&
+      block_table.scalar_type() == torch::kInt32) {
+    DISPATCH_BLOCK(int32_t, int32_t, int32_t);
+  }
+  if (topk_indices.scalar_type() == torch::kInt32 &&
+      token_to_req_indices.scalar_type() == torch::kInt64 &&
+      block_table.scalar_type() == torch::kInt32) {
+    DISPATCH_BLOCK(int32_t, int64_t, int32_t);
+  }
+  if (topk_indices.scalar_type() == torch::kInt64 &&
+      token_to_req_indices.scalar_type() == torch::kInt32 &&
+      block_table.scalar_type() == torch::kInt32) {
+    DISPATCH_BLOCK(int64_t, int32_t, int32_t);
+  }
+  if (topk_indices.scalar_type() == torch::kInt64 &&
+      token_to_req_indices.scalar_type() == torch::kInt64 &&
+      block_table.scalar_type() == torch::kInt32) {
+    DISPATCH_BLOCK(int64_t, int64_t, int32_t);
+  }
+  if (topk_indices.scalar_type() == torch::kInt32 &&
+      token_to_req_indices.scalar_type() == torch::kInt64 &&
+      block_table.scalar_type() == torch::kInt64) {
+    DISPATCH_BLOCK(int32_t, int64_t, int64_t);
+  }
+  if (topk_indices.scalar_type() == torch::kInt64 &&
+      token_to_req_indices.scalar_type() == torch::kInt64 &&
+      block_table.scalar_type() == torch::kInt64) {
+    DISPATCH_BLOCK(int64_t, int64_t, int64_t);
+  }
+
+#undef DISPATCH_BLOCK
+  TORCH_CHECK(false, "unsupported dtype combination for "
+                     "deepseek_v4_compute_global_topk_indices_and_lens");
+}
+
+std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_combine_topk_swa_indices(
+    const torch::Tensor &topk_indices, const torch::Tensor &query_start_loc,
+    const torch::Tensor &seq_lens, const torch::Tensor &gather_lens,
+    int64_t window_size, int64_t compress_ratio, int64_t topk, int64_t m,
+    int64_t n) {
+  check_musa_tensor(topk_indices, "topk_indices");
+  check_same_device(topk_indices, query_start_loc, "query_start_loc");
+  check_same_device(topk_indices, seq_lens, "seq_lens");
+  check_same_device(topk_indices, gather_lens, "gather_lens");
+  TORCH_CHECK(topk_indices.dim() == 2, "topk_indices must be 2-D");
+  TORCH_CHECK(query_start_loc.dim() == 1, "query_start_loc must be 1-D");
+  TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must be 1-D");
+  TORCH_CHECK(gather_lens.dim() == 1, "gather_lens must be 1-D");
+  TORCH_CHECK(query_start_loc.size(0) == seq_lens.size(0) + 1,
+              "query_start_loc must have num_reqs + 1 entries");
+  TORCH_CHECK(gather_lens.size(0) == seq_lens.size(0),
+              "gather_lens and seq_lens batch mismatch");
+  TORCH_CHECK(window_size >= 0, "window_size must be non-negative");
+  TORCH_CHECK(compress_ratio > 0, "compress_ratio must be positive");
+  TORCH_CHECK(topk >= 0, "topk must be non-negative");
+  TORCH_CHECK(m >= 0 && n >= 0, "M and N must be non-negative");
+  TORCH_CHECK(topk <= topk_indices.size(1),
+              "topk exceeds topk_indices row width");
+  index_kind(query_start_loc, "query_start_loc");
+  index_kind(seq_lens, "seq_lens");
+  index_kind(gather_lens, "gather_lens");
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(topk_indices));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+  if (topk_indices.scalar_type() == torch::kInt32) {
+    return launch_combine_topk_swa_indices<int32_t>(
+        topk_indices, query_start_loc, seq_lens, gather_lens, window_size,
+        compress_ratio, topk, m, n, stream);
+  }
+  if (topk_indices.scalar_type() == torch::kInt64) {
+    return launch_combine_topk_swa_indices<int64_t>(
+        topk_indices, query_start_loc, seq_lens, gather_lens, window_size,
+        compress_ratio, topk, m, n, stream);
+  }
+
+  TORCH_CHECK(false, "topk_indices must be int32 or int64 for "
+                     "deepseek_v4_combine_topk_swa_indices");
+}

--- a/csrc/musa/attention/deepseek_v4_fused_qkv_rmsnorm.mu
+++ b/csrc/musa/attention/deepseek_v4_fused_qkv_rmsnorm.mu
@@ -1,0 +1,220 @@
+#include <cstdint>
+#include <limits>
+#include <tuple>
+
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+
+namespace {
+
+constexpr int kBlock = 256;
+
+template <int BLOCK_X>
+__device__ __forceinline__ float block_reduce_sum(float value) {
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_xor_sync(0xffffffff, value, offset);
+  }
+  if constexpr (BLOCK_X <= 32) {
+    return value;
+  }
+
+  __shared__ float shared[BLOCK_X / 32];
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  if (lane == 0) {
+    shared[warp] = value;
+  }
+  __syncthreads();
+
+  value = threadIdx.x < (BLOCK_X / 32) ? shared[threadIdx.x] : 0.0f;
+  if (warp == 0) {
+    for (int offset = (BLOCK_X / 32) >> 1; offset > 0; offset >>= 1) {
+      value += __shfl_xor_sync(0xffffffff, value, offset);
+    }
+    if (threadIdx.x == 0) {
+      shared[0] = value;
+    }
+  }
+  __syncthreads();
+  return shared[0];
+}
+
+__device__ __forceinline__ float load_float(float value) {
+  return value;
+}
+
+__device__ __forceinline__ float load_float(__half value) {
+  return __half2float(value);
+}
+
+__device__ __forceinline__ float load_float(__mt_bfloat16 value) {
+  return __bfloat162float(value);
+}
+
+template <typename T>
+__device__ __forceinline__ T store_float(float value);
+
+template <>
+__device__ __forceinline__ __half store_float<__half>(float value) {
+  return __float2half(value);
+}
+
+template <>
+__device__ __forceinline__ __mt_bfloat16 store_float<__mt_bfloat16>(
+    float value) {
+  return __float2bfloat16(value);
+}
+
+template <typename T, typename W>
+__global__ void deepseek_v4_fused_q_kv_rmsnorm_kernel(
+    const T* __restrict__ q, T* __restrict__ q_out,
+    const W* __restrict__ q_weight, int64_t q_in_stride,
+    int64_t q_out_stride, const T* __restrict__ kv,
+    T* __restrict__ kv_out, const W* __restrict__ kv_weight,
+    int64_t kv_in_stride, int64_t kv_out_stride, float eps,
+    int64_t num_tokens, int64_t q_size, int64_t kv_size) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x);
+  const int task = blockIdx.y;
+  if (token >= num_tokens) {
+    return;
+  }
+
+  const T* row_in;
+  T* row_out;
+  const W* weight;
+  int64_t size;
+  if (task == 0) {
+    row_in = q + token * q_in_stride;
+    row_out = q_out + token * q_out_stride;
+    weight = q_weight;
+    size = q_size;
+  } else {
+    row_in = kv + token * kv_in_stride;
+    row_out = kv_out + token * kv_out_stride;
+    weight = kv_weight;
+    size = kv_size;
+  }
+
+  float partial = 0.0f;
+  for (int64_t dim = threadIdx.x; dim < size; dim += blockDim.x) {
+    const float value = load_float(row_in[dim]);
+    partial += value * value;
+  }
+
+  const float total = block_reduce_sum<kBlock>(partial);
+  const float inv_rms = rsqrtf(total / static_cast<float>(size) + eps);
+
+  for (int64_t dim = threadIdx.x; dim < size; dim += blockDim.x) {
+    const float value =
+        load_float(row_in[dim]) * inv_rms * load_float(weight[dim]);
+    row_out[dim] = store_float<T>(value);
+  }
+}
+
+template <typename T, typename W>
+void launch_deepseek_v4_fused_q_kv_rmsnorm(
+    const torch::Tensor& q, torch::Tensor& q_out,
+    const torch::Tensor& q_weight, const torch::Tensor& kv,
+    torch::Tensor& kv_out, const torch::Tensor& kv_weight, double eps,
+    musaStream_t stream) {
+  const int64_t num_tokens = q.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
+  const dim3 grid(static_cast<unsigned int>(num_tokens), 2);
+  const dim3 block(kBlock);
+  deepseek_v4_fused_q_kv_rmsnorm_kernel<T, W><<<grid, block, 0, stream>>>(
+      static_cast<const T*>(q.data_ptr()), static_cast<T*>(q_out.data_ptr()),
+      static_cast<const W*>(q_weight.data_ptr()),
+      static_cast<int64_t>(q.stride(0)),
+      static_cast<int64_t>(q_out.stride(0)),
+      static_cast<const T*>(kv.data_ptr()), static_cast<T*>(kv_out.data_ptr()),
+      static_cast<const W*>(kv_weight.data_ptr()),
+      static_cast<int64_t>(kv.stride(0)),
+      static_cast<int64_t>(kv_out.stride(0)), static_cast<float>(eps),
+      num_tokens, static_cast<int64_t>(q.size(1)),
+      static_cast<int64_t>(kv.size(1)));
+}
+
+template <typename T>
+void dispatch_weight_dtype(const torch::Tensor& q, torch::Tensor& q_out,
+                           const torch::Tensor& q_weight,
+                           const torch::Tensor& kv, torch::Tensor& kv_out,
+                           const torch::Tensor& kv_weight, double eps,
+                           musaStream_t stream) {
+  if (q_weight.scalar_type() == at::ScalarType::Float) {
+    launch_deepseek_v4_fused_q_kv_rmsnorm<T, float>(
+        q, q_out, q_weight, kv, kv_out, kv_weight, eps, stream);
+  } else if (q_weight.scalar_type() == at::ScalarType::Half) {
+    launch_deepseek_v4_fused_q_kv_rmsnorm<T, __half>(
+        q, q_out, q_weight, kv, kv_out, kv_weight, eps, stream);
+  } else if (q_weight.scalar_type() == at::ScalarType::BFloat16) {
+    launch_deepseek_v4_fused_q_kv_rmsnorm<T, __mt_bfloat16>(
+        q, q_out, q_weight, kv, kv_out, kv_weight, eps, stream);
+  } else {
+    TORCH_CHECK(false, "q_weight/kv_weight must be float, fp16, or bf16");
+  }
+}
+
+void check_inputs(const torch::Tensor& q, const torch::Tensor& kv,
+                  const torch::Tensor& q_weight,
+                  const torch::Tensor& kv_weight) {
+  TORCH_CHECK(q.device().is_privateuseone(), "q must be a MUSA tensor");
+  TORCH_CHECK(kv.device().is_privateuseone(), "kv must be a MUSA tensor");
+  TORCH_CHECK(q_weight.device().is_privateuseone(),
+              "q_weight must be a MUSA tensor");
+  TORCH_CHECK(kv_weight.device().is_privateuseone(),
+              "kv_weight must be a MUSA tensor");
+  TORCH_CHECK(q.dim() == 2, "q must be 2-D");
+  TORCH_CHECK(kv.dim() == 2, "kv must be 2-D");
+  TORCH_CHECK(q.size(0) == kv.size(0), "q/kv token dimension mismatch");
+  TORCH_CHECK(q.stride(1) == 1, "q last dimension must be contiguous");
+  TORCH_CHECK(kv.stride(1) == 1, "kv last dimension must be contiguous");
+  TORCH_CHECK(q_weight.dim() == 1, "q_weight must be 1-D");
+  TORCH_CHECK(kv_weight.dim() == 1, "kv_weight must be 1-D");
+  TORCH_CHECK(q_weight.is_contiguous(), "q_weight must be contiguous");
+  TORCH_CHECK(kv_weight.is_contiguous(), "kv_weight must be contiguous");
+  TORCH_CHECK(q_weight.size(0) == q.size(1), "q_weight size mismatch");
+  TORCH_CHECK(kv_weight.size(0) == kv.size(1), "kv_weight size mismatch");
+  TORCH_CHECK(q.scalar_type() == kv.scalar_type(), "q/kv dtype mismatch");
+  TORCH_CHECK(q_weight.scalar_type() == kv_weight.scalar_type(),
+              "q_weight/kv_weight dtype mismatch");
+  TORCH_CHECK(q.scalar_type() == at::ScalarType::Half ||
+                  q.scalar_type() == at::ScalarType::BFloat16,
+              "q/kv must be fp16 or bf16");
+  TORCH_CHECK(q.size(0) <= std::numeric_limits<int>::max(),
+              "num_tokens exceeds launch grid limit");
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_q_kv_rmsnorm(
+    const torch::Tensor& q, const torch::Tensor& kv,
+    const torch::Tensor& q_weight, const torch::Tensor& kv_weight,
+    double eps) {
+  check_inputs(q, kv, q_weight, kv_weight);
+
+  auto q_out = torch::empty_like(q);
+  auto kv_out = torch::empty_like(kv);
+  const c10::musa::OptionalMUSAGuard guard(device_of(q));
+  musaStream_t stream = c10::musa::getCurrentMUSAStream().stream();
+
+  if (q.scalar_type() == at::ScalarType::Half) {
+    dispatch_weight_dtype<__half>(
+        q, q_out, q_weight, kv, kv_out, kv_weight, eps, stream);
+  } else {
+    dispatch_weight_dtype<__mt_bfloat16>(
+        q, q_out, q_weight, kv, kv_out, kv_weight, eps, stream);
+  }
+
+  const musaError_t err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "deepseek_v4_fused_q_kv_rmsnorm launch failed: ",
+              musaGetErrorString(err));
+  return {q_out, kv_out};
+}

--- a/csrc/musa/attention/deepseek_v4_indexer_topk.mu
+++ b/csrc/musa/attention/deepseek_v4_indexer_topk.mu
@@ -1,0 +1,513 @@
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include <musa_fp8.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+namespace {
+
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kNumHeads = 64;
+constexpr int64_t kScaleBytes = 4;
+constexpr int64_t kMaxSeqLen = 4096;
+constexpr int64_t kMaxTopK = 512;
+constexpr int kThreads = 256;
+constexpr int kIndexInt32 = 1;
+constexpr int kIndexInt64 = 2;
+
+__device__ __forceinline__ float dequant_fp8_e4m3(uint8_t byte) {
+  __mt_fp8_e4m3 packed;
+  packed.__x = byte;
+  return static_cast<float>(packed);
+}
+
+__device__ __forceinline__ int64_t load_index(const void *ptr, int kind,
+                                              int64_t idx) {
+  if (kind == kIndexInt32) {
+    return static_cast<int64_t>(static_cast<const int32_t *>(ptr)[idx]);
+  }
+  return static_cast<int64_t>(static_cast<const int64_t *>(ptr)[idx]);
+}
+
+int index_kind(const torch::Tensor &tensor, const char *name) {
+  if (tensor.scalar_type() == torch::kInt32) {
+    return kIndexInt32;
+  }
+  if (tensor.scalar_type() == torch::kInt64) {
+    return kIndexInt64;
+  }
+  TORCH_CHECK(false, name, " must be int32 or int64");
+}
+
+void check_musa_tensor(const torch::Tensor &tensor, const char *name) {
+  TORCH_CHECK(tensor.device().is_privateuseone(), name,
+              " must be a MUSA tensor");
+}
+
+void check_same_device(const torch::Tensor &a, const torch::Tensor &b,
+                       const char *b_name) {
+  TORCH_CHECK(a.device() == b.device(), b_name, " must be on the same device");
+}
+
+__device__ __forceinline__ bool better_pair(float lhs_value, int lhs_index,
+                                            float rhs_value, int rhs_index) {
+  return lhs_value > rhs_value ||
+         (lhs_value == rhs_value &&
+          (rhs_index < 0 || (lhs_index >= 0 && lhs_index < rhs_index)));
+}
+
+template <typename OutT>
+__global__ void deepseek_v4_indexer_topk_decode_kernel(
+    const uint8_t *__restrict__ q_quant, int64_t q_stride0, int64_t q_stride1,
+    int64_t q_stride2, const uint8_t *__restrict__ kv_cache,
+    int64_t num_blocks, int64_t block_size, int64_t block_stride,
+    const float *__restrict__ weights, int64_t weights_stride0,
+    int64_t weights_stride1, const void *__restrict__ seq_lens,
+    int seq_lens_kind, int64_t seq_lens_stride,
+    const void *__restrict__ block_table, int block_table_kind,
+    int64_t block_table_stride, OutT *__restrict__ topk_indices,
+    int64_t topk_stride0, int64_t topk_stride1, int64_t rows, int64_t topk) {
+  const int64_t row = static_cast<int64_t>(blockIdx.x);
+  if (row >= rows) {
+    return;
+  }
+
+  __shared__ float scores[kMaxSeqLen];
+  __shared__ float reduce_values[kThreads];
+  __shared__ int reduce_indices[kThreads];
+
+  const int tid = threadIdx.x;
+  const int64_t raw_seq_len =
+      load_index(seq_lens, seq_lens_kind, row * seq_lens_stride);
+  const int64_t seq_len =
+      raw_seq_len < kMaxSeqLen ? (raw_seq_len > 0 ? raw_seq_len : 0)
+                               : kMaxSeqLen;
+
+  for (int64_t pos = tid; pos < kMaxSeqLen; pos += blockDim.x) {
+    float score = -INFINITY;
+    if (pos < seq_len) {
+      const int64_t logical_block = pos / block_size;
+      const int64_t pos_in_block = pos - logical_block * block_size;
+      const int64_t physical_block = load_index(
+          block_table, block_table_kind, row * block_table_stride + logical_block);
+
+      if (physical_block >= 0 && physical_block < num_blocks &&
+          pos_in_block >= 0 && pos_in_block < block_size) {
+        const uint8_t *block_ptr = kv_cache + physical_block * block_stride;
+        const uint8_t *k_ptr = block_ptr + pos_in_block * kHeadDim;
+        const uint8_t *scale_ptr =
+            block_ptr + block_size * kHeadDim + pos_in_block * kScaleBytes;
+        const float k_scale = *reinterpret_cast<const float *>(scale_ptr);
+
+        float accum = 0.0f;
+        for (int64_t head = 0; head < kNumHeads; ++head) {
+          const uint8_t *q_ptr =
+              q_quant + row * q_stride0 + head * q_stride1;
+          float dot = 0.0f;
+#pragma unroll 4
+          for (int64_t dim = 0; dim < kHeadDim; ++dim) {
+            dot += dequant_fp8_e4m3(q_ptr[dim * q_stride2]) *
+                   dequant_fp8_e4m3(k_ptr[dim]);
+          }
+          accum += fmaxf(dot, 0.0f) *
+                   weights[row * weights_stride0 + head * weights_stride1];
+        }
+        score = accum * k_scale;
+      }
+    }
+    scores[pos] = score;
+  }
+  __syncthreads();
+
+  const int64_t effective_topk =
+      topk < seq_len ? (topk < kMaxTopK ? topk : kMaxTopK)
+                     : (seq_len < kMaxTopK ? seq_len : kMaxTopK);
+
+  for (int64_t rank = 0; rank < effective_topk; ++rank) {
+    float local_value = -INFINITY;
+    int local_index = -1;
+    for (int64_t pos = tid; pos < seq_len; pos += blockDim.x) {
+      const float value = scores[pos];
+      if (better_pair(value, static_cast<int>(pos), local_value, local_index)) {
+        local_value = value;
+        local_index = static_cast<int>(pos);
+      }
+    }
+    reduce_values[tid] = local_value;
+    reduce_indices[tid] = local_index;
+    __syncthreads();
+
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+      if (tid < stride) {
+        const float other_value = reduce_values[tid + stride];
+        const int other_index = reduce_indices[tid + stride];
+        if (better_pair(other_value, other_index, reduce_values[tid],
+                        reduce_indices[tid])) {
+          reduce_values[tid] = other_value;
+          reduce_indices[tid] = other_index;
+        }
+      }
+      __syncthreads();
+    }
+
+    if (tid == 0) {
+      const int selected = reduce_indices[0];
+      topk_indices[row * topk_stride0 + rank * topk_stride1] =
+          static_cast<OutT>(selected);
+      if (selected >= 0) {
+        scores[selected] = -INFINITY;
+      }
+    }
+    __syncthreads();
+  }
+
+  for (int64_t rank = effective_topk + tid; rank < topk; rank += blockDim.x) {
+    topk_indices[row * topk_stride0 + rank * topk_stride1] =
+        static_cast<OutT>(-1);
+  }
+}
+
+template <typename OutT>
+__global__ void deepseek_v4_indexer_topk_prefill_kernel(
+    const uint8_t *__restrict__ q_quant, int64_t q_stride0, int64_t q_stride1,
+    int64_t q_stride2, const uint8_t *__restrict__ kv_cache,
+    int64_t num_blocks, int64_t block_size, int64_t block_stride,
+    const float *__restrict__ weights, int64_t weights_stride0,
+    int64_t weights_stride1, const void *__restrict__ block_table,
+    int block_table_kind, int64_t block_table_stride,
+    const void *__restrict__ cu_seq_lens, int cu_seq_lens_kind,
+    int64_t cu_seq_lens_stride, const void *__restrict__ token_to_seq,
+    int token_to_seq_kind, int64_t token_to_seq_stride,
+    const void *__restrict__ cu_seqlen_ks, int cu_seqlen_ks_kind,
+    int64_t cu_seqlen_ks_stride, const void *__restrict__ cu_seqlen_ke,
+    int cu_seqlen_ke_kind, int64_t cu_seqlen_ke_stride,
+    OutT *__restrict__ topk_indices, int64_t topk_stride0,
+    int64_t topk_stride1, int64_t rows, int64_t total_seq_lens,
+    int64_t topk) {
+  const int64_t row = static_cast<int64_t>(blockIdx.x);
+  if (row >= rows) {
+    return;
+  }
+
+  __shared__ float scores[kMaxSeqLen];
+  __shared__ float reduce_values[kThreads];
+  __shared__ int reduce_indices[kThreads];
+
+  const int tid = threadIdx.x;
+  const int64_t row_start =
+      load_index(cu_seqlen_ks, cu_seqlen_ks_kind, row * cu_seqlen_ks_stride);
+  const int64_t row_end =
+      load_index(cu_seqlen_ke, cu_seqlen_ke_kind, row * cu_seqlen_ke_stride);
+  const int64_t raw_row_len = row_end - row_start;
+  const int64_t row_len =
+      raw_row_len < kMaxSeqLen ? (raw_row_len > 0 ? raw_row_len : 0)
+                               : kMaxSeqLen;
+
+  for (int64_t rel_pos = tid; rel_pos < kMaxSeqLen; rel_pos += blockDim.x) {
+    float score = -INFINITY;
+    if (rel_pos < row_len) {
+      const int64_t abs_pos = row_start + rel_pos;
+      if (abs_pos >= 0 && abs_pos < total_seq_lens) {
+        const int64_t req_idx = load_index(
+            token_to_seq, token_to_seq_kind, abs_pos * token_to_seq_stride);
+        const int64_t req_start = load_index(
+            cu_seq_lens, cu_seq_lens_kind, req_idx * cu_seq_lens_stride);
+        const int64_t local_pos = abs_pos - req_start;
+        const int64_t logical_block = local_pos / block_size;
+        const int64_t pos_in_block = local_pos - logical_block * block_size;
+        const int64_t physical_block =
+            load_index(block_table, block_table_kind,
+                       req_idx * block_table_stride + logical_block);
+
+        if (physical_block >= 0 && physical_block < num_blocks &&
+            pos_in_block >= 0 && pos_in_block < block_size) {
+          const uint8_t *block_ptr = kv_cache + physical_block * block_stride;
+          const uint8_t *k_ptr = block_ptr + pos_in_block * kHeadDim;
+          const uint8_t *scale_ptr =
+              block_ptr + block_size * kHeadDim + pos_in_block * kScaleBytes;
+          const float k_scale = *reinterpret_cast<const float *>(scale_ptr);
+
+          float accum = 0.0f;
+          for (int64_t head = 0; head < kNumHeads; ++head) {
+            const uint8_t *q_ptr =
+                q_quant + row * q_stride0 + head * q_stride1;
+            float dot = 0.0f;
+#pragma unroll 4
+            for (int64_t dim = 0; dim < kHeadDim; ++dim) {
+              dot += dequant_fp8_e4m3(q_ptr[dim * q_stride2]) *
+                     dequant_fp8_e4m3(k_ptr[dim]);
+            }
+            accum += fmaxf(dot, 0.0f) *
+                     weights[row * weights_stride0 + head * weights_stride1];
+          }
+          score = accum * k_scale;
+        }
+      }
+    }
+    scores[rel_pos] = score;
+  }
+  __syncthreads();
+
+  const int64_t effective_topk =
+      topk < row_len ? (topk < kMaxTopK ? topk : kMaxTopK)
+                     : (row_len < kMaxTopK ? row_len : kMaxTopK);
+
+  for (int64_t rank = 0; rank < effective_topk; ++rank) {
+    float local_value = -INFINITY;
+    int local_index = -1;
+    for (int64_t rel_pos = tid; rel_pos < row_len; rel_pos += blockDim.x) {
+      const float value = scores[rel_pos];
+      if (better_pair(value, static_cast<int>(rel_pos), local_value,
+                      local_index)) {
+        local_value = value;
+        local_index = static_cast<int>(rel_pos);
+      }
+    }
+    reduce_values[tid] = local_value;
+    reduce_indices[tid] = local_index;
+    __syncthreads();
+
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+      if (tid < stride) {
+        const float other_value = reduce_values[tid + stride];
+        const int other_index = reduce_indices[tid + stride];
+        if (better_pair(other_value, other_index, reduce_values[tid],
+                        reduce_indices[tid])) {
+          reduce_values[tid] = other_value;
+          reduce_indices[tid] = other_index;
+        }
+      }
+      __syncthreads();
+    }
+
+    if (tid == 0) {
+      const int selected = reduce_indices[0];
+      topk_indices[row * topk_stride0 + rank * topk_stride1] =
+          static_cast<OutT>(selected);
+      if (selected >= 0) {
+        scores[selected] = -INFINITY;
+      }
+    }
+    __syncthreads();
+  }
+
+  for (int64_t rank = effective_topk + tid; rank < topk; rank += blockDim.x) {
+    topk_indices[row * topk_stride0 + rank * topk_stride1] =
+        static_cast<OutT>(-1);
+  }
+}
+
+template <typename OutT>
+void launch_indexer_topk_decode(const torch::Tensor &q_quant,
+                                const torch::Tensor &kv_cache,
+                                const torch::Tensor &weights,
+                                const torch::Tensor &seq_lens,
+                                const torch::Tensor &block_table,
+                                torch::Tensor &topk_indices, int64_t topk,
+                                musaStream_t stream) {
+  const dim3 grid(static_cast<unsigned int>(q_quant.size(0)));
+  const dim3 block(kThreads);
+  deepseek_v4_indexer_topk_decode_kernel<OutT><<<grid, block, 0, stream>>>(
+      static_cast<const uint8_t *>(q_quant.data_ptr()), q_quant.stride(0),
+      q_quant.stride(1), q_quant.stride(2),
+      static_cast<const uint8_t *>(kv_cache.data_ptr()), kv_cache.size(0),
+      kv_cache.size(1), kv_cache.stride(0),
+      static_cast<const float *>(weights.data_ptr()), weights.stride(0),
+      weights.stride(1), seq_lens.data_ptr(), index_kind(seq_lens, "seq_lens"),
+      seq_lens.stride(0), block_table.data_ptr(),
+      index_kind(block_table, "block_table"), block_table.stride(0),
+      static_cast<OutT *>(topk_indices.data_ptr()), topk_indices.stride(0),
+      topk_indices.stride(1), q_quant.size(0), topk);
+}
+
+template <typename OutT>
+void launch_indexer_topk_prefill(
+    const torch::Tensor &q_quant, const torch::Tensor &kv_cache,
+    const torch::Tensor &weights, const torch::Tensor &block_table,
+    const torch::Tensor &cu_seq_lens, const torch::Tensor &token_to_seq,
+    const torch::Tensor &cu_seqlen_ks, const torch::Tensor &cu_seqlen_ke,
+    torch::Tensor &topk_indices, int64_t topk, musaStream_t stream) {
+  const dim3 grid(static_cast<unsigned int>(q_quant.size(0)));
+  const dim3 block(kThreads);
+  deepseek_v4_indexer_topk_prefill_kernel<OutT><<<grid, block, 0, stream>>>(
+      static_cast<const uint8_t *>(q_quant.data_ptr()), q_quant.stride(0),
+      q_quant.stride(1), q_quant.stride(2),
+      static_cast<const uint8_t *>(kv_cache.data_ptr()), kv_cache.size(0),
+      kv_cache.size(1), kv_cache.stride(0),
+      static_cast<const float *>(weights.data_ptr()), weights.stride(0),
+      weights.stride(1), block_table.data_ptr(),
+      index_kind(block_table, "block_table"), block_table.stride(0),
+      cu_seq_lens.data_ptr(), index_kind(cu_seq_lens, "cu_seq_lens"),
+      cu_seq_lens.stride(0), token_to_seq.data_ptr(),
+      index_kind(token_to_seq, "token_to_seq"), token_to_seq.stride(0),
+      cu_seqlen_ks.data_ptr(), index_kind(cu_seqlen_ks, "cu_seqlen_ks"),
+      cu_seqlen_ks.stride(0), cu_seqlen_ke.data_ptr(),
+      index_kind(cu_seqlen_ke, "cu_seqlen_ke"), cu_seqlen_ke.stride(0),
+      static_cast<OutT *>(topk_indices.data_ptr()), topk_indices.stride(0),
+      topk_indices.stride(1), q_quant.size(0), token_to_seq.numel(), topk);
+}
+
+} // namespace
+
+void deepseek_v4_indexer_topk_decode(
+    const torch::Tensor &q_quant, const torch::Tensor &kv_cache,
+    const torch::Tensor &weights, const torch::Tensor &seq_lens,
+    const torch::Tensor &block_table, torch::Tensor &topk_indices,
+    int64_t topk) {
+  check_musa_tensor(q_quant, "q_quant");
+  check_same_device(q_quant, kv_cache, "kv_cache");
+  check_same_device(q_quant, weights, "weights");
+  check_same_device(q_quant, seq_lens, "seq_lens");
+  check_same_device(q_quant, block_table, "block_table");
+  check_same_device(q_quant, topk_indices, "topk_indices");
+
+  TORCH_CHECK(q_quant.scalar_type() == torch::kFloat8_e4m3fn,
+              "q_quant must be float8_e4m3fn");
+  TORCH_CHECK(kv_cache.scalar_type() == torch::kUInt8,
+              "kv_cache must be uint8");
+  TORCH_CHECK(weights.scalar_type() == torch::kFloat32,
+              "weights must be float32");
+  TORCH_CHECK(q_quant.dim() == 3, "q_quant must be [rows, 64, 128]");
+  TORCH_CHECK(q_quant.size(1) == kNumHeads && q_quant.size(2) == kHeadDim,
+              "q_quant must be [rows, 64, 128]");
+  TORCH_CHECK(weights.dim() == 2 && weights.size(0) == q_quant.size(0) &&
+                  weights.size(1) == kNumHeads,
+              "weights must be [rows, 64]");
+  TORCH_CHECK(seq_lens.dim() == 1 && seq_lens.size(0) >= q_quant.size(0),
+              "seq_lens must be 1-D with at least one entry per row");
+  TORCH_CHECK(block_table.dim() == 2 && block_table.size(0) >= q_quant.size(0),
+              "block_table must be 2-D with at least one row per query");
+  TORCH_CHECK(topk_indices.dim() == 2 &&
+                  topk_indices.size(0) >= q_quant.size(0),
+              "topk_indices must be 2-D with at least one row per query");
+  TORCH_CHECK(topk >= 0 && topk <= topk_indices.size(1),
+              "topk must fit topk_indices width");
+  TORCH_CHECK(topk <= kMaxTopK, "topk > 512 is not supported");
+  TORCH_CHECK(kv_cache.dim() >= 2 && kv_cache.size(1) > 0,
+              "kv_cache must include a non-empty block dimension");
+  TORCH_CHECK(block_table.size(1) * kv_cache.size(1) <= kMaxSeqLen,
+              "deepseek_v4_indexer_topk_decode supports max sequence length "
+              "4096");
+  TORCH_CHECK(kv_cache.stride(-1) == 1,
+              "kv_cache byte dimension must be contiguous");
+  TORCH_CHECK(kv_cache.stride(0) >=
+                  kv_cache.size(1) * (kHeadDim + kScaleBytes),
+              "kv_cache block stride is too small for indexer FP8 layout");
+  TORCH_CHECK(q_quant.stride(2) == 1, "q_quant last dimension must be contiguous");
+  TORCH_CHECK(topk_indices.stride(1) == 1,
+              "topk_indices last dimension must be contiguous");
+  index_kind(seq_lens, "seq_lens");
+  index_kind(block_table, "block_table");
+
+  if (q_quant.size(0) == 0 || topk == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(q_quant));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  if (topk_indices.scalar_type() == torch::kInt32) {
+    launch_indexer_topk_decode<int32_t>(
+        q_quant, kv_cache, weights, seq_lens, block_table, topk_indices, topk,
+        stream);
+  } else if (topk_indices.scalar_type() == torch::kInt64) {
+    launch_indexer_topk_decode<int64_t>(
+        q_quant, kv_cache, weights, seq_lens, block_table, topk_indices, topk,
+        stream);
+  } else {
+    TORCH_CHECK(false, "topk_indices must be int32 or int64");
+  }
+
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "deepseek_v4_indexer_topk_decode launch failed: ",
+              musaGetErrorString(err));
+}
+
+void deepseek_v4_indexer_topk_prefill(
+    const torch::Tensor &q_quant, const torch::Tensor &kv_cache,
+    const torch::Tensor &weights, const torch::Tensor &block_table,
+    const torch::Tensor &cu_seq_lens, const torch::Tensor &token_to_seq,
+    const torch::Tensor &cu_seqlen_ks, const torch::Tensor &cu_seqlen_ke,
+    torch::Tensor &topk_indices, int64_t topk) {
+  check_musa_tensor(q_quant, "q_quant");
+  check_same_device(q_quant, kv_cache, "kv_cache");
+  check_same_device(q_quant, weights, "weights");
+  check_same_device(q_quant, block_table, "block_table");
+  check_same_device(q_quant, cu_seq_lens, "cu_seq_lens");
+  check_same_device(q_quant, token_to_seq, "token_to_seq");
+  check_same_device(q_quant, cu_seqlen_ks, "cu_seqlen_ks");
+  check_same_device(q_quant, cu_seqlen_ke, "cu_seqlen_ke");
+  check_same_device(q_quant, topk_indices, "topk_indices");
+
+  TORCH_CHECK(q_quant.scalar_type() == torch::kFloat8_e4m3fn,
+              "q_quant must be float8_e4m3fn");
+  TORCH_CHECK(kv_cache.scalar_type() == torch::kUInt8,
+              "kv_cache must be uint8");
+  TORCH_CHECK(weights.scalar_type() == torch::kFloat32,
+              "weights must be float32");
+  TORCH_CHECK(q_quant.dim() == 3, "q_quant must be [rows, 64, 128]");
+  TORCH_CHECK(q_quant.size(1) == kNumHeads && q_quant.size(2) == kHeadDim,
+              "q_quant must be [rows, 64, 128]");
+  TORCH_CHECK(weights.dim() == 2 && weights.size(0) == q_quant.size(0) &&
+                  weights.size(1) == kNumHeads,
+              "weights must be [rows, 64]");
+  TORCH_CHECK(block_table.dim() == 2, "block_table must be 2-D");
+  TORCH_CHECK(cu_seq_lens.dim() == 1, "cu_seq_lens must be 1-D");
+  TORCH_CHECK(token_to_seq.dim() == 1, "token_to_seq must be 1-D");
+  TORCH_CHECK(cu_seqlen_ks.dim() == 1 &&
+                  cu_seqlen_ks.size(0) >= q_quant.size(0),
+              "cu_seqlen_ks must be 1-D with at least one entry per row");
+  TORCH_CHECK(cu_seqlen_ke.dim() == 1 &&
+                  cu_seqlen_ke.size(0) >= q_quant.size(0),
+              "cu_seqlen_ke must be 1-D with at least one entry per row");
+  TORCH_CHECK(topk_indices.dim() == 2 &&
+                  topk_indices.size(0) >= q_quant.size(0),
+              "topk_indices must be 2-D with at least one row per query");
+  TORCH_CHECK(topk >= 0 && topk <= topk_indices.size(1),
+              "topk must fit topk_indices width");
+  TORCH_CHECK(topk <= kMaxTopK, "topk > 512 is not supported");
+  TORCH_CHECK(kv_cache.dim() >= 2 && kv_cache.size(1) > 0,
+              "kv_cache must include a non-empty block dimension");
+  TORCH_CHECK(kv_cache.stride(-1) == 1,
+              "kv_cache byte dimension must be contiguous");
+  TORCH_CHECK(kv_cache.stride(0) >=
+                  kv_cache.size(1) * (kHeadDim + kScaleBytes),
+              "kv_cache block stride is too small for indexer FP8 layout");
+  TORCH_CHECK(q_quant.stride(2) == 1, "q_quant last dimension must be contiguous");
+  TORCH_CHECK(topk_indices.stride(1) == 1,
+              "topk_indices last dimension must be contiguous");
+  index_kind(block_table, "block_table");
+  index_kind(cu_seq_lens, "cu_seq_lens");
+  index_kind(token_to_seq, "token_to_seq");
+  index_kind(cu_seqlen_ks, "cu_seqlen_ks");
+  index_kind(cu_seqlen_ke, "cu_seqlen_ke");
+
+  if (q_quant.size(0) == 0 || topk == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(q_quant));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  if (topk_indices.scalar_type() == torch::kInt32) {
+    launch_indexer_topk_prefill<int32_t>(
+        q_quant, kv_cache, weights, block_table, cu_seq_lens, token_to_seq,
+        cu_seqlen_ks, cu_seqlen_ke, topk_indices, topk, stream);
+  } else if (topk_indices.scalar_type() == torch::kInt64) {
+    launch_indexer_topk_prefill<int64_t>(
+        q_quant, kv_cache, weights, block_table, cu_seq_lens, token_to_seq,
+        cu_seqlen_ks, cu_seqlen_ke, topk_indices, topk, stream);
+  } else {
+    TORCH_CHECK(false, "topk_indices must be int32 or int64");
+  }
+
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "deepseek_v4_indexer_topk_prefill launch failed: ",
+              musaGetErrorString(err));
+}

--- a/csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu
+++ b/csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu
@@ -1,0 +1,283 @@
+#include <cmath>
+#include <cstdint>
+#include <tuple>
+
+#include <musa_bf16.h>
+#include <musa_fp8.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+namespace {
+
+constexpr int64_t kNopeDim = 448;
+constexpr int64_t kRopeDim = 64;
+constexpr int64_t kHeadDim = kNopeDim + kRopeDim;
+constexpr int64_t kQuantGroupSize = 128;
+constexpr int64_t kChunksPerHead = kHeadDim / kQuantGroupSize;
+constexpr int kThreads = 128;
+constexpr float kFp8Max = 448.0f;
+constexpr float kFp8Min = -448.0f;
+constexpr float kScaleEps = 1.0e-10f;
+
+constexpr int kIndexInt32 = 1;
+constexpr int kIndexInt64 = 2;
+
+__device__ __forceinline__ int64_t load_index(const void* ptr, int kind,
+                                              int64_t idx) {
+  if (kind == kIndexInt32) {
+    return static_cast<int64_t>(static_cast<const int32_t*>(ptr)[idx]);
+  }
+  return static_cast<int64_t>(static_cast<const int64_t*>(ptr)[idx]);
+}
+
+__device__ __forceinline__ float reduce_max_128(float* shared, int tid,
+                                                float value) {
+  shared[tid] = value;
+  __syncthreads();
+
+  for (int stride = kThreads / 2; stride > 0; stride >>= 1) {
+    if (tid < stride) {
+      shared[tid] = fmaxf(shared[tid], shared[tid + stride]);
+    }
+    __syncthreads();
+  }
+  return shared[0];
+}
+
+__device__ __forceinline__ float load_rotated_or_raw(
+    const __mt_bfloat16* __restrict__ input, int64_t dim,
+    const float* __restrict__ cos_ptr, const float* __restrict__ sin_ptr) {
+  if (dim < kNopeDim) {
+    return __bfloat162float(input[dim]);
+  }
+
+  const int64_t rope_offset = dim - kNopeDim;
+  const int64_t pair = rope_offset / 2;
+  const int64_t even_dim = kNopeDim + pair * 2;
+  const int64_t odd_dim = even_dim + 1;
+  const float even = __bfloat162float(input[even_dim]);
+  const float odd = __bfloat162float(input[odd_dim]);
+  const float c = cos_ptr[pair];
+  const float s = sin_ptr[pair];
+  if ((rope_offset & 1) == 0) {
+    return even * c + odd * s;
+  }
+  return odd * c - even * s;
+}
+
+template <bool TMA_ALIGNED_SCALES>
+__global__ void deepseek_v4_inv_rope_fp8_quant_kernel(
+    const __mt_bfloat16* __restrict__ o, int64_t o_stride_token,
+    int64_t o_stride_head, const void* __restrict__ positions,
+    int position_kind, const float* __restrict__ cos_sin_cache,
+    int64_t cache_stride_pos, uint8_t* __restrict__ fp8_out,
+    int64_t fp8_stride_group, int64_t fp8_stride_token, void* __restrict__ scale,
+    int64_t scale_stride_group, int64_t scale_stride_k, int64_t num_tokens,
+    int64_t heads_per_group) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x);
+  const int64_t global_head = static_cast<int64_t>(blockIdx.y);
+  const int tid = threadIdx.x;
+
+  const int64_t group = global_head / heads_per_group;
+  const int64_t head_in_group = global_head - group * heads_per_group;
+  const int64_t chunk_base = head_in_group * kChunksPerHead;
+
+  if (token >= num_tokens) {
+    if constexpr (TMA_ALIGNED_SCALES) {
+      if (tid == 0) {
+        auto* packed = static_cast<int32_t*>(scale);
+        packed[group * scale_stride_group + token +
+               head_in_group * scale_stride_k] = 0;
+      }
+    } else if (tid < kChunksPerHead) {
+      auto* scale_f = static_cast<float*>(scale);
+      const int64_t chunk = chunk_base + tid;
+      scale_f[group * scale_stride_group + token + chunk * scale_stride_k] =
+          0.0f;
+    }
+    return;
+  }
+
+  __shared__ float reduce[kThreads];
+  __shared__ float values[kQuantGroupSize];
+  __shared__ uint32_t scale_bytes[kChunksPerHead];
+
+  const int64_t pos = load_index(positions, position_kind, token);
+  const float* cos_ptr = cos_sin_cache + pos * cache_stride_pos;
+  const float* sin_ptr = cos_ptr + kRopeDim / 2;
+  const __mt_bfloat16* input =
+      o + token * o_stride_token + global_head * o_stride_head;
+  uint8_t* output = fp8_out + group * fp8_stride_group +
+                    token * fp8_stride_token + head_in_group * kHeadDim;
+
+#pragma unroll
+  for (int64_t chunk = 0; chunk < kChunksPerHead; ++chunk) {
+    const int64_t dim = chunk * kQuantGroupSize + tid;
+    const float value = load_rotated_or_raw(input, dim, cos_ptr, sin_ptr);
+    values[tid] = value;
+
+    const float absmax = reduce_max_128(reduce, tid, fabsf(value));
+    const float scale_raw = fmaxf(absmax / kFp8Max, kScaleEps);
+    const float scale_pow2 = exp2f(ceilf(log2f(scale_raw)));
+
+    if (tid == 0) {
+      if constexpr (TMA_ALIGNED_SCALES) {
+        const uint32_t bits = __float_as_uint(scale_pow2);
+        scale_bytes[chunk] = (bits >> 23u) & 0xffu;
+      } else {
+        auto* scale_f = static_cast<float*>(scale);
+        const int64_t out_chunk = chunk_base + chunk;
+        scale_f[group * scale_stride_group + token +
+                out_chunk * scale_stride_k] = scale_pow2;
+      }
+    }
+    __syncthreads();
+
+    float q = values[tid] / scale_pow2;
+    q = fminf(fmaxf(q, kFp8Min), kFp8Max);
+    const __mt_fp8_e4m3 packed(q);
+    output[dim] = packed.__x;
+    __syncthreads();
+  }
+
+  if constexpr (TMA_ALIGNED_SCALES) {
+    if (tid == 0) {
+      uint32_t packed = 0;
+#pragma unroll
+      for (int64_t chunk = 0; chunk < kChunksPerHead; ++chunk) {
+        packed |= scale_bytes[chunk] << (chunk * 8);
+      }
+      auto* scale_i = static_cast<int32_t*>(scale);
+      scale_i[group * scale_stride_group + token +
+              head_in_group * scale_stride_k] =
+          static_cast<int32_t>(packed);
+    }
+  }
+}
+
+int index_kind(const torch::Tensor& tensor, const char* name) {
+  if (tensor.scalar_type() == torch::kInt32) {
+    return kIndexInt32;
+  }
+  if (tensor.scalar_type() == torch::kInt64) {
+    return kIndexInt64;
+  }
+  TORCH_CHECK(false, name, " must be int32 or int64");
+}
+
+int64_t tma_aligned_tokens(int64_t num_tokens) {
+  return ((num_tokens + 3) / 4) * 4;
+}
+
+void check_musa_tensor(const torch::Tensor& tensor, const char* name) {
+  TORCH_CHECK(tensor.device().is_privateuseone(), name,
+              " must be a MUSA tensor");
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_inv_rope_fp8_quant(
+    const torch::Tensor& o, const torch::Tensor& positions,
+    const torch::Tensor& cos_sin_cache, int64_t n_groups,
+    int64_t heads_per_group, int64_t nope_dim, int64_t rope_dim,
+    int64_t quant_group_size, bool tma_aligned_scales) {
+  check_musa_tensor(o, "o");
+  check_musa_tensor(positions, "positions");
+  check_musa_tensor(cos_sin_cache, "cos_sin_cache");
+  TORCH_CHECK(o.scalar_type() == torch::kBFloat16, "o must be bfloat16");
+  TORCH_CHECK(cos_sin_cache.scalar_type() == torch::kFloat32,
+              "cos_sin_cache must be float32");
+  TORCH_CHECK(o.dim() == 3, "o must have shape [tokens, heads, head_dim]");
+  TORCH_CHECK(o.size(2) == kHeadDim, "DeepSeek-V4 head dim must be 512");
+  TORCH_CHECK(o.stride(2) == 1, "o last dimension must be contiguous");
+  TORCH_CHECK(positions.dim() == 1 && positions.numel() == o.size(0),
+              "positions must be [tokens]");
+  TORCH_CHECK(positions.is_contiguous(), "positions must be contiguous");
+  TORCH_CHECK(cos_sin_cache.dim() == 2 && cos_sin_cache.size(1) == kRopeDim,
+              "cos_sin_cache must have shape [max_positions, 64]");
+  TORCH_CHECK(cos_sin_cache.stride(1) == 1,
+              "cos_sin_cache last dimension must be contiguous");
+  TORCH_CHECK(o.device() == positions.device() &&
+                  o.device() == cos_sin_cache.device(),
+              "o, positions, and cos_sin_cache must be on the same device");
+  TORCH_CHECK(nope_dim == kNopeDim && rope_dim == kRopeDim &&
+                  quant_group_size == kQuantGroupSize,
+              "only DeepSeek-V4 dimensions 448/64 with group_size=128 are "
+              "supported");
+  TORCH_CHECK(heads_per_group > 0 && n_groups > 0,
+              "n_groups and heads_per_group must be positive");
+  TORCH_CHECK(o.size(1) == n_groups * heads_per_group,
+              "num heads must equal n_groups * heads_per_group");
+
+  const int64_t num_tokens = o.size(0);
+  const int64_t num_heads = o.size(1);
+  const int64_t d = heads_per_group * kHeadDim;
+  const int64_t num_scale_blocks = d / kQuantGroupSize;
+  const int64_t aligned_tokens = tma_aligned_tokens(num_tokens);
+
+  auto fp8_buf =
+      torch::empty({n_groups, num_tokens, d},
+                   o.options().dtype(torch::kFloat8_e4m3fn));
+
+  torch::Tensor scale_storage;
+  torch::Tensor scale_buf;
+  if (tma_aligned_scales) {
+    const int64_t packed_sf_k = (num_scale_blocks + 3) / 4;
+    scale_storage = torch::empty({n_groups * packed_sf_k * aligned_tokens},
+                                 o.options().dtype(torch::kInt32));
+    scale_buf =
+        scale_storage.as_strided({n_groups, num_tokens, packed_sf_k},
+                                 {packed_sf_k * aligned_tokens, 1,
+                                  aligned_tokens});
+  } else {
+    scale_storage = torch::empty({n_groups * num_scale_blocks * aligned_tokens},
+                                 o.options().dtype(torch::kFloat32));
+    scale_buf =
+        scale_storage.as_strided({n_groups, num_tokens, num_scale_blocks},
+                                 {num_scale_blocks * aligned_tokens, 1,
+                                  aligned_tokens});
+  }
+
+  if (num_tokens == 0 || num_heads == 0) {
+    return std::make_tuple(fp8_buf.transpose(0, 1), scale_buf.transpose(0, 1));
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(o));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  const dim3 grid(static_cast<unsigned int>(aligned_tokens),
+                  static_cast<unsigned int>(num_heads));
+  const dim3 block(kThreads);
+
+  if (tma_aligned_scales) {
+    deepseek_v4_inv_rope_fp8_quant_kernel<true>
+        <<<grid, block, 0, stream>>>(
+            static_cast<const __mt_bfloat16*>(o.data_ptr()), o.stride(0),
+            o.stride(1), positions.data_ptr(), index_kind(positions, "positions"),
+            static_cast<const float*>(cos_sin_cache.data_ptr()),
+            cos_sin_cache.stride(0), static_cast<uint8_t*>(fp8_buf.data_ptr()),
+            fp8_buf.stride(0), fp8_buf.stride(1), scale_buf.data_ptr(),
+            scale_buf.stride(0), scale_buf.stride(2), num_tokens,
+            heads_per_group);
+  } else {
+    deepseek_v4_inv_rope_fp8_quant_kernel<false>
+        <<<grid, block, 0, stream>>>(
+            static_cast<const __mt_bfloat16*>(o.data_ptr()), o.stride(0),
+            o.stride(1), positions.data_ptr(), index_kind(positions, "positions"),
+            static_cast<const float*>(cos_sin_cache.data_ptr()),
+            cos_sin_cache.stride(0), static_cast<uint8_t*>(fp8_buf.data_ptr()),
+            fp8_buf.stride(0), fp8_buf.stride(1), scale_buf.data_ptr(),
+            scale_buf.stride(0), scale_buf.stride(2), num_tokens,
+            heads_per_group);
+  }
+
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "deepseek_v4_fused_inv_rope_fp8_quant launch failed: ",
+              musaGetErrorString(err));
+
+  return std::make_tuple(fp8_buf.transpose(0, 1), scale_buf.transpose(0, 1));
+}

--- a/csrc/musa/attention/deepseek_v4_sparse_flashmla.mu
+++ b/csrc/musa/attention/deepseek_v4_sparse_flashmla.mu
@@ -1,0 +1,411 @@
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <tuple>
+
+#include <musa_bf16.h>
+#include <musa_fp8.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+namespace {
+
+constexpr int64_t kNopeDim = 448;
+constexpr int64_t kRopeDim = 64;
+constexpr int64_t kHeadDim = kNopeDim + kRopeDim;
+constexpr int64_t kTokenDataBytes = kNopeDim + kRopeDim * 2;
+constexpr int64_t kTokenScaleBytes = 8;
+constexpr int64_t kQuantBlockSize = 64;
+constexpr int kThreads = 256;
+
+constexpr int kIndexInt32 = 1;
+constexpr int kIndexInt64 = 2;
+
+__device__ __forceinline__ int64_t load_index(const void *ptr, int kind,
+                                              int64_t idx) {
+  if (kind == kIndexInt32) {
+    return static_cast<int64_t>(static_cast<const int32_t *>(ptr)[idx]);
+  }
+  return static_cast<int64_t>(static_cast<const int64_t *>(ptr)[idx]);
+}
+
+__device__ __forceinline__ float load_bf16(const __mt_bfloat16 *ptr,
+                                           int64_t idx) {
+  return __bfloat162float(ptr[idx]);
+}
+
+__device__ __forceinline__ float dequant_fp8_e4m3(uint8_t byte,
+                                                  uint8_t encoded_scale) {
+  __mt_fp8_e4m3 packed;
+  packed.__x = byte;
+  return static_cast<float>(packed) *
+         exp2f(static_cast<float>(encoded_scale) - 127.0f);
+}
+
+__device__ __forceinline__ float load_packed_cache_value(
+    const uint8_t *__restrict__ cache, int64_t num_blocks, int64_t block_size,
+    int64_t block_stride, int64_t slot, int64_t dim) {
+  if (slot < 0 || slot >= num_blocks * block_size) {
+    return 0.0f;
+  }
+  const int64_t block_idx = slot / block_size;
+  const int64_t pos_in_block = slot - block_idx * block_size;
+  const uint8_t *block_ptr = cache + block_idx * block_stride;
+  const uint8_t *token_ptr = block_ptr + pos_in_block * kTokenDataBytes;
+  if (dim < kNopeDim) {
+    const uint8_t *scale_ptr =
+        block_ptr + block_size * kTokenDataBytes +
+        pos_in_block * kTokenScaleBytes;
+    return dequant_fp8_e4m3(token_ptr[dim],
+                            scale_ptr[dim / kQuantBlockSize]);
+  }
+  const __mt_bfloat16 *rope =
+      reinterpret_cast<const __mt_bfloat16 *>(token_ptr + kNopeDim);
+  return load_bf16(rope, dim - kNopeDim);
+}
+
+__device__ void process_sparse_slot(
+    int64_t slot, const uint8_t *__restrict__ cache, int64_t num_blocks,
+    int64_t block_size, int64_t block_stride, const __mt_bfloat16 *q_ptr,
+    int64_t q_dim_stride, float softmax_scale, float *__restrict__ acc,
+    float *__restrict__ kv_vec, float *__restrict__ reduce,
+    float *__restrict__ denom_m, float *__restrict__ denom_l,
+    float *__restrict__ key_m, float *__restrict__ key_l,
+    float *__restrict__ alpha, float *__restrict__ beta) {
+  if (slot < 0 || slot >= num_blocks * block_size) {
+    return;
+  }
+
+  float partial = 0.0f;
+  for (int64_t dim = threadIdx.x; dim < kHeadDim; dim += blockDim.x) {
+    const float q_val = load_bf16(q_ptr, dim * q_dim_stride);
+    const float kv_val =
+        load_packed_cache_value(cache, num_blocks, block_size, block_stride,
+                                slot, dim);
+    kv_vec[dim] = kv_val;
+    partial += q_val * kv_val;
+  }
+  reduce[threadIdx.x] = partial;
+  __syncthreads();
+
+  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride) {
+      reduce[threadIdx.x] += reduce[threadIdx.x + stride];
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    const float logit = reduce[0] * softmax_scale;
+
+    if (*key_l == 0.0f) {
+      *key_m = logit;
+      *key_l = 1.0f;
+    } else {
+      const float new_key_m = fmaxf(*key_m, logit);
+      *key_l = *key_l * expf(*key_m - new_key_m) + expf(logit - new_key_m);
+      *key_m = new_key_m;
+    }
+
+    if (*denom_l == 0.0f) {
+      *alpha = 0.0f;
+      *beta = 1.0f;
+      *denom_m = logit;
+      *denom_l = 1.0f;
+    } else {
+      const float new_m = fmaxf(*denom_m, logit);
+      *alpha = expf(*denom_m - new_m);
+      *beta = expf(logit - new_m);
+      *denom_l = *denom_l * *alpha + *beta;
+      *denom_m = new_m;
+    }
+  }
+  __syncthreads();
+
+  for (int64_t dim = threadIdx.x; dim < kHeadDim; dim += blockDim.x) {
+    acc[dim] = acc[dim] * *alpha + kv_vec[dim] * *beta;
+  }
+  __syncthreads();
+}
+
+__global__ void deepseek_v4_sparse_flashmla_decode_kernel(
+    const __mt_bfloat16 *__restrict__ q, int64_t q_stride0,
+    int64_t q_stride1, int64_t q_stride2, int64_t q_stride3,
+    __mt_bfloat16 *__restrict__ out, int64_t out_stride0,
+    int64_t out_stride1, int64_t out_stride2, int64_t out_stride3,
+    float *__restrict__ lse, const uint8_t *__restrict__ k_cache,
+    int64_t k_num_blocks, int64_t k_block_size, int64_t k_block_stride,
+    const void *__restrict__ indices, int index_kind, int64_t indices_stride0,
+    int64_t indices_stride1, const void *__restrict__ topk_length,
+    int topk_length_kind, int64_t topk, const uint8_t *__restrict__ extra_cache,
+    int64_t extra_num_blocks, int64_t extra_block_size,
+    int64_t extra_block_stride, const void *__restrict__ extra_indices,
+    int extra_index_kind, int64_t extra_indices_stride0,
+    int64_t extra_indices_stride1, const void *__restrict__ extra_topk_length,
+    int extra_topk_length_kind, int64_t extra_topk, const float *attn_sink,
+    int64_t batch, int64_t seq_len, int64_t num_heads, float softmax_scale) {
+  const int64_t query_idx = static_cast<int64_t>(blockIdx.x);
+  const int64_t head_idx = static_cast<int64_t>(blockIdx.y);
+  if (query_idx >= batch * seq_len || head_idx >= num_heads) {
+    return;
+  }
+
+  __shared__ float acc[kHeadDim];
+  __shared__ float kv_vec[kHeadDim];
+  __shared__ float reduce[kThreads];
+  __shared__ float denom_m;
+  __shared__ float denom_l;
+  __shared__ float key_m;
+  __shared__ float key_l;
+  __shared__ float alpha;
+  __shared__ float beta;
+
+  const int64_t b = query_idx / seq_len;
+  const int64_t s = query_idx - b * seq_len;
+  const __mt_bfloat16 *q_ptr =
+      q + b * q_stride0 + s * q_stride1 + head_idx * q_stride2;
+  __mt_bfloat16 *out_ptr =
+      out + b * out_stride0 + s * out_stride1 + head_idx * out_stride2;
+
+  for (int64_t dim = threadIdx.x; dim < kHeadDim; dim += blockDim.x) {
+    acc[dim] = 0.0f;
+  }
+  if (threadIdx.x == 0) {
+    const float sink = attn_sink == nullptr ? -INFINITY : attn_sink[head_idx];
+    if (isfinite(sink)) {
+      denom_m = sink;
+      denom_l = 1.0f;
+    } else {
+      denom_m = -INFINITY;
+      denom_l = 0.0f;
+    }
+    key_m = -INFINITY;
+    key_l = 0.0f;
+    alpha = 0.0f;
+    beta = 0.0f;
+  }
+  __syncthreads();
+
+  int64_t main_len = topk;
+  if (topk_length != nullptr) {
+    const int64_t raw_len = load_index(topk_length, topk_length_kind, query_idx);
+    main_len = raw_len < topk ? raw_len : topk;
+    main_len = main_len > 0 ? main_len : 0;
+  }
+  for (int64_t i = 0; i < main_len; ++i) {
+    const int64_t slot = load_index(indices, index_kind,
+                                    query_idx * indices_stride0 +
+                                        i * indices_stride1);
+    process_sparse_slot(slot, k_cache, k_num_blocks, k_block_size,
+                        k_block_stride, q_ptr, q_stride3, softmax_scale, acc,
+                        kv_vec, reduce, &denom_m, &denom_l, &key_m, &key_l,
+                        &alpha, &beta);
+  }
+
+  if (extra_cache != nullptr && extra_indices != nullptr) {
+    int64_t extra_len = extra_topk;
+    if (extra_topk_length != nullptr) {
+      const int64_t raw_len =
+          load_index(extra_topk_length, extra_topk_length_kind, query_idx);
+      extra_len = raw_len < extra_topk ? raw_len : extra_topk;
+      extra_len = extra_len > 0 ? extra_len : 0;
+    }
+    for (int64_t i = 0; i < extra_len; ++i) {
+      const int64_t slot = load_index(extra_indices, extra_index_kind,
+                                      query_idx * extra_indices_stride0 +
+                                          i * extra_indices_stride1);
+      process_sparse_slot(slot, extra_cache, extra_num_blocks, extra_block_size,
+                          extra_block_stride, q_ptr, q_stride3, softmax_scale,
+                          acc, kv_vec, reduce, &denom_m, &denom_l, &key_m,
+                          &key_l, &alpha, &beta);
+    }
+  }
+
+  const float inv_l = denom_l == 0.0f ? 0.0f : 1.0f / denom_l;
+  for (int64_t dim = threadIdx.x; dim < kHeadDim; dim += blockDim.x) {
+    const float value = acc[dim] * inv_l;
+    out_ptr[dim * out_stride3] = __float2bfloat16(value);
+  }
+  if (threadIdx.x == 0) {
+    const float key_lse =
+        key_l == 0.0f ? INFINITY : key_m + logf(fmaxf(key_l, 1.0e-30f));
+    lse[b * num_heads * seq_len + head_idx * seq_len + s] = key_lse;
+  }
+}
+
+int index_kind(const torch::Tensor &tensor, const char *name) {
+  if (tensor.scalar_type() == torch::kInt32) {
+    return kIndexInt32;
+  }
+  if (tensor.scalar_type() == torch::kInt64) {
+    return kIndexInt64;
+  }
+  TORCH_CHECK(false, name, " must be int32 or int64");
+}
+
+void check_musa_tensor(const torch::Tensor &tensor, const char *name) {
+  TORCH_CHECK(tensor.device().is_privateuseone(), name,
+              " must be a MUSA tensor");
+}
+
+void check_packed_cache(const torch::Tensor &cache, const char *name) {
+  check_musa_tensor(cache, name);
+  TORCH_CHECK(cache.scalar_type() == torch::kUInt8, name, " must be uint8");
+  TORCH_CHECK(cache.dim() == 4 || cache.dim() == 3, name,
+              " must be [blocks, block, 1, bytes] or [blocks, block, bytes]");
+  if (cache.dim() == 4) {
+    TORCH_CHECK(cache.size(2) == 1, name,
+                " must use one KV head for DeepSeek-V4 MLA");
+  }
+  TORCH_CHECK(cache.size(0) > 0 && cache.size(1) > 0, name,
+              " must have non-empty blocks");
+  TORCH_CHECK(cache.stride(-1) == 1, name,
+              " byte dimension must be contiguous");
+  const int64_t logical_block_bytes =
+      cache.size(1) * (kTokenDataBytes + kTokenScaleBytes);
+  TORCH_CHECK(cache.stride(0) >= logical_block_bytes, name,
+              " block stride is smaller than packed fp8_ds_mla payload");
+}
+
+void check_flat_indices(const torch::Tensor &indices, const char *name,
+                        int64_t num_queries) {
+  check_musa_tensor(indices, name);
+  TORCH_CHECK(indices.dim() == 2, name, " must be flattened to [queries, topk]");
+  TORCH_CHECK(indices.size(0) == num_queries, name,
+              " first dimension must match query count");
+  TORCH_CHECK(indices.is_contiguous(), name, " must be contiguous");
+  index_kind(indices, name);
+}
+
+void check_optional_lengths(const c10::optional<torch::Tensor> &lengths,
+                            const char *name, int64_t num_queries) {
+  if (!lengths.has_value()) {
+    return;
+  }
+  const torch::Tensor &tensor = lengths.value();
+  check_musa_tensor(tensor, name);
+  TORCH_CHECK(tensor.numel() == num_queries, name,
+              " must contain one length per query");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+  index_kind(tensor, name);
+}
+
+} // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_sparse_flashmla_decode(
+    const torch::Tensor &q, const torch::Tensor &k_cache,
+    const torch::Tensor &indices,
+    const c10::optional<torch::Tensor> &topk_length,
+    const c10::optional<torch::Tensor> &attn_sink,
+    const c10::optional<torch::Tensor> &extra_k_cache,
+    const c10::optional<torch::Tensor> &extra_indices,
+    const c10::optional<torch::Tensor> &extra_topk_length, torch::Tensor &out,
+    double softmax_scale) {
+  check_musa_tensor(q, "q");
+  check_musa_tensor(out, "out");
+  check_packed_cache(k_cache, "k_cache");
+  TORCH_CHECK(q.scalar_type() == torch::kBFloat16, "q must be bfloat16");
+  TORCH_CHECK(out.scalar_type() == torch::kBFloat16, "out must be bfloat16");
+  TORCH_CHECK(q.dim() == 4, "q must be [batch, seq, heads, 512]");
+  TORCH_CHECK(out.dim() == 4, "out must be [batch, seq, heads, 512]");
+  TORCH_CHECK(q.size(3) == kHeadDim && out.size(3) == kHeadDim,
+              "DeepSeek-V4 sparse FlashMLA decode requires head dim 512");
+  TORCH_CHECK(q.size(0) == out.size(0) && q.size(1) == out.size(1) &&
+                  q.size(2) == out.size(2),
+              "q and out leading dimensions must match");
+  TORCH_CHECK(q.stride(3) == 1, "q last dimension must be contiguous");
+  TORCH_CHECK(out.stride(3) == 1, "out last dimension must be contiguous");
+  TORCH_CHECK(q.device() == out.device() && q.device() == k_cache.device() &&
+                  q.device() == indices.device(),
+              "q, out, k_cache, and indices must be on the same device");
+
+  const int64_t batch = q.size(0);
+  const int64_t seq_len = q.size(1);
+  const int64_t num_heads = q.size(2);
+  const int64_t num_queries = batch * seq_len;
+  check_flat_indices(indices, "indices", num_queries);
+  check_optional_lengths(topk_length, "topk_length", num_queries);
+
+  const bool has_extra_cache = extra_k_cache.has_value();
+  const bool has_extra_indices = extra_indices.has_value();
+  TORCH_CHECK(has_extra_cache == has_extra_indices,
+              "extra_k_cache and extra_indices must be provided together");
+  if (has_extra_cache) {
+    check_packed_cache(extra_k_cache.value(), "extra_k_cache");
+    check_flat_indices(extra_indices.value(), "extra_indices", num_queries);
+    TORCH_CHECK(extra_k_cache.value().device() == q.device() &&
+                    extra_indices.value().device() == q.device(),
+                "extra sparse tensors must be on the same device");
+    check_optional_lengths(extra_topk_length, "extra_topk_length", num_queries);
+  }
+  if (attn_sink.has_value()) {
+    check_musa_tensor(attn_sink.value(), "attn_sink");
+    TORCH_CHECK(attn_sink.value().scalar_type() == torch::kFloat32,
+                "attn_sink must be float32");
+    TORCH_CHECK(attn_sink.value().numel() >= num_heads,
+                "attn_sink must include one value per query head");
+    TORCH_CHECK(attn_sink.value().is_contiguous(),
+                "attn_sink must be contiguous");
+  }
+
+  auto lse = torch::empty({batch, num_heads, seq_len},
+                          q.options().dtype(torch::kFloat32));
+  if (num_queries == 0 || num_heads == 0) {
+    return std::make_tuple(out, lse);
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(q));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  const dim3 grid(static_cast<unsigned int>(num_queries),
+                  static_cast<unsigned int>(num_heads));
+  const dim3 block(kThreads);
+
+  const torch::Tensor *extra_cache_ptr =
+      has_extra_cache ? &extra_k_cache.value() : nullptr;
+  const torch::Tensor *extra_indices_ptr =
+      has_extra_indices ? &extra_indices.value() : nullptr;
+
+  deepseek_v4_sparse_flashmla_decode_kernel<<<grid, block, 0, stream>>>(
+      static_cast<const __mt_bfloat16 *>(q.data_ptr()), q.stride(0),
+      q.stride(1), q.stride(2), q.stride(3),
+      static_cast<__mt_bfloat16 *>(out.data_ptr()), out.stride(0),
+      out.stride(1), out.stride(2), out.stride(3),
+      static_cast<float *>(lse.data_ptr()),
+      static_cast<const uint8_t *>(k_cache.data_ptr()), k_cache.size(0),
+      k_cache.size(1), k_cache.stride(0), indices.data_ptr(),
+      index_kind(indices, "indices"), indices.stride(0), indices.stride(1),
+      topk_length.has_value() ? topk_length.value().data_ptr() : nullptr,
+      topk_length.has_value() ? index_kind(topk_length.value(), "topk_length")
+                              : kIndexInt32,
+      indices.size(1),
+      extra_cache_ptr == nullptr
+          ? nullptr
+          : static_cast<const uint8_t *>(extra_cache_ptr->data_ptr()),
+      extra_cache_ptr == nullptr ? 0 : extra_cache_ptr->size(0),
+      extra_cache_ptr == nullptr ? 0 : extra_cache_ptr->size(1),
+      extra_cache_ptr == nullptr ? 0 : extra_cache_ptr->stride(0),
+      extra_indices_ptr == nullptr ? nullptr : extra_indices_ptr->data_ptr(),
+      extra_indices_ptr == nullptr ? kIndexInt32
+                                   : index_kind(*extra_indices_ptr,
+                                                "extra_indices"),
+      extra_indices_ptr == nullptr ? 0 : extra_indices_ptr->stride(0),
+      extra_indices_ptr == nullptr ? 0 : extra_indices_ptr->stride(1),
+      extra_topk_length.has_value() ? extra_topk_length.value().data_ptr()
+                                    : nullptr,
+      extra_topk_length.has_value()
+          ? index_kind(extra_topk_length.value(), "extra_topk_length")
+          : kIndexInt32,
+      extra_indices_ptr == nullptr ? 0 : extra_indices_ptr->size(1),
+      attn_sink.has_value() ? static_cast<const float *>(attn_sink.value().data_ptr())
+                            : nullptr,
+      batch, seq_len, num_heads, static_cast<float>(softmax_scale));
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "deepseek_v4_sparse_flashmla_decode launch failed: ",
+              musaGetErrorString(err));
+  return std::make_tuple(out, lse);
+}

--- a/csrc/musa/mhc/deepseek_v4_mhc_pre.mu
+++ b/csrc/musa/mhc/deepseek_v4_mhc_pre.mu
@@ -1,0 +1,276 @@
+#include <cmath>
+#include <cstdint>
+
+#include <musa_bf16.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+namespace {
+
+constexpr int kHcMult = 4;
+constexpr int kMixCount = kHcMult * 2 + kHcMult * kHcMult;
+constexpr int kThreads = 256;
+
+void check_musa_tensor(const torch::Tensor& tensor, const char* name) {
+  TORCH_CHECK(tensor.device().is_privateuseone(), name,
+              " must be a MUSA tensor");
+}
+
+__device__ __forceinline__ float sigmoidf_fast(float x) {
+  return 1.0f / (1.0f + expf(-x));
+}
+
+__global__ void deepseek_v4_mhc_pre_kernel(
+    const __mt_bfloat16* __restrict__ residual,
+    const float* __restrict__ fn, const float* __restrict__ hc_scale,
+    const float* __restrict__ hc_base, float* __restrict__ post_mix,
+    float* __restrict__ comb_mix, __mt_bfloat16* __restrict__ layer_input,
+    int64_t num_tokens, int64_t hidden_size, float rms_eps, float hc_pre_eps,
+    float hc_sinkhorn_eps, float hc_post_mult_value, int sinkhorn_repeat) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x);
+  if (token >= num_tokens) {
+    return;
+  }
+
+  const int tid = threadIdx.x;
+  const int64_t hc_hidden_size = kHcMult * hidden_size;
+  const __mt_bfloat16* token_residual = residual + token * hc_hidden_size;
+
+  float local_mix[kMixCount];
+#pragma unroll
+  for (int i = 0; i < kMixCount; ++i) {
+    local_mix[i] = 0.0f;
+  }
+  float local_sqrsum = 0.0f;
+
+  for (int64_t col = tid; col < hc_hidden_size; col += blockDim.x) {
+    const float value = __bfloat162float(token_residual[col]);
+    local_sqrsum += value * value;
+#pragma unroll
+    for (int mix = 0; mix < kMixCount; ++mix) {
+      local_mix[mix] += value * fn[mix * hc_hidden_size + col];
+    }
+  }
+
+  __shared__ float mix_reduce[kMixCount][kThreads];
+  __shared__ float sq_reduce[kThreads];
+  __shared__ float pre_shared[kHcMult];
+
+#pragma unroll
+  for (int mix = 0; mix < kMixCount; ++mix) {
+    mix_reduce[mix][tid] = local_mix[mix];
+  }
+  sq_reduce[tid] = local_sqrsum;
+  __syncthreads();
+
+  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+    if (tid < stride) {
+#pragma unroll
+      for (int mix = 0; mix < kMixCount; ++mix) {
+        mix_reduce[mix][tid] += mix_reduce[mix][tid + stride];
+      }
+      sq_reduce[tid] += sq_reduce[tid + stride];
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    float mixes[kMixCount];
+    const float inv_rms =
+        rsqrtf(sq_reduce[0] / static_cast<float>(hc_hidden_size) + rms_eps);
+#pragma unroll
+    for (int mix = 0; mix < kMixCount; ++mix) {
+      mixes[mix] = mix_reduce[mix][0] * inv_rms;
+    }
+
+#pragma unroll
+    for (int i = 0; i < kHcMult; ++i) {
+      const float pre =
+          sigmoidf_fast(mixes[i] * hc_scale[0] + hc_base[i]) + hc_pre_eps;
+      pre_shared[i] = pre;
+      post_mix[token * kHcMult + i] =
+          sigmoidf_fast(mixes[kHcMult + i] * hc_scale[1] +
+                        hc_base[kHcMult + i]) *
+          hc_post_mult_value;
+    }
+
+    float comb[kHcMult][kHcMult];
+#pragma unroll
+    for (int row = 0; row < kHcMult; ++row) {
+      float row_max = -INFINITY;
+#pragma unroll
+      for (int col = 0; col < kHcMult; ++col) {
+        const int idx = 2 * kHcMult + row * kHcMult + col;
+        const float value = mixes[idx] * hc_scale[2] + hc_base[idx];
+        comb[row][col] = value;
+        row_max = fmaxf(row_max, value);
+      }
+      float row_sum = 0.0f;
+#pragma unroll
+      for (int col = 0; col < kHcMult; ++col) {
+        const float value = expf(comb[row][col] - row_max);
+        comb[row][col] = value;
+        row_sum += value;
+      }
+#pragma unroll
+      for (int col = 0; col < kHcMult; ++col) {
+        comb[row][col] = comb[row][col] / row_sum + hc_sinkhorn_eps;
+      }
+    }
+
+#pragma unroll
+    for (int col = 0; col < kHcMult; ++col) {
+      float col_sum = 0.0f;
+#pragma unroll
+      for (int row = 0; row < kHcMult; ++row) {
+        col_sum += comb[row][col];
+      }
+#pragma unroll
+      for (int row = 0; row < kHcMult; ++row) {
+        comb[row][col] /= col_sum + hc_sinkhorn_eps;
+      }
+    }
+
+    for (int repeat = 1; repeat < sinkhorn_repeat; ++repeat) {
+#pragma unroll
+      for (int row = 0; row < kHcMult; ++row) {
+        float row_sum = 0.0f;
+#pragma unroll
+        for (int col = 0; col < kHcMult; ++col) {
+          row_sum += comb[row][col];
+        }
+#pragma unroll
+        for (int col = 0; col < kHcMult; ++col) {
+          comb[row][col] /= row_sum + hc_sinkhorn_eps;
+        }
+      }
+#pragma unroll
+      for (int col = 0; col < kHcMult; ++col) {
+        float col_sum = 0.0f;
+#pragma unroll
+        for (int row = 0; row < kHcMult; ++row) {
+          col_sum += comb[row][col];
+        }
+#pragma unroll
+        for (int row = 0; row < kHcMult; ++row) {
+          comb[row][col] /= col_sum + hc_sinkhorn_eps;
+        }
+      }
+    }
+
+#pragma unroll
+    for (int row = 0; row < kHcMult; ++row) {
+#pragma unroll
+      for (int col = 0; col < kHcMult; ++col) {
+        comb_mix[token * kHcMult * kHcMult + row * kHcMult + col] =
+            comb[row][col];
+      }
+    }
+  }
+  __syncthreads();
+
+  for (int64_t h = tid; h < hidden_size; h += blockDim.x) {
+    float value = 0.0f;
+#pragma unroll
+    for (int hc = 0; hc < kHcMult; ++hc) {
+      value += pre_shared[hc] *
+               __bfloat162float(token_residual[hc * hidden_size + h]);
+    }
+    layer_input[token * hidden_size + h] = __float2bfloat16(value);
+  }
+}
+
+}  // namespace
+
+void deepseek_v4_mhc_pre(
+    const torch::Tensor& residual, const torch::Tensor& fn,
+    const torch::Tensor& hc_scale, const torch::Tensor& hc_base,
+    torch::Tensor& post_mix, torch::Tensor& comb_mix,
+    torch::Tensor& layer_input, double rms_eps, double hc_pre_eps,
+    double hc_sinkhorn_eps, double hc_post_mult_value,
+    int64_t sinkhorn_repeat) {
+  check_musa_tensor(residual, "residual");
+  check_musa_tensor(fn, "fn");
+  check_musa_tensor(hc_scale, "hc_scale");
+  check_musa_tensor(hc_base, "hc_base");
+  check_musa_tensor(post_mix, "post_mix");
+  check_musa_tensor(comb_mix, "comb_mix");
+  check_musa_tensor(layer_input, "layer_input");
+  TORCH_CHECK(residual.device() == fn.device(), "fn device mismatch");
+  TORCH_CHECK(residual.device() == hc_scale.device(), "hc_scale device mismatch");
+  TORCH_CHECK(residual.device() == hc_base.device(), "hc_base device mismatch");
+  TORCH_CHECK(residual.device() == post_mix.device(), "post_mix device mismatch");
+  TORCH_CHECK(residual.device() == comb_mix.device(), "comb_mix device mismatch");
+  TORCH_CHECK(residual.device() == layer_input.device(),
+              "layer_input device mismatch");
+
+  TORCH_CHECK(residual.scalar_type() == torch::kBFloat16,
+              "residual must be bfloat16");
+  TORCH_CHECK(fn.scalar_type() == torch::kFloat32, "fn must be float32");
+  TORCH_CHECK(hc_scale.scalar_type() == torch::kFloat32,
+              "hc_scale must be float32");
+  TORCH_CHECK(hc_base.scalar_type() == torch::kFloat32,
+              "hc_base must be float32");
+  TORCH_CHECK(post_mix.scalar_type() == torch::kFloat32,
+              "post_mix must be float32");
+  TORCH_CHECK(comb_mix.scalar_type() == torch::kFloat32,
+              "comb_mix must be float32");
+  TORCH_CHECK(layer_input.scalar_type() == torch::kBFloat16,
+              "layer_input must be bfloat16");
+
+  TORCH_CHECK(residual.dim() == 3, "residual must have shape [T, 4, H]");
+  TORCH_CHECK(residual.size(1) == kHcMult, "residual hc dimension must be 4");
+  TORCH_CHECK(fn.dim() == 2, "fn must have shape [24, 4 * H]");
+  TORCH_CHECK(fn.size(0) == kMixCount, "fn first dimension must be 24");
+  TORCH_CHECK(fn.size(1) == residual.size(1) * residual.size(2),
+              "fn second dimension must equal 4 * hidden_size");
+  TORCH_CHECK(hc_scale.sizes() == torch::IntArrayRef({3}),
+              "hc_scale must have shape [3]");
+  TORCH_CHECK(hc_base.sizes() == torch::IntArrayRef({kMixCount}),
+              "hc_base must have shape [24]");
+  TORCH_CHECK(post_mix.sizes() ==
+                  torch::IntArrayRef({residual.size(0), kHcMult}),
+              "post_mix must have shape [T, 4]");
+  TORCH_CHECK(comb_mix.sizes() ==
+                  torch::IntArrayRef({residual.size(0), kHcMult, kHcMult}),
+              "comb_mix must have shape [T, 4, 4]");
+  TORCH_CHECK(layer_input.sizes() ==
+                  torch::IntArrayRef({residual.size(0), residual.size(2)}),
+              "layer_input must have shape [T, H]");
+
+  TORCH_CHECK(residual.is_contiguous(), "residual must be contiguous");
+  TORCH_CHECK(fn.is_contiguous(), "fn must be contiguous");
+  TORCH_CHECK(hc_scale.is_contiguous(), "hc_scale must be contiguous");
+  TORCH_CHECK(hc_base.is_contiguous(), "hc_base must be contiguous");
+  TORCH_CHECK(post_mix.is_contiguous(), "post_mix must be contiguous");
+  TORCH_CHECK(comb_mix.is_contiguous(), "comb_mix must be contiguous");
+  TORCH_CHECK(layer_input.is_contiguous(), "layer_input must be contiguous");
+
+  if (residual.size(0) == 0) {
+    return;
+  }
+  TORCH_CHECK(sinkhorn_repeat >= 1, "sinkhorn_repeat must be >= 1");
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(residual));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  deepseek_v4_mhc_pre_kernel<<<residual.size(0), kThreads, 0, stream>>>(
+      static_cast<const __mt_bfloat16*>(residual.data_ptr()),
+      static_cast<const float*>(fn.data_ptr()),
+      static_cast<const float*>(hc_scale.data_ptr()),
+      static_cast<const float*>(hc_base.data_ptr()),
+      static_cast<float*>(post_mix.data_ptr()),
+      static_cast<float*>(comb_mix.data_ptr()),
+      static_cast<__mt_bfloat16*>(layer_input.data_ptr()), residual.size(0),
+      residual.size(2), static_cast<float>(rms_eps),
+      static_cast<float>(hc_pre_eps), static_cast<float>(hc_sinkhorn_eps),
+      static_cast<float>(hc_post_mult_value),
+      static_cast<int>(sinkhorn_repeat));
+
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess, "deepseek_v4_mhc_pre launch failed: ",
+              musaGetErrorString(err));
+}

--- a/csrc/musa/moe/deepseek_v4_topk_softplus_sqrt.mu
+++ b/csrc/musa/moe/deepseek_v4_topk_softplus_sqrt.mu
@@ -1,0 +1,357 @@
+#include <cmath>
+#include <cstdint>
+
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+namespace {
+
+constexpr int kIndexInt32 = 1;
+constexpr int kIndexInt64 = 2;
+
+__device__ __forceinline__ float load_scalar(const float* ptr,
+                                             int64_t offset) {
+  return ptr[offset];
+}
+
+__device__ __forceinline__ float load_scalar(const __half* ptr,
+                                             int64_t offset) {
+  return __half2float(ptr[offset]);
+}
+
+__device__ __forceinline__ float load_scalar(const __mt_bfloat16* ptr,
+                                             int64_t offset) {
+  return __bfloat162float(ptr[offset]);
+}
+
+__device__ __forceinline__ float sqrt_softplus(float x) {
+  const float softplus = x > 20.0f ? x : log1pf(expf(x));
+  return sqrtf(softplus);
+}
+
+__device__ __forceinline__ int64_t load_index(const void* ptr, int kind,
+                                              int64_t offset) {
+  if (kind == kIndexInt32) {
+    return static_cast<int64_t>(static_cast<const int32_t*>(ptr)[offset]);
+  }
+  return static_cast<const int64_t*>(ptr)[offset];
+}
+
+__device__ __forceinline__ void store_index(void* ptr, int kind,
+                                            int64_t offset, int64_t value) {
+  if (kind == kIndexInt32) {
+    static_cast<int32_t*>(ptr)[offset] = static_cast<int32_t>(value);
+  } else {
+    static_cast<int64_t*>(ptr)[offset] = value;
+  }
+}
+
+template <typename InputT>
+__global__ void deepseek_v4_topk_softplus_sqrt_kernel(
+    const InputT* __restrict__ gating_output, float* __restrict__ topk_weights,
+    void* __restrict__ topk_indices, int32_t* __restrict__ token_expert_indices,
+    const float* __restrict__ correction_bias, const void* __restrict__ input_ids,
+    const void* __restrict__ hash_indices_table, int topk_index_kind,
+    int input_index_kind, int hash_index_kind, int64_t num_tokens,
+    int64_t num_experts, int64_t topk, bool renormalize,
+    float routed_scaling_factor, int64_t gating_stride_m,
+    int64_t gating_stride_n, int64_t weights_stride_m,
+    int64_t weights_stride_k, int64_t indices_stride_m,
+    int64_t indices_stride_k, int64_t token_indices_stride_m,
+    int64_t token_indices_stride_k, int64_t hash_stride_m,
+    int64_t hash_stride_k) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x);
+  const int tid = threadIdx.x;
+  extern __shared__ float shared[];
+  float* scores = shared;
+  float* choice_scores = shared + num_experts;
+  float* reduce_values = choice_scores + num_experts;
+  int32_t* reduce_indices =
+      reinterpret_cast<int32_t*>(reduce_values + blockDim.x);
+
+  if (token >= num_tokens) {
+    return;
+  }
+
+  for (int64_t expert = tid; expert < num_experts; expert += blockDim.x) {
+    const int64_t offset = token * gating_stride_m + expert * gating_stride_n;
+    const float score = sqrt_softplus(load_scalar(gating_output, offset));
+    scores[expert] = score;
+    choice_scores[expert] =
+        correction_bias == nullptr ? score : score + correction_bias[expert];
+  }
+  __syncthreads();
+
+  float selected_sum = 0.0f;
+
+  if (hash_indices_table != nullptr) {
+    if (tid == 0) {
+      const int64_t token_id = load_index(input_ids, input_index_kind, token);
+      for (int64_t k_idx = 0; k_idx < topk; ++k_idx) {
+        const int64_t expert = load_index(hash_indices_table, hash_index_kind,
+                                          token_id * hash_stride_m +
+                                              k_idx * hash_stride_k);
+        const float score =
+            expert >= 0 && expert < num_experts ? scores[expert] : 0.0f;
+        const int64_t out_idx =
+            token * weights_stride_m + k_idx * weights_stride_k;
+        topk_weights[out_idx] = score;
+        store_index(topk_indices, topk_index_kind,
+                    token * indices_stride_m + k_idx * indices_stride_k, expert);
+        token_expert_indices[token * token_indices_stride_m +
+                             k_idx * token_indices_stride_k] =
+            static_cast<int32_t>(expert);
+        selected_sum += score;
+      }
+    }
+  } else {
+    for (int64_t k_idx = 0; k_idx < topk; ++k_idx) {
+      int32_t local_expert = -1;
+      float local_choice = -1.0e20f;
+      for (int64_t expert = tid; expert < num_experts; expert += blockDim.x) {
+        const float candidate = choice_scores[expert];
+        if (candidate > local_choice ||
+            (candidate == local_choice &&
+             (local_expert < 0 || expert < local_expert))) {
+          local_choice = candidate;
+          local_expert = static_cast<int32_t>(expert);
+        }
+      }
+      reduce_values[tid] = local_choice;
+      reduce_indices[tid] = local_expert;
+      __syncthreads();
+
+      for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+          const float other_choice = reduce_values[tid + stride];
+          const int32_t other_expert = reduce_indices[tid + stride];
+          const bool other_wins =
+              other_choice > reduce_values[tid] ||
+              (other_choice == reduce_values[tid] && other_expert >= 0 &&
+               (reduce_indices[tid] < 0 || other_expert < reduce_indices[tid]));
+          if (other_wins) {
+            reduce_values[tid] = other_choice;
+            reduce_indices[tid] = other_expert;
+          }
+        }
+        __syncthreads();
+      }
+
+      const int32_t best_expert = reduce_indices[0];
+
+      if (tid == 0) {
+        const float score = scores[best_expert];
+        const int64_t out_idx =
+            token * weights_stride_m + k_idx * weights_stride_k;
+        topk_weights[out_idx] = score;
+        store_index(topk_indices, topk_index_kind,
+                    token * indices_stride_m + k_idx * indices_stride_k,
+                    best_expert);
+        token_expert_indices[token * token_indices_stride_m +
+                             k_idx * token_indices_stride_k] = best_expert;
+        selected_sum += score;
+        choice_scores[best_expert] = -1.0e20f;
+      }
+      __syncthreads();
+    }
+  }
+
+  if (tid == 0) {
+    float scale = routed_scaling_factor;
+    if (renormalize) {
+      const float denom = selected_sum > 0.0f ? selected_sum : 1.0f;
+      scale /= denom;
+    }
+    if (scale != 1.0f) {
+      for (int64_t k_idx = 0; k_idx < topk; ++k_idx) {
+        const int64_t out_idx =
+            token * weights_stride_m + k_idx * weights_stride_k;
+        topk_weights[out_idx] *= scale;
+      }
+    }
+  }
+}
+
+void check_musa_tensor(const torch::Tensor& tensor, const char* name) {
+  TORCH_CHECK(tensor.device().is_privateuseone(), name,
+              " must be a MUSA tensor");
+}
+
+int index_kind(const torch::Tensor& tensor, const char* name) {
+  if (tensor.scalar_type() == torch::kInt32) {
+    return kIndexInt32;
+  }
+  if (tensor.scalar_type() == torch::kInt64) {
+    return kIndexInt64;
+  }
+  TORCH_CHECK(false, name, " must be int32 or int64");
+}
+
+int choose_threads(int64_t num_experts) {
+  if (num_experts <= 64) {
+    return 64;
+  }
+  if (num_experts <= 128) {
+    return 128;
+  }
+  if (num_experts <= 256) {
+    return 256;
+  }
+  if (num_experts <= 512) {
+    return 512;
+  }
+  return 1024;
+}
+
+template <typename InputT>
+void launch_deepseek_v4_topk_softplus_sqrt(
+    const torch::Tensor& gating_output, torch::Tensor& topk_weights,
+    torch::Tensor& topk_indices, torch::Tensor& token_expert_indices,
+    bool renormalize, double routed_scaling_factor,
+    const c10::optional<torch::Tensor>& correction_bias,
+    const c10::optional<torch::Tensor>& input_ids,
+    const c10::optional<torch::Tensor>& hash_indices_table,
+    musaStream_t stream) {
+  const int64_t num_tokens = gating_output.size(0);
+  const int64_t num_experts = gating_output.size(1);
+  const int64_t topk = topk_weights.size(1);
+  const int threads = choose_threads(num_experts);
+  const size_t shared_bytes =
+      static_cast<size_t>(num_experts) * 2 * sizeof(float) +
+      static_cast<size_t>(threads) * (sizeof(float) + sizeof(int32_t));
+  const float* bias_ptr =
+      correction_bias.has_value() ? correction_bias.value().data_ptr<float>()
+                                  : nullptr;
+  const void* input_ids_ptr =
+      input_ids.has_value() ? input_ids.value().data_ptr() : nullptr;
+  const void* hash_table_ptr = hash_indices_table.has_value()
+                                   ? hash_indices_table.value().data_ptr()
+                                   : nullptr;
+  const int input_index_kind =
+      input_ids.has_value() ? index_kind(input_ids.value(), "input_ids")
+                            : kIndexInt32;
+  const int hash_index_kind = hash_indices_table.has_value()
+                                  ? index_kind(hash_indices_table.value(),
+                                               "hash_indices_table")
+                                  : kIndexInt32;
+  const int64_t hash_stride_m =
+      hash_indices_table.has_value() ? hash_indices_table.value().stride(0) : 0;
+  const int64_t hash_stride_k =
+      hash_indices_table.has_value() ? hash_indices_table.value().stride(1) : 0;
+
+  deepseek_v4_topk_softplus_sqrt_kernel<InputT>
+      <<<static_cast<unsigned int>(num_tokens), threads, shared_bytes, stream>>>(
+          reinterpret_cast<const InputT*>(gating_output.data_ptr()),
+          topk_weights.data_ptr<float>(), topk_indices.data_ptr(),
+          token_expert_indices.data_ptr<int32_t>(), bias_ptr, input_ids_ptr,
+          hash_table_ptr, index_kind(topk_indices, "topk_indices"),
+          input_index_kind, hash_index_kind, num_tokens, num_experts, topk,
+          renormalize, static_cast<float>(routed_scaling_factor),
+          gating_output.stride(0), gating_output.stride(1),
+          topk_weights.stride(0), topk_weights.stride(1),
+          topk_indices.stride(0), topk_indices.stride(1),
+          token_expert_indices.stride(0), token_expert_indices.stride(1),
+          hash_stride_m, hash_stride_k);
+}
+
+}  // namespace
+
+void deepseek_v4_topk_softplus_sqrt(
+    torch::Tensor& topk_weights, torch::Tensor& topk_indices,
+    torch::Tensor& token_expert_indices, const torch::Tensor& gating_output,
+    bool renormalize, double routed_scaling_factor,
+    const c10::optional<torch::Tensor>& correction_bias,
+    const c10::optional<torch::Tensor>& input_ids,
+    const c10::optional<torch::Tensor>& hash_indices_table) {
+  check_musa_tensor(topk_weights, "topk_weights");
+  check_musa_tensor(topk_indices, "topk_indices");
+  check_musa_tensor(token_expert_indices, "token_expert_indices");
+  check_musa_tensor(gating_output, "gating_output");
+  TORCH_CHECK(gating_output.dim() == 2,
+              "gating_output must have shape [num_tokens, num_experts]");
+  TORCH_CHECK(topk_weights.dim() == 2 && topk_indices.dim() == 2 &&
+                  token_expert_indices.dim() == 2,
+              "topk outputs must have shape [num_tokens, topk]");
+  TORCH_CHECK(topk_weights.sizes() == topk_indices.sizes() &&
+                  topk_weights.sizes() == token_expert_indices.sizes(),
+              "topk output tensors must have matching shapes");
+  TORCH_CHECK(topk_weights.size(0) == gating_output.size(0),
+              "topk output row count must match gating_output");
+  TORCH_CHECK(topk_weights.scalar_type() == torch::kFloat32,
+              "topk_weights must be float32");
+  TORCH_CHECK(token_expert_indices.scalar_type() == torch::kInt32,
+              "token_expert_indices must be int32");
+  index_kind(topk_indices, "topk_indices");
+  TORCH_CHECK(gating_output.size(1) > 0 && gating_output.size(1) <= 1024,
+              "deepseek_v4_topk_softplus_sqrt supports 1..1024 experts");
+  TORCH_CHECK(topk_weights.size(1) > 0 && topk_weights.size(1) <= 64,
+              "deepseek_v4_topk_softplus_sqrt supports topk in 1..64");
+  TORCH_CHECK(topk_weights.device() == gating_output.device() &&
+                  topk_indices.device() == gating_output.device() &&
+                  token_expert_indices.device() == gating_output.device(),
+              "all tensors must be on the same device");
+
+  if (correction_bias.has_value()) {
+    check_musa_tensor(correction_bias.value(), "correction_bias");
+    TORCH_CHECK(correction_bias.value().scalar_type() == torch::kFloat32,
+                "correction_bias must be float32");
+    TORCH_CHECK(correction_bias.value().dim() == 1 &&
+                    correction_bias.value().size(0) == gating_output.size(1),
+                "correction_bias must have shape [num_experts]");
+    TORCH_CHECK(correction_bias.value().is_contiguous(),
+                "correction_bias must be contiguous");
+  }
+
+  if (hash_indices_table.has_value()) {
+    check_musa_tensor(hash_indices_table.value(), "hash_indices_table");
+    TORCH_CHECK(input_ids.has_value(),
+                "input_ids is required when hash_indices_table is provided");
+    check_musa_tensor(input_ids.value(), "input_ids");
+    index_kind(hash_indices_table.value(), "hash_indices_table");
+    index_kind(input_ids.value(), "input_ids");
+    TORCH_CHECK(input_ids.value().dim() == 1 &&
+                    input_ids.value().size(0) == gating_output.size(0),
+                "input_ids must have shape [num_tokens]");
+    TORCH_CHECK(hash_indices_table.value().dim() == 2 &&
+                    hash_indices_table.value().size(1) >= topk_weights.size(1),
+                "hash_indices_table must have shape [vocab_size, >=topk]");
+  }
+
+  if (gating_output.numel() == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(gating_output));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+  if (gating_output.scalar_type() == torch::kFloat32) {
+    launch_deepseek_v4_topk_softplus_sqrt<float>(
+        gating_output, topk_weights, topk_indices, token_expert_indices,
+        renormalize, routed_scaling_factor, correction_bias, input_ids,
+        hash_indices_table, stream);
+  } else if (gating_output.scalar_type() == torch::kFloat16) {
+    launch_deepseek_v4_topk_softplus_sqrt<__half>(
+        gating_output, topk_weights, topk_indices, token_expert_indices,
+        renormalize, routed_scaling_factor, correction_bias, input_ids,
+        hash_indices_table, stream);
+  } else if (gating_output.scalar_type() == torch::kBFloat16) {
+    launch_deepseek_v4_topk_softplus_sqrt<__mt_bfloat16>(
+        gating_output, topk_weights, topk_indices, token_expert_indices,
+        renormalize, routed_scaling_factor, correction_bias, input_ids,
+        hash_indices_table, stream);
+  } else {
+    TORCH_CHECK(false, "Unsupported gating_output data type: ",
+                gating_output.scalar_type());
+  }
+
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "deepseek_v4_topk_softplus_sqrt launch failed: ",
+              musaGetErrorString(err));
+}

--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -1,4 +1,5 @@
 #include <optional>
+#include <tuple>
 #include <torch/library.h>
 
 #include "core/scalar_type.hpp"
@@ -86,3 +87,78 @@ void top_p_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
 
 void top_k_renorm_probs(at::Tensor probs, at::Tensor renorm_probs,
                         std::optional<at::Tensor> maybe_top_k_arr, int64_t top_k_val);
+
+void deepseek_v4_store_sparse_kv(
+    const torch::Tensor& normed,
+    torch::Tensor& kv_cache,
+    const torch::Tensor& slot_mapping,
+    const torch::Tensor& write_mask);
+void deepseek_v4_qnorm_rope_kv_insert(
+    torch::Tensor& q,
+    const torch::Tensor& kv,
+    torch::Tensor& kv_cache,
+    const torch::Tensor& slot_mapping,
+    const torch::Tensor& positions,
+    const torch::Tensor& cos_sin_cache,
+    double eps,
+    int64_t cache_block_size);
+std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_q_kv_rmsnorm(
+    const torch::Tensor& q,
+    const torch::Tensor& kv,
+    const torch::Tensor& q_weight,
+    const torch::Tensor& kv_weight,
+    double eps);
+void deepseek_v4_dequantize_and_gather_k_cache(
+    torch::Tensor &out, const torch::Tensor &k_cache,
+    const torch::Tensor &seq_lens,
+    const c10::optional<torch::Tensor> &gather_lens,
+    const torch::Tensor &block_table, int64_t block_size, int64_t offset);
+std::tuple<torch::Tensor, torch::Tensor>
+deepseek_v4_compute_global_topk_indices_and_lens(
+    const torch::Tensor &topk_indices,
+    const torch::Tensor &token_to_req_indices, const torch::Tensor &block_table,
+    int64_t block_size, const torch::Tensor &is_valid_token);
+std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_combine_topk_swa_indices(
+    const torch::Tensor &topk_indices, const torch::Tensor &query_start_loc,
+    const torch::Tensor &seq_lens, const torch::Tensor &gather_lens,
+    int64_t window_size, int64_t compress_ratio, int64_t topk, int64_t M,
+    int64_t N);
+void deepseek_v4_indexer_topk_decode(
+    const torch::Tensor &q_quant, const torch::Tensor &kv_cache,
+    const torch::Tensor &weights, const torch::Tensor &seq_lens,
+    const torch::Tensor &block_table, torch::Tensor &topk_indices,
+    int64_t topk);
+void deepseek_v4_indexer_topk_prefill(
+    const torch::Tensor &q_quant, const torch::Tensor &kv_cache,
+    const torch::Tensor &weights, const torch::Tensor &block_table,
+    const torch::Tensor &cu_seq_lens, const torch::Tensor &token_to_seq,
+    const torch::Tensor &cu_seqlen_ks, const torch::Tensor &cu_seqlen_ke,
+    torch::Tensor &topk_indices, int64_t topk);
+std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_sparse_flashmla_decode(
+    const torch::Tensor &q, const torch::Tensor &k_cache,
+    const torch::Tensor &indices,
+    const c10::optional<torch::Tensor> &topk_length,
+    const c10::optional<torch::Tensor> &attn_sink,
+    const c10::optional<torch::Tensor> &extra_k_cache,
+    const c10::optional<torch::Tensor> &extra_indices,
+    const c10::optional<torch::Tensor> &extra_topk_length, torch::Tensor &out,
+    double softmax_scale);
+std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_inv_rope_fp8_quant(
+    const torch::Tensor &o, const torch::Tensor &positions,
+    const torch::Tensor &cos_sin_cache, int64_t n_groups,
+    int64_t heads_per_group, int64_t nope_dim, int64_t rope_dim,
+    int64_t quant_group_size, bool tma_aligned_scales);
+void deepseek_v4_topk_softplus_sqrt(
+    torch::Tensor &topk_weights, torch::Tensor &topk_indices,
+    torch::Tensor &token_expert_indices, const torch::Tensor &gating_output,
+    bool renormalize, double routed_scaling_factor,
+    const c10::optional<torch::Tensor> &correction_bias,
+    const c10::optional<torch::Tensor> &input_ids,
+    const c10::optional<torch::Tensor> &hash_indices_table);
+void deepseek_v4_mhc_pre(
+    const torch::Tensor &residual, const torch::Tensor &fn,
+    const torch::Tensor &hc_scale, const torch::Tensor &hc_base,
+    torch::Tensor &post_mix, torch::Tensor &comb_mix,
+    torch::Tensor &layer_input, double rms_eps, double hc_pre_eps,
+    double hc_sinkhorn_eps, double hc_post_mult_value,
+    int64_t sinkhorn_repeat);

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -74,6 +74,96 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
       "top_p_sampling_from_probs(Tensor probs, Tensor! output, Tensor? maybe_indices, Tensor? maybe_top_p_arr, "
       "float top_p_val, bool deterministic, Generator? gen) -> ()");
   musa_ops.impl("top_p_sampling_from_probs", torch::kMUSA, &top_p_sampling_from_probs);
+
+  musa_ops.def(
+      "deepseek_v4_store_sparse_kv(Tensor normed, Tensor! kv_cache, "
+      "Tensor slot_mapping, Tensor write_mask) -> ()");
+  musa_ops.impl("deepseek_v4_store_sparse_kv", torch::kMUSA,
+                &deepseek_v4_store_sparse_kv);
+
+  musa_ops.def(
+      "deepseek_v4_qnorm_rope_kv_insert(Tensor! q, Tensor kv, "
+      "Tensor! kv_cache, Tensor slot_mapping, Tensor positions, "
+      "Tensor cos_sin_cache, float eps, int cache_block_size) -> ()");
+  musa_ops.impl("deepseek_v4_qnorm_rope_kv_insert", torch::kMUSA,
+                &deepseek_v4_qnorm_rope_kv_insert);
+
+  musa_ops.def(
+      "deepseek_v4_fused_q_kv_rmsnorm(Tensor q, Tensor kv, Tensor q_weight, "
+      "Tensor kv_weight, float eps) -> (Tensor, Tensor)");
+  musa_ops.impl("deepseek_v4_fused_q_kv_rmsnorm", torch::kMUSA,
+                &deepseek_v4_fused_q_kv_rmsnorm);
+
+  musa_ops.def(
+      "deepseek_v4_dequantize_and_gather_k_cache(Tensor! out, Tensor k_cache, "
+      "Tensor seq_lens, Tensor? gather_lens, Tensor block_table, int "
+      "block_size, int offset) -> ()");
+  musa_ops.impl("deepseek_v4_dequantize_and_gather_k_cache", torch::kMUSA,
+                &deepseek_v4_dequantize_and_gather_k_cache);
+
+  musa_ops.def(
+      "deepseek_v4_compute_global_topk_indices_and_lens(Tensor topk_indices, "
+      "Tensor token_to_req_indices, Tensor block_table, int block_size, "
+      "Tensor is_valid_token) -> (Tensor, Tensor)");
+  musa_ops.impl("deepseek_v4_compute_global_topk_indices_and_lens",
+                torch::kMUSA,
+                &deepseek_v4_compute_global_topk_indices_and_lens);
+
+  musa_ops.def(
+      "deepseek_v4_combine_topk_swa_indices(Tensor topk_indices, Tensor "
+      "query_start_loc, Tensor seq_lens, Tensor gather_lens, int window_size, "
+      "int compress_ratio, int topk, int M, int N) -> (Tensor, Tensor)");
+  musa_ops.impl("deepseek_v4_combine_topk_swa_indices", torch::kMUSA,
+                &deepseek_v4_combine_topk_swa_indices);
+
+  musa_ops.def(
+      "deepseek_v4_indexer_topk_decode(Tensor q_quant, Tensor kv_cache, "
+      "Tensor weights, Tensor seq_lens, Tensor block_table, Tensor! "
+      "topk_indices, int topk) -> ()");
+  musa_ops.impl("deepseek_v4_indexer_topk_decode", torch::kMUSA,
+                &deepseek_v4_indexer_topk_decode);
+
+  musa_ops.def(
+      "deepseek_v4_indexer_topk_prefill(Tensor q_quant, Tensor kv_cache, "
+      "Tensor weights, Tensor block_table, Tensor cu_seq_lens, Tensor "
+      "token_to_seq, Tensor cu_seqlen_ks, Tensor cu_seqlen_ke, Tensor! "
+      "topk_indices, int topk) -> ()");
+  musa_ops.impl("deepseek_v4_indexer_topk_prefill", torch::kMUSA,
+                &deepseek_v4_indexer_topk_prefill);
+
+  musa_ops.def(
+      "deepseek_v4_sparse_flashmla_decode(Tensor q, Tensor k_cache, "
+      "Tensor indices, Tensor? topk_length, Tensor? attn_sink, "
+      "Tensor? extra_k_cache, Tensor? extra_indices, Tensor? "
+      "extra_topk_length, Tensor! out, float softmax_scale) -> "
+      "(Tensor, Tensor)");
+  musa_ops.impl("deepseek_v4_sparse_flashmla_decode", torch::kMUSA,
+                &deepseek_v4_sparse_flashmla_decode);
+
+  musa_ops.def(
+      "deepseek_v4_fused_inv_rope_fp8_quant(Tensor o, Tensor positions, "
+      "Tensor cos_sin_cache, int n_groups, int heads_per_group, int nope_dim, "
+      "int rope_dim, int quant_group_size, bool tma_aligned_scales) -> "
+      "(Tensor, Tensor)");
+  musa_ops.impl("deepseek_v4_fused_inv_rope_fp8_quant", torch::kMUSA,
+                &deepseek_v4_fused_inv_rope_fp8_quant);
+
+  musa_ops.def(
+      "deepseek_v4_topk_softplus_sqrt(Tensor! topk_weights, Tensor! "
+      "topk_indices, Tensor! token_expert_indices, Tensor gating_output, bool "
+      "renormalize, float routed_scaling_factor, Tensor? correction_bias, "
+      "Tensor? input_ids, Tensor? hash_indices_table) -> ()");
+  musa_ops.impl("deepseek_v4_topk_softplus_sqrt", torch::kMUSA,
+                &deepseek_v4_topk_softplus_sqrt);
+
+  musa_ops.def(
+      "deepseek_v4_mhc_pre(Tensor residual, Tensor fn, Tensor hc_scale, "
+      "Tensor hc_base, Tensor! post_mix, Tensor! comb_mix, Tensor! "
+      "layer_input, float rms_eps, float hc_pre_eps, float hc_sinkhorn_eps, "
+      "float hc_post_mult_value, int sinkhorn_repeat) -> ()");
+  musa_ops.impl("deepseek_v4_mhc_pre", torch::kMUSA,
+                &deepseek_v4_mhc_pre);
+
 #endif
 }
 

--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,14 @@ VLLM_MUSA_CSRC_SOURCES = [
     "csrc/musa/gemv.mu",
     "csrc/musa/fused_add_rmsnorm.mu",
     "csrc/musa/cache_kernels.mu",
+    "csrc/musa/attention/deepseek_v4_cache_store.mu",
+    "csrc/musa/attention/deepseek_v4_fused_qkv_rmsnorm.mu",
+    "csrc/musa/attention/deepseek_v4_cache_utils.mu",
+    "csrc/musa/attention/deepseek_v4_indexer_topk.mu",
+    "csrc/musa/attention/deepseek_v4_sparse_flashmla.mu",
+    "csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu",
+    "csrc/musa/mhc/deepseek_v4_mhc_pre.mu",
+    "csrc/musa/moe/deepseek_v4_topk_softplus_sqrt.mu",
     # XXX (MUSA): The version used here is vllm 0.18.0, located at csrc/quantization/w8a8/fp8.
     # While in version 0.20.0, the path has changed to csrc/libtorch_stable/quantization/w8a8/fp8,
     # and depends on two header file from PyTorch 2.11's torch/headeronly/core/ScalarType.h and
@@ -245,12 +253,10 @@ CSRC_TEXT_PATCHES = {
         # invoking it on MUSA would error at dispatch time, which is fine
         # because MUSA code paths never call paged_attention.
         {
-            '  ops.impl("paged_attention_v1", torch::kCUDA, &paged_attention_v1);':
-            '  // MUSA-0203: paged_attention_v1 impl stripped (kernel not built on MUSA)',
+            '  ops.impl("paged_attention_v1", torch::kCUDA, &paged_attention_v1);': "  // MUSA-0203: paged_attention_v1 impl stripped (kernel not built on MUSA)",
         },
         {
-            '  ops.impl("paged_attention_v2", torch::kCUDA, &paged_attention_v2);':
-            '  // MUSA-0203: paged_attention_v2 impl stripped (kernel not built on MUSA)',
+            '  ops.impl("paged_attention_v2", torch::kCUDA, &paged_attention_v2);': "  // MUSA-0203: paged_attention_v2 impl stripped (kernel not built on MUSA)",
         },
     ],
     str(_VLLM_REPO.source_dir / "csrc/quantization/w8a8/fp8/nvidia/quant_utils.cuh"): [
@@ -430,8 +436,10 @@ if mcc_version:
             # VLLM_MUSA_DISABLE_LOAD_CLUSTER=1.
             if os.environ.get("VLLM_MUSA_DISABLE_LOAD_CLUSTER", "0") != "1":
                 MCC_FLAGS += [
-                    "-mllvm", "-mtgpu-load-cluster-mutation=1",
-                    "-mllvm", "--num-dwords-of-load-in-mutation=64",
+                    "-mllvm",
+                    "-mtgpu-load-cluster-mutation=1",
+                    "-mllvm",
+                    "--num-dwords-of-load-in-mutation=64",
                 ]
     except Exception as e:
         print(

--- a/tests/jit_kernel/benchmark_rope.py
+++ b/tests/jit_kernel/benchmark_rope.py
@@ -16,18 +16,16 @@ import time
 from dataclasses import dataclass
 from typing import Callable
 
+import torch
+
 # torchada redirects torch.cuda symbols to MUSA. Keep this import first.
 import torchada  # noqa: F401
-
-import torch
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
 
 # Register the vllm-musa platform hooks and torch.ops.vllm.musa_rotary_embedding.
 import vllm_musa  # noqa: F401
 from vllm_musa.jit_kernel.csrc import rope as _rope_module  # noqa: F401
-
-from vllm.config import VllmConfig, set_current_vllm_config
-from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
-
 
 _VLLM_CFG = VllmConfig()
 _VLLM_CFG_CM = set_current_vllm_config(_VLLM_CFG)
@@ -201,8 +199,8 @@ def bench_shape(
     if check_correctness:
         assert_close(shape, rope, positions, query, key)
 
-    shape_warmup = warmup if warmup is not None else default_warmup(
-        shape.num_tokens, quick
+    shape_warmup = (
+        warmup if warmup is not None else default_warmup(shape.num_tokens, quick)
     )
     shape_iters = iters if iters is not None else default_iters(shape.num_tokens, quick)
 
@@ -228,9 +226,7 @@ def bench_shape(
     native_event_us, native_wall_us = measure(
         run_native, warmup=shape_warmup, iters=shape_iters
     )
-    jit_event_us, jit_wall_us = measure(
-        run_jit, warmup=shape_warmup, iters=shape_iters
-    )
+    jit_event_us, jit_wall_us = measure(run_jit, warmup=shape_warmup, iters=shape_iters)
 
     native = BenchResult(
         shape.label,
@@ -315,7 +311,9 @@ def main() -> int:
         return 1
 
     shape_filter = parse_shape_filter(args.shapes)
-    unknown = shape_filter - {shape.label for shape in SHAPES} if shape_filter else set()
+    unknown = (
+        shape_filter - {shape.label for shape in SHAPES} if shape_filter else set()
+    )
     if unknown:
         print(f"FAIL unknown shape label(s): {', '.join(sorted(unknown))}")
         return 1

--- a/tests/jit_kernel/test_rope.py
+++ b/tests/jit_kernel/test_rope.py
@@ -21,26 +21,23 @@ Run on the authorized MUSA container (TP=1 / single rank to isolate
 from any distributed-side effects).
 """
 
-import math
-import os
 import sys
 import traceback
 from dataclasses import dataclass
 
+import torch
+
 # torchada redirects torch.cuda symbols to MUSA — must be first.
 import torchada  # noqa: F401
-
-import torch
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
 
 # Plug into vllm_musa so torch.ops.vllm.musa_rotary_embedding is registered
 # and the MusaRotaryEmbedding OOT class is registered.
 import vllm_musa  # noqa: F401
+
 # Explicit import: register `torch.ops.vllm.musa_rotary_embedding`.
 from vllm_musa.jit_kernel.csrc import rope as _rope_module  # noqa: F401
-
-from vllm.config import VllmConfig, set_current_vllm_config
-from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
-
 
 # RotaryEmbedding.__init__ -> CustomOp.__init__ -> dispatch_forward() reads the
 # current vllm config. We enter set_current_vllm_config() inside main() (NOT at
@@ -49,6 +46,7 @@ from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
 
 
 # ---- shape matrix ----------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class Shape:
@@ -66,36 +64,87 @@ class Shape:
 # in MUSA-0202 / MUSA-0203 testing on yeahdongcn70.
 SHAPES = [
     # Eagle3 draft, the failing case at TP=8 + captured chain
-    Shape("eagle3_draft_tp8_decode", num_heads_per_rank=3, num_kv_heads_per_rank=1,
-          head_dim=128, rotary_dim=128, num_tokens=1),
-    Shape("eagle3_draft_tp8_chain8", num_heads_per_rank=3, num_kv_heads_per_rank=1,
-          head_dim=128, rotary_dim=128, num_tokens=8),
-
+    Shape(
+        "eagle3_draft_tp8_decode",
+        num_heads_per_rank=3,
+        num_kv_heads_per_rank=1,
+        head_dim=128,
+        rotary_dim=128,
+        num_tokens=1,
+    ),
+    Shape(
+        "eagle3_draft_tp8_chain8",
+        num_heads_per_rank=3,
+        num_kv_heads_per_rank=1,
+        head_dim=128,
+        rotary_dim=128,
+        num_tokens=8,
+    ),
     # M2.5 target at TP=8
-    Shape("m25_target_tp8_decode", num_heads_per_rank=6, num_kv_heads_per_rank=1,
-          head_dim=128, rotary_dim=128, num_tokens=1),
-    Shape("m25_target_tp8_prefill", num_heads_per_rank=6, num_kv_heads_per_rank=1,
-          head_dim=128, rotary_dim=128, num_tokens=4096),
-
+    Shape(
+        "m25_target_tp8_decode",
+        num_heads_per_rank=6,
+        num_kv_heads_per_rank=1,
+        head_dim=128,
+        rotary_dim=128,
+        num_tokens=1,
+    ),
+    Shape(
+        "m25_target_tp8_prefill",
+        num_heads_per_rank=6,
+        num_kv_heads_per_rank=1,
+        head_dim=128,
+        rotary_dim=128,
+        num_tokens=4096,
+    ),
     # Qwen3-8B-FP8 at TP=8 (known-working control)
-    Shape("qwen3_8b_tp8_decode", num_heads_per_rank=4, num_kv_heads_per_rank=1,
-          head_dim=128, rotary_dim=128, num_tokens=1),
-    Shape("qwen3_8b_tp8_prefill", num_heads_per_rank=4, num_kv_heads_per_rank=1,
-          head_dim=128, rotary_dim=128, num_tokens=1024),
-
+    Shape(
+        "qwen3_8b_tp8_decode",
+        num_heads_per_rank=4,
+        num_kv_heads_per_rank=1,
+        head_dim=128,
+        rotary_dim=128,
+        num_tokens=1,
+    ),
+    Shape(
+        "qwen3_8b_tp8_prefill",
+        num_heads_per_rank=4,
+        num_kv_heads_per_rank=1,
+        head_dim=128,
+        rotary_dim=128,
+        num_tokens=1024,
+    ),
     # Qwen3-30B-A3B-FP8 at TP=2 (known-working control)
-    Shape("qwen3_30b_tp2_decode", num_heads_per_rank=16, num_kv_heads_per_rank=4,
-          head_dim=128, rotary_dim=128, num_tokens=1),
-
+    Shape(
+        "qwen3_30b_tp2_decode",
+        num_heads_per_rank=16,
+        num_kv_heads_per_rank=4,
+        head_dim=128,
+        rotary_dim=128,
+        num_tokens=1,
+    ),
     # Edge: smallest possible num_heads (boundary case)
-    Shape("min_heads_1_decode", num_heads_per_rank=1, num_kv_heads_per_rank=1,
-          head_dim=128, rotary_dim=128, num_tokens=1),
-    Shape("min_heads_2_decode", num_heads_per_rank=2, num_kv_heads_per_rank=1,
-          head_dim=128, rotary_dim=128, num_tokens=1),
+    Shape(
+        "min_heads_1_decode",
+        num_heads_per_rank=1,
+        num_kv_heads_per_rank=1,
+        head_dim=128,
+        rotary_dim=128,
+        num_tokens=1,
+    ),
+    Shape(
+        "min_heads_2_decode",
+        num_heads_per_rank=2,
+        num_kv_heads_per_rank=1,
+        head_dim=128,
+        rotary_dim=128,
+        num_tokens=1,
+    ),
 ]
 
 
 # ---- harness ---------------------------------------------------------------
+
 
 def make_inputs(shape: Shape, max_pos: int = 8192, device: str = "cuda"):
     """Returns (positions, query, key, cos_sin_cache, jit_module).
@@ -105,14 +154,19 @@ def make_inputs(shape: Shape, max_pos: int = 8192, device: str = "cuda"):
     doesn't contaminate the reference.
     """
     torch.manual_seed(0)
-    positions = torch.arange(shape.num_tokens, dtype=torch.int64,
-                              device=device)
-    query = torch.randn(shape.num_tokens,
-                         shape.num_heads_per_rank * shape.head_dim,
-                         dtype=shape.dtype, device=device)
-    key = torch.randn(shape.num_tokens,
-                       shape.num_kv_heads_per_rank * shape.head_dim,
-                       dtype=shape.dtype, device=device)
+    positions = torch.arange(shape.num_tokens, dtype=torch.int64, device=device)
+    query = torch.randn(
+        shape.num_tokens,
+        shape.num_heads_per_rank * shape.head_dim,
+        dtype=shape.dtype,
+        device=device,
+    )
+    key = torch.randn(
+        shape.num_tokens,
+        shape.num_kv_heads_per_rank * shape.head_dim,
+        dtype=shape.dtype,
+        device=device,
+    )
 
     # Build a RotaryEmbedding to inherit its forward_native + cache shape.
     rope = RotaryEmbedding(
@@ -137,8 +191,13 @@ def eager_native(rope, positions, query, key):
     q = query.clone()
     k = key.clone()
     out_q, out_k = RotaryEmbedding.forward_static(
-        positions, q, k,
-        rope.head_size, rope.rotary_dim, rope.cos_sin_cache, rope.is_neox_style,
+        positions,
+        q,
+        k,
+        rope.head_size,
+        rope.rotary_dim,
+        rope.cos_sin_cache,
+        rope.is_neox_style,
     )
     return out_q, out_k
 
@@ -149,19 +208,21 @@ def eager_jit(positions, query, key, head_size, cos_sin_cache, is_neox):
     k = key.clone()
     # Match dtype / device of cos_sin_cache to query (the wrapper does this).
     csc = cos_sin_cache.to(query.device, dtype=query.dtype)
-    torch.ops.vllm.musa_rotary_embedding(
-        positions, q, k, head_size, csc, is_neox
-    )
+    torch.ops.vllm.musa_rotary_embedding(positions, q, k, head_size, csc, is_neox)
     return q, k
 
 
 def compare(label: str, kind: str, q_ref, k_ref, q_test, k_test, atol=1e-2, rtol=1e-2):
     """Compare two (q, k) outputs and print a single PASS/FAIL line."""
     if q_test.shape != q_ref.shape:
-        print(f"FAIL {label} {kind} SHAPE_MISMATCH q_ref={q_ref.shape} q_test={q_test.shape}")
+        print(
+            f"FAIL {label} {kind} SHAPE_MISMATCH q_ref={q_ref.shape} q_test={q_test.shape}"
+        )
         return False
     if k_test.shape != k_ref.shape:
-        print(f"FAIL {label} {kind} SHAPE_MISMATCH k_ref={k_ref.shape} k_test={k_test.shape}")
+        print(
+            f"FAIL {label} {kind} SHAPE_MISMATCH k_ref={k_ref.shape} k_test={k_test.shape}"
+        )
         return False
     q_close = torch.allclose(q_ref.float(), q_test.float(), atol=atol, rtol=rtol)
     k_close = torch.allclose(k_ref.float(), k_test.float(), atol=atol, rtol=rtol)
@@ -171,8 +232,10 @@ def compare(label: str, kind: str, q_ref, k_ref, q_test, k_test, atol=1e-2, rtol
         print(f"PASS {label} {kind} q_max_diff={q_max:.4e} k_max_diff={k_max:.4e}")
         return True
     else:
-        print(f"FAIL {label} {kind} q_close={q_close} k_close={k_close} "
-              f"q_max_diff={q_max:.4e} k_max_diff={k_max:.4e}")
+        print(
+            f"FAIL {label} {kind} q_close={q_close} k_close={k_close} "
+            f"q_max_diff={q_max:.4e} k_max_diff={k_max:.4e}"
+        )
         return False
 
 
@@ -182,8 +245,12 @@ def check_eager_parity(shape: Shape) -> bool:
         positions, query, key, rope = make_inputs(shape)
         q_native, k_native = eager_native(rope, positions, query, key)
         q_jit, k_jit = eager_jit(
-            positions, query, key, shape.head_dim,
-            rope.cos_sin_cache, shape.is_neox,
+            positions,
+            query,
+            key,
+            shape.head_dim,
+            rope.cos_sin_cache,
+            shape.is_neox,
         )
         return compare(shape.label, "EAGER", q_native, k_native, q_jit, k_jit)
     except Exception as e:
@@ -226,7 +293,12 @@ def check_captured_jit_parity(shape: Shape) -> bool:
 
         def fn():
             torch.ops.vllm.musa_rotary_embedding(
-                positions, q_buf, k_buf, shape.head_dim, csc, shape.is_neox,
+                positions,
+                q_buf,
+                k_buf,
+                shape.head_dim,
+                csc,
+                shape.is_neox,
             )
 
         # Reset buffers, capture + replay.
@@ -272,7 +344,12 @@ def check_multi_replay(shape: Shape, n_replays: int = 32) -> bool:
 
         def fn():
             torch.ops.vllm.musa_rotary_embedding(
-                positions, q_buf, k_buf, shape.head_dim, csc, shape.is_neox,
+                positions,
+                q_buf,
+                k_buf,
+                shape.head_dim,
+                csc,
+                shape.is_neox,
             )
 
         # Capture
@@ -311,6 +388,7 @@ def check_multi_replay(shape: Shape, n_replays: int = 32) -> bool:
 
 # ---- main ------------------------------------------------------------------
 
+
 def main() -> int:
     if not torch.musa.is_available():
         print("FAIL no MUSA device available")
@@ -323,9 +401,11 @@ def main() -> int:
 
     results = []
     for shape in SHAPES:
-        print(f"--- {shape.label}  (q={shape.num_heads_per_rank}, "
-              f"kv={shape.num_kv_heads_per_rank}, head_dim={shape.head_dim}, "
-              f"rot_dim={shape.rotary_dim}, n_tok={shape.num_tokens}) ---")
+        print(
+            f"--- {shape.label}  (q={shape.num_heads_per_rank}, "
+            f"kv={shape.num_kv_heads_per_rank}, head_dim={shape.head_dim}, "
+            f"rot_dim={shape.rotary_dim}, n_tok={shape.num_tokens}) ---"
+        )
         r1 = check_eager_parity(shape)
         r2 = check_captured_jit_parity(shape)
         r3 = check_multi_replay(shape, n_replays=32)
@@ -335,9 +415,11 @@ def main() -> int:
     print(f"{'shape':<35} {'EAGER':>6} {'CAPTURED':>9} {'MULTI':>7}")
     fails = 0
     for label, r1, r2, r3 in results:
-        flags = ("PASS" if r1 else "FAIL",
-                 "PASS" if r2 else "FAIL",
-                 "PASS" if r3 else "FAIL")
+        flags = (
+            "PASS" if r1 else "FAIL",
+            "PASS" if r2 else "FAIL",
+            "PASS" if r3 else "FAIL",
+        )
         if not (r1 and r2 and r3):
             fails += 1
         print(f"{label:<35} {flags[0]:>6} {flags[1]:>9} {flags[2]:>7}")

--- a/tests/test_build_ccache.py
+++ b/tests/test_build_ccache.py
@@ -53,9 +53,7 @@ def test_host_compiler_fallback_uses_real_compiler_path(monkeypatch, tmp_path):
     mcc = bin_dir / "mcc"
     _write_executable(
         ccache,
-        "#!/usr/bin/env bash\n"
-        f"printf '%s\\n' \"$@\" > {arg_log}\n"
-        "exit 0\n",
+        "#!/usr/bin/env bash\n" f"printf '%s\\n' \"$@\" > {arg_log}\n" "exit 0\n",
     )
     for compiler_name in ("cc", "c++", "gcc", "g++", "mcc"):
         _write_executable(bin_dir / compiler_name, "#!/usr/bin/env bash\nexit 0\n")
@@ -92,9 +90,7 @@ def test_mcc_wrapper_presents_musa_sources_as_cu_to_ccache(monkeypatch, tmp_path
     mcc = bin_dir / "mcc"
     _write_executable(
         ccache,
-        "#!/usr/bin/env bash\n"
-        f"printf '%s\\n' \"$@\" > {arg_log}\n"
-        "exit 0\n",
+        "#!/usr/bin/env bash\n" f"printf '%s\\n' \"$@\" > {arg_log}\n" "exit 0\n",
     )
     _write_executable(mcc, "#!/usr/bin/env bash\nexit 0\n")
 
@@ -149,9 +145,7 @@ def test_mcc_wrapper_only_strips_musa_language_flag(monkeypatch, tmp_path):
     mcc = bin_dir / "mcc"
     _write_executable(
         ccache,
-        "#!/usr/bin/env bash\n"
-        f"printf '%s\\n' \"$@\" > {arg_log}\n"
-        "exit 0\n",
+        "#!/usr/bin/env bash\n" f"printf '%s\\n' \"$@\" > {arg_log}\n" "exit 0\n",
     )
     _write_executable(mcc, "#!/usr/bin/env bash\nexit 0\n")
 

--- a/tests/test_deepseek_v4_mhc.py
+++ b/tests/test_deepseek_v4_mhc.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Source-level checks for DeepSeek-V4 MHC MUSA dispatch."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text()
+
+
+def test_mhc_pre_defaults_to_auto_provider():
+    source = _read("vllm_musa/deepseek_v4_mhc.py")
+
+    assert 'VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL", "auto"' in source
+    assert "def _select_mhc_pre_auto_impl(" in source
+    assert "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS" in source
+    assert "hidden_size in {4096, 7168}" in source
+    assert "def _mhc_pre_native_provider(" in source
+    assert "deepseek_v4_mhc_pre(" in source
+    assert "mhc_pre_torch_fallback(" in source
+    assert source.index("def _mhc_pre_native_provider(") < source.index(
+        "def _mhc_pre_tilelang_provider("
+    )
+    assert '"deepgemm_big_fuse"' in source
+    assert 'if impl == "auto":' in source
+    assert "impl = _select_mhc_pre_auto_impl(residual)" in source
+
+
+def test_mhc_pre_custom_op_is_registered():
+    source = _read("vllm_musa/_custom_ops.py")
+    bindings = _read("csrc/musa/torch_bindings.cpp")
+    headers = _read("csrc/musa/musa_ops.h")
+    setup = _read("setup.py")
+
+    assert "def deepseek_v4_mhc_pre(" in source
+    assert "torch.ops._C_musa_ops.deepseek_v4_mhc_pre" in source
+    assert "deepseek_v4_mhc_pre(Tensor residual" in bindings
+    assert "&deepseek_v4_mhc_pre" in bindings
+    assert "void deepseek_v4_mhc_pre(" in headers
+    assert "csrc/musa/mhc/deepseek_v4_mhc_pre.mu" in setup
+
+
+def test_mhc_patch_uses_musa_provider_by_default():
+    source = _read("vllm_musa/patches/vllm__model_executor__layers__mhc.patch.py")
+
+    assert "from vllm_musa.deepseek_v4_mhc import mhc_pre_musa" in source
+    assert "from vllm_musa.deepseek_v4_mhc import mhc_post_musa" in source
+    assert "VLLM_MUSA_ENABLE_DEEPSEEK_V4_MHC_MUSA_IMPL" in source
+    assert (
+        'VLLM_MUSA_ENABLE_TORCH_MHC_PRENORM_FALLBACK",\n                "0"' in source
+    )
+
+
+def test_mhc_pre_deepgemm_big_fuse_is_default_off():
+    source = _read("vllm_musa/deepseek_v4_mhc.py")
+
+    assert "def _mhc_pre_deepgemm_big_fuse_provider(" in source
+    assert "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_DECODE_PRENORM_IMPL" in source
+    assert "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_DEEPGEMM_SPLIT_K" in source
+    assert "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_BIG_FUSE_HIDDEN_BLOCK" in source
+    assert "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_BIG_FUSE_PASS_CONFIG" in source
+    assert 'impl in {"deepgemm_big_fuse", "deepgemm-big-fuse"}' in source
+    assert "return _mhc_pre_deepgemm_big_fuse_provider(" in source
+    assert 'return "native"' in source
+    assert 'return "deepgemm_big_fuse"' not in source
+
+
+def test_mhc_pre_decode_prenorm_tilelang_selector_is_default_off():
+    source = _read("vllm_musa/deepseek_v4_mhc.py")
+
+    assert "def _select_mhc_pre_big_fuse_prenorm_impl(" in source
+    assert 'os.getenv(_MHC_PRE_DECODE_PRENORM_IMPL_ENV, "deepgemm")' in source
+    assert 'impl in {"", "0", "false", "off", "deepgemm"}' in source
+    assert 'impl in {"1", "true", "on", "auto", "tilelang"}' in source
+    assert "hc_hidden_size == 16384 and num_tokens <= 64" in source
+    assert 'return "tilelang"' in source
+    assert 'return "deepgemm"' in source
+
+
+def test_mhc_pre_deepgemm_big_fuse_shape_guards_and_splitk():
+    source = _read("vllm_musa/deepseek_v4_mhc.py")
+    kernels = _read("vllm_musa/deepseek_v4_jit/tilelang_kernels.py")
+
+    assert "def select_mhc_prenorm_split_k(" in source
+    assert "if hc_hidden_size == 16384:" in source
+    assert "if num_tokens <= 64:" in source
+    assert "return 64" in source
+    assert "return 16 if num_tokens <= 1024 else 8" in source
+    assert "hc_mult != 4" in source
+    assert "fn.shape != (hc_mult3, hc_hidden_size)" in source
+    assert "hidden_size % hidden_block != 0" in source
+    assert "hc_hidden_size % split_k != 0" in source
+    assert "tf32_hc_prenorm_gemm" in source
+    assert "mhc_pre_big_fuse_decode_split_kernel" in source
+    assert "mhc_pre_big_fuse_kernel" in source
+    assert "def mhc_pre_big_fuse_kernel(" in kernels
+    assert "def mhc_pre_big_fuse_decode_split_kernel(" in kernels
+
+
+def test_mhc_pre_decode_prenorm_tilelang_partials_path_exists():
+    source = _read("vllm_musa/deepseek_v4_mhc.py")
+    kernels = _read("vllm_musa/deepseek_v4_jit/tilelang_kernels.py")
+
+    assert "def _mhc_prenorm_gemm_sqrsum_tilelang_decode_partials(" in source
+    assert "num_tokens > 64 or hc_hidden_size != 16384" in source
+    assert "split_size % 128 != 0" in source
+    assert "mhc_prenorm_splitk_x_tme_cast_kernel" in source
+    assert "fn.float().contiguous()" in source
+    assert "def mhc_prenorm_splitk_x_tme_cast_kernel(" in kernels
+    assert "TL_ENABLE_MUSA_TMA_PREFETCH" in kernels
+    assert "T.alloc_barrier" in kernels
+    assert "with T.ws(" in kernels
+    assert "T.gemm(" in kernels

--- a/tests/test_deepseek_v4_qkv_rmsnorm.py
+++ b/tests/test_deepseek_v4_qkv_rmsnorm.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text()
+
+
+def test_deepseek_v4_fused_qkv_rmsnorm_custom_op_is_registered():
+    custom_ops = _read("vllm_musa/_custom_ops.py")
+    bindings = _read("csrc/musa/torch_bindings.cpp")
+    headers = _read("csrc/musa/musa_ops.h")
+    setup = _read("setup.py")
+
+    assert "def deepseek_v4_fused_q_kv_rmsnorm(" in custom_ops
+    assert "torch.ops._C_musa_ops.deepseek_v4_fused_q_kv_rmsnorm" in custom_ops
+    assert "deepseek_v4_fused_q_kv_rmsnorm(Tensor q" in bindings
+    assert "&deepseek_v4_fused_q_kv_rmsnorm" in bindings
+    assert "deepseek_v4_fused_q_kv_rmsnorm(" in headers
+    assert "csrc/musa/attention/deepseek_v4_fused_qkv_rmsnorm.mu" in setup
+
+
+def test_deepseek_v4_fused_qkv_rmsnorm_patch_uses_native_by_default():
+    source = _read(
+        "vllm_musa/patches/"
+        "vllm__v1__attention__ops__deepseek_v4_ops__fused_qk_rmsnorm.patch.py"
+    )
+
+    assert "VLLM_MUSA_DEEPSEEK_V4_QKV_RMSNORM_FALLBACK" in source
+    assert "return _musa_fused_q_kv_rmsnorm(qr, kv, q_weight, kv_weight, eps)" in source
+    assert "_musa_rmsnorm_fallback(qr, q_weight, eps)" in source
+    assert "_OLD_HELPERS" in source
+    assert "_OLD_FALLBACK_RETURN" in source
+    assert source.index("return _musa_fused_q_kv_rmsnorm") < source.index(
+        "_musa_rmsnorm_fallback(qr, q_weight, eps)"
+    )

--- a/tests/test_deepseek_v4_tilelang_common.py
+++ b/tests/test_deepseek_v4_tilelang_common.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for DeepSeek-V4 TileLang MUSA helper compatibility."""
+
+from vllm_musa.deepseek_v4_jit import kernel_common
+
+
+class _PassConfigKey:
+    TL_ENABLE_MUSA_BURST = "burst"
+    TL_ENABLE_REDUCE_BURST = "reduce_burst"
+    TL_DEVICE_COMPILE_FLAGS = "compile_flags"
+    TL_DISABLE_THREAD_STORAGE_SYNC = "disable_thread_storage_sync"
+    TL_DISABLE_SAFE_MEMORY_ACCESS = "disable_safe_memory"
+    TL_ENABLE_LOWER_LDGSTG = "lower_ldgstg"
+    TL_ENABLE_LOWER_LDGSTG_PREDICATED = "lower_ldgstg_predicated"
+    TL_DISABLE_INDEX_TYPE_PROMOTION = "disable_index_promotion"
+    TL_DISABLE_HOST_ASSERTS = "disable_host_asserts"
+
+
+class _TileLangStub:
+    PassConfigKey = _PassConfigKey
+
+    def __init__(self, unsupported=()):
+        self.unsupported = set(unsupported)
+        self.calls = []
+
+    def jit(self, **kwargs):
+        for key in self.unsupported:
+            if key in kwargs:
+                raise TypeError(f"unexpected keyword argument: {key}")
+        self.calls.append(kwargs)
+        return kwargs
+
+
+def test_pass_config_default_is_disabled(monkeypatch):
+    monkeypatch.delenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_PASS_CONFIG", raising=False)
+    monkeypatch.delenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE", raising=False)
+
+    assert kernel_common._tilelang_musa_pass_configs(_TileLangStub()) is None
+
+
+def test_old_pass_config_env_preserves_opt1_flags(monkeypatch):
+    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_PASS_CONFIG", "1")
+    monkeypatch.delenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE", raising=False)
+
+    configs = kernel_common._tilelang_musa_pass_configs(_TileLangStub())
+
+    assert configs["burst"] is True
+    assert configs["reduce_burst"] is True
+    assert "-mtgpu-opt-level=1" in configs["compile_flags"]
+
+
+def test_compile_profile_and_aggressive_switches(monkeypatch):
+    monkeypatch.delenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_PASS_CONFIG", raising=False)
+    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE", "ls")
+    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_AGGRESSIVE_PASS_CONFIG", "1")
+    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_INDEX_PROMOTION", "1")
+
+    configs = kernel_common._tilelang_musa_pass_configs(_TileLangStub())
+
+    assert "-mtgpu-load-store-opt=1" in configs["compile_flags"]
+    assert configs["disable_thread_storage_sync"] is True
+    assert configs["disable_safe_memory"] is True
+    assert configs["lower_ldgstg"] is True
+    assert configs["lower_ldgstg_predicated"] is True
+    assert configs["disable_index_promotion"] is True
+
+
+def test_host_asserts_can_be_disabled_without_aggressive_pass(monkeypatch):
+    monkeypatch.delenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_PASS_CONFIG", raising=False)
+    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE", "dsa_full")
+    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS", "1")
+    monkeypatch.delenv(
+        "VLLM_MUSA_DEEPSEEK_V4_TILELANG_AGGRESSIVE_PASS_CONFIG", raising=False
+    )
+
+    configs = kernel_common._tilelang_musa_pass_configs(_TileLangStub())
+
+    assert configs["disable_host_asserts"] is True
+    assert "disable_thread_storage_sync" not in configs
+    assert "disable_safe_memory" not in configs
+    assert "-mtgpu-combine-instr-with-burst=1" in configs["compile_flags"]
+
+
+def test_explicit_dsa_profile_helper(monkeypatch):
+    monkeypatch.delenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE", raising=False)
+
+    configs = kernel_common._tilelang_musa_dsa_pass_configs(
+        _TileLangStub(),
+        full=True,
+    )
+
+    assert configs["burst"] is True
+    assert configs["reduce_burst"] is True
+    assert configs["disable_index_promotion"] is True
+    assert "-mtgpu-combine-instr-with-burst=1" in configs["compile_flags"]
+
+
+def test_tilelang_jit_uses_name_target_and_pass_configs(monkeypatch):
+    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_PASS_CONFIG", "1")
+    tilelang = _TileLangStub()
+
+    result = kernel_common._tilelang_jit(tilelang, "kernel_name")
+
+    assert result["name"] == "kernel_name"
+    assert result["target"] == "musa"
+    assert result["pass_configs"]["burst"] is True
+
+
+def test_tilelang_jit_falls_back_for_old_tilelang_apis(monkeypatch):
+    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_TILELANG_PASS_CONFIG", "1")
+    tilelang = _TileLangStub(unsupported={"name", "pass_configs"})
+
+    result = kernel_common._tilelang_jit(tilelang, "kernel_name")
+
+    assert result == {"target": "musa"}

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -3,6 +3,7 @@
 """Tests for the MUSA platform patches module."""
 
 import importlib
+import os
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -156,6 +157,376 @@ class TestSamplerPatch:
                 break
         else:
             raise AssertionError("topk_topp_sampler patch file was not found")
+
+
+class TestRejectionSamplerPatch:
+    """Tests for the MUSA speculative rejection-sampler patch."""
+
+    def test_rejection_sampler_random_path_uses_target_token_fallback(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.v1.sample.rejection_sampler":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "VLLM_MUSA_SPEC_DECODE_RANDOM_FALLBACK" in new_source
+                assert "_musa_sample_first_target_token" in new_source
+                assert "not sampling_metadata.all_greedy" in new_source
+                assert "sampling_metadata.max_num_logprobs is None" in new_source
+                assert "PLACEHOLDER_TOKEN_ID" in new_source
+                break
+        else:
+            raise AssertionError("rejection_sampler patch file was not found")
+
+
+class TestGPUModelRunnerPatch:
+    """Tests for MUSA GPU model runner speculative guards."""
+
+    def test_model_runner_skips_musa_random_drafter(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.v1.worker.gpu_model_runner":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "VLLM_MUSA_SPEC_DECODE_RANDOM_FALLBACK" in new_source
+                assert "current_platform.is_musa()" in new_source
+                assert "not self.input_batch.sampling_metadata.all_greedy" in (
+                    new_source
+                )
+                assert "input_fits_in_drafter = False" in new_source
+                break
+        else:
+            raise AssertionError("gpu_model_runner patch file was not found")
+
+
+class TestLLMBaseProposerPatch:
+    """Tests for MUSA LLM base proposer speculative guards."""
+
+    def test_draft_full_wrapper_is_musa_opt_in(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.v1.spec_decode.llm_base_proposer":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert (
+                    'draft_full_wrap_default = "0" if current_platform.is_musa()'
+                    in new_source
+                )
+                assert 'VLLM_MUSA_DRAFT_FULL_WRAP", draft_full_wrap_default' in (
+                    new_source
+                )
+                assert "self.model = CUDAGraphWrapper(" in new_source
+                break
+        else:
+            raise AssertionError("llm_base_proposer patch file was not found")
+
+    def test_draft_full_wrapper_normalizer_updates_old_default(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.v1.spec_decode.llm_base_proposer":
+                module = _load_patch_module(patch_path)
+                assert module is not None
+                source = """
+        # Gated by VLLM_MUSA_DRAFT_FULL_WRAP (default ON since the
+        # query_start_loc in-place hunk fixed the captured-replay stale
+        # data_ptr issue). Set to "0" to disable for debugging.
+        import os as _os
+        cudagraph_mode = self.compilation_config.cudagraph_mode
+        if (
+            _os.environ.get("VLLM_MUSA_DRAFT_FULL_WRAP", "1") == "1"
+            and cudagraph_mode.has_full_cudagraphs()
+"""
+                normalized = module.normalize_source(source)
+
+                assert '_os.environ.get("VLLM_MUSA_DRAFT_FULL_WRAP", "1")' not in (
+                    normalized
+                )
+                assert (
+                    'draft_full_wrap_default = "0" if current_platform.is_musa()'
+                    in normalized
+                )
+                assert 'VLLM_MUSA_DRAFT_FULL_WRAP", draft_full_wrap_default' in (
+                    normalized
+                )
+                break
+        else:
+            raise AssertionError("llm_base_proposer patch file was not found")
+
+
+class TestDeepSeekV4AttentionPatch:
+    """Tests for the MUSA DeepSeek-V4 attention patch."""
+
+    def test_qnorm_rope_native_path_trims_padded_slot_mapping(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.model_executor.layers.deepseek_v4_attention":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "native_slot_mapping = slot_mapping" in new_source
+                assert "slot_mapping.shape[0] > q.shape[0]" in new_source
+                assert "slot_mapping[: q.shape[0]].contiguous()" in new_source
+                assert "native_slot_mapping," in new_source
+                assert new_source.count("native_slot_mapping = slot_mapping") >= 2
+                break
+        else:
+            raise AssertionError("deepseek_v4_attention patch file was not found")
+
+    def test_custom_ops_wrapper_trims_padded_slot_mapping(self):
+        source = (Path(__file__).parents[1] / "vllm_musa/_custom_ops.py").read_text()
+
+        assert "def deepseek_v4_qnorm_rope_kv_insert(" in source
+        assert "slot_mapping.shape[0] > q.shape[0]" in source
+        assert "slot_mapping[: q.shape[0]].contiguous()" in source
+
+    def test_decode_flashmla_path_trims_padded_sparse_metadata(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.model_executor.layers.deepseek_v4_attention":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "active_decode_tokens = q.shape[0]" in new_source
+                assert "topk_indices[:active_decode_tokens]" in new_source
+                assert "topk_lens[:active_decode_tokens]" in new_source
+                assert "swa_indices[:active_decode_tokens]" in new_source
+                assert "swa_lens[:active_decode_tokens]" in new_source
+                break
+        else:
+            raise AssertionError("deepseek_v4_attention patch file was not found")
+
+
+class TestSparseAttnIndexerPatch:
+    """Tests for the MUSA DeepSeek-V4 sparse indexer patch."""
+
+    def test_sparse_indexer_patch_handles_mtp_block_table_rows(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.model_executor.layers.sparse_attn_indexer":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "_musa_decode_block_table_for_token_rows" in new_source
+                assert "repeat_interleave(rows // block_rows, dim=0)" in new_source
+                assert "block_table is None" in new_source
+                break
+        else:
+            raise AssertionError("sparse_attn_indexer patch file was not found")
+
+    def test_sparse_indexer_prefill_uses_musa_native_before_torch_path(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.model_executor.layers.sparse_attn_indexer":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert 'VLLM_MUSA_SPARSE_INDEXER_GRAPH_EXACT_DECODE", "0"' in (
+                    new_source
+                )
+                assert "_musa_try_fill_prefill_topk_from_indexer_cache_native" in (
+                    new_source
+                )
+                assert "deepseek_v4_indexer_topk_prefill" in new_source
+                assert new_source.index(
+                    "_musa_try_fill_prefill_topk_from_indexer_cache_native"
+                ) < new_source.index("_musa_gather_indexer_fp8_cache")
+                assert (
+                    "VLLM_MUSA_ENABLE_DEEPSEEK_V4_SPARSE_INDEXER_MUSA_IMPL"
+                    in new_source
+                )
+                assert "per_head = per_head.clamp_min(0.0)" in new_source
+                break
+        else:
+            raise AssertionError("sparse_attn_indexer patch file was not found")
+
+    def test_sparse_indexer_patch_removes_stale_duplicate_helpers(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.model_executor.layers.sparse_attn_indexer":
+                module = _load_patch_module(patch_path)
+                assert module is not None
+                source = """
+logger = init_logger(__name__)
+
+
+def _musa_sparse_indexer_is_current_stream_capturing() -> bool:
+    return False
+
+
+def _musa_fill_exact_sparse_indexer_indices_capture():
+    return "current"
+
+
+def _musa_sparse_indexer_is_current_stream_capturing() -> bool:
+    return True
+
+
+def _musa_fill_decode_topk_from_indexer_cache_capture():
+    block_table = decode_metadata.block_table[:rows]
+
+
+def _musa_fill_exact_sparse_indexer_indices(
+    return "entry"
+"""
+                normalized = module.normalize_source(source)
+
+                assert (
+                    normalized.count(
+                        "def _musa_sparse_indexer_is_current_stream_capturing()"
+                    )
+                    == 1
+                )
+                assert "decode_metadata.block_table[:rows]" not in normalized
+                assert "def _musa_fill_exact_sparse_indexer_indices(" in normalized
+                break
+        else:
+            raise AssertionError("sparse_attn_indexer patch file was not found")
+
+    def test_sparse_indexer_patch_upgrades_partial_prefill_native_helper(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.model_executor.layers.sparse_attn_indexer":
+                module = _load_patch_module(patch_path)
+                assert module is not None
+                source = """
+def _musa_sparse_indexer_graph_exact_decode_enabled() -> bool:
+    return os.getenv("VLLM_MUSA_SPARSE_INDEXER_GRAPH_EXACT_DECODE", "0") == "1"
+
+
+def _musa_fill_exact_sparse_indexer_indices():
+    if _musa_try_fill_prefill_topk_from_indexer_cache_native():
+        return "native"
+
+
+def _musa_indexer_cache_block(kv_cache: torch.Tensor, block_id: int) -> torch.Tensor:
+    return kv_cache[block_id].view(torch.uint8).flatten()
+"""
+                normalized = module.normalize_source(source)
+
+                assert 'VLLM_MUSA_SPARSE_INDEXER_GRAPH_EXACT_DECODE", "0"' in (
+                    normalized
+                )
+                assert (
+                    "def _musa_try_fill_prefill_topk_from_indexer_cache_native"
+                    in normalized
+                )
+                assert "deepseek_v4_indexer_topk_prefill" in normalized
+                break
+        else:
+            raise AssertionError("sparse_attn_indexer patch file was not found")
+
+    def test_sparse_indexer_patch_removes_shadowed_exact_torch_fallback(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.model_executor.layers.sparse_attn_indexer":
+                module = _load_patch_module(patch_path)
+                assert module is not None
+                source = """
+def _musa_fill_exact_sparse_indexer_indices():
+    if metadata.num_prefills > 0 and metadata.prefill is not None:
+        for chunk in metadata.prefill.chunks:
+            if _musa_try_fill_prefill_topk_from_indexer_cache_native(
+                q_quant[token_start:token_end],
+                kv_cache,
+                weights[token_start:token_end],
+                chunk,
+                topk_indices_buffer[token_start:token_end, :topk_tokens],
+                topk_tokens,
+                head_dim,
+            ):
+                continue
+            k_deq = _musa_gather_indexer_fp8_cache()
+    return topk_indices_buffer
+
+
+def _musa_fill_exact_sparse_indexer_indices():
+    if metadata.num_prefills > 0 and metadata.prefill is not None:
+        q_deq = q_quant.to(torch.float32)
+        weights_fp32 = weights.to(torch.float32)
+        for chunk in metadata.prefill.chunks:
+            k_deq = _musa_gather_indexer_fp8_cache()
+            _musa_fill_topk_rows_from_indexer_logits()
+    return topk_indices_buffer
+"""
+                normalized = module.normalize_source(source)
+
+                assert (
+                    normalized.count("def _musa_fill_exact_sparse_indexer_indices()")
+                    == 1
+                )
+                assert (
+                    "_musa_try_fill_prefill_topk_from_indexer_cache_native"
+                    in normalized
+                )
+                assert "q_deq = q_quant.to(torch.float32)" not in normalized
+                assert normalized.index(
+                    "_musa_try_fill_prefill_topk_from_indexer_cache_native"
+                ) < normalized.index("_musa_gather_indexer_fp8_cache")
+                break
+        else:
+            raise AssertionError("sparse_attn_indexer patch file was not found")
+
+
+class TestSparseSWAPatch:
+    """Tests for the MUSA DeepSeek-V4 sparse SWA metadata patch."""
+
+    def test_sparse_swa_patch_builds_token_metadata_on_device(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.v1.attention.backends.mla.sparse_swa":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "_compute_token_to_req_and_valid_kernel" in new_source
+                assert "token_to_req_indices.copy_(x, non_blocking=True)" not in (
+                    new_source
+                )
+                assert (
+                    "torch.repeat_interleave(torch.arange(num_reqs), query_lens)"
+                    not in (new_source)
+                )
+                assert "slot >= 0" in new_source
+                break
+        else:
+            raise AssertionError("sparse_swa patch file was not found")
 
 
 class TestDeepGemmPatch:
@@ -519,6 +890,10 @@ class TestMUSAPlatformDefaults:
         cudagraph_capture_sizes=None,
         cudagraph_mode=None,
         tensor_parallel_size=1,
+        use_mla=False,
+        index_topk=None,
+        attention_backend=None,
+        cache_block_size=16,
     ):
         from types import SimpleNamespace
 
@@ -526,23 +901,26 @@ class TestMUSAPlatformDefaults:
             architectures=architectures,
             quantization_config=quantization_config,
         )
+        if index_topk is not None:
+            hf_config.index_topk = index_topk
         return SimpleNamespace(
             model_config=SimpleNamespace(
                 architectures=architectures,
                 hf_config=hf_config,
                 quantization=quantization,
-                use_mla=False,
+                use_mla=use_mla,
                 is_mm_prefix_lm=False,
             ),
             parallel_config=SimpleNamespace(
                 tensor_parallel_size=tensor_parallel_size,
                 worker_cls="auto",
             ),
-            cache_config=SimpleNamespace(block_size=16),
+            cache_config=SimpleNamespace(block_size=cache_block_size),
             scheduler_config=SimpleNamespace(
                 is_multimodal_model=False,
                 disable_chunked_mm_input=False,
             ),
+            attention_config=SimpleNamespace(backend=attention_backend),
             compilation_config=SimpleNamespace(
                 custom_ops=[],
                 cudagraph_mode=cudagraph_mode,
@@ -623,6 +1001,352 @@ class TestMUSAPlatformDefaults:
         assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.PIECEWISE
         assert vllm_config.compilation_config.max_cudagraph_capture_size == 512
         assert vllm_config.compilation_config.cudagraph_capture_sizes == [1, 2, 4, 8]
+
+    def test_deepseek_v4_defaults_moe_gemv_block32x8(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+        )
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV", None)
+            os.environ.pop("VLLM_MUSA_GEMV_MOE_BLOCK", None)
+
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV"] == "1"
+            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "32x8"
+
+    def test_deepseek_v4_preserves_user_moe_gemv_block(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+        )
+
+        with patch.dict(os.environ, {"VLLM_MUSA_GEMV_MOE_BLOCK": "16x8"}):
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "16x8"
+
+    def test_deepseek_v4_preserves_empty_user_moe_gemv_block(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+        )
+
+        with patch.dict(os.environ, {"VLLM_MUSA_GEMV_MOE_BLOCK": ""}):
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == ""
+
+    def test_non_deepseek_v4_does_not_default_moe_gemv_block(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["Qwen3ForCausalLM"],
+        )
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VLLM_MUSA_GEMV_MOE_BLOCK", None)
+
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+            assert "VLLM_MUSA_GEMV_MOE_BLOCK" not in os.environ
+
+    def test_deepseek_v4_tp8_profile_unset_keeps_default_envs(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+            tensor_parallel_size=8,
+        )
+        profile_keys = [
+            "VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE",
+            "VLLM_MUSA_GEMV_MOE_BLOCK",
+            "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X",
+            "VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE",
+            "VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE",
+            "VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS",
+            "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS",
+            "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL",
+            "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV",
+        ]
+
+        with patch.dict(os.environ, {}, clear=False):
+            for key in profile_keys:
+                os.environ.pop(key, None)
+
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV"] == "1"
+            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "32x8"
+            assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in os.environ
+            assert "VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE" not in os.environ
+            assert "VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE" not in os.environ
+            assert (
+                "VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS" not in os.environ
+            )
+            assert "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS" not in os.environ
+            assert "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL" not in os.environ
+
+    def test_deepseek_v4_tp8_profile_sets_missing_envs(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+            tensor_parallel_size=8,
+            use_mla=True,
+            index_topk=512,
+            cache_block_size=64,
+        )
+        profile_keys = [
+            "VLLM_MUSA_GEMV_MOE_BLOCK",
+            "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X",
+            "VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE",
+            "VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE",
+            "VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS",
+            "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS",
+            "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL",
+            "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV",
+        ]
+
+        with patch.dict(
+            os.environ,
+            {"VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE": "balanced_long_prefill"},
+            clear=False,
+        ):
+            for key in profile_keys:
+                os.environ.pop(key, None)
+
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV"] == "1"
+            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "16x8"
+            assert os.environ["VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X"] == "256"
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE"] == "256"
+            )
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE"]
+                == "dsa_full"
+            )
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS"] == "1"
+            )
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS"]
+                == "2048"
+            )
+            assert "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL" not in os.environ
+            assert vllm_config.cache_config.block_size == 256
+
+    def test_deepseek_v4_tp8_aggressive_profile_sets_mhc_deepgemm(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+            tensor_parallel_size=8,
+            use_mla=True,
+            index_topk=512,
+            cache_block_size=64,
+        )
+        profile_keys = [
+            "VLLM_MUSA_GEMV_MOE_BLOCK",
+            "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X",
+            "VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE",
+            "VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE",
+            "VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS",
+            "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS",
+            "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL",
+            "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV",
+        ]
+
+        with patch.dict(
+            os.environ,
+            {"VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE": "aggressive_long_prefill"},
+            clear=False,
+        ):
+            for key in profile_keys:
+                os.environ.pop(key, None)
+
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV"] == "1"
+            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "16x8"
+            assert os.environ["VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X"] == "256"
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE"] == "256"
+            )
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE"]
+                == "dsa_full"
+            )
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS"] == "1"
+            )
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS"]
+                == "2048"
+            )
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL"] == "deepgemm_big_fuse"
+            )
+            assert vllm_config.cache_config.block_size == 256
+
+    def test_deepseek_v4_tp8_profile_preserves_explicit_overrides(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+            tensor_parallel_size=8,
+            use_mla=True,
+            index_topk=512,
+            cache_block_size=256,
+        )
+        env = {
+            "VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE": "balanced_long_prefill",
+            "VLLM_MUSA_GEMV_MOE_BLOCK": "32x8",
+            "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X": "128",
+            "VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE": "64",
+            "VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE": "opt1",
+            "VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS": "0",
+            "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS": "0",
+            "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL": "native",
+        }
+
+        with patch.dict(os.environ, env, clear=False):
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "32x8"
+            assert os.environ["VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X"] == "128"
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE"] == "64"
+            )
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE"] == "opt1"
+            )
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS"] == "0"
+            )
+            assert (
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS"] == "0"
+            )
+            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL"] == "native"
+            assert vllm_config.cache_config.block_size == 64
+
+    def test_deepseek_v4_tp8_profile_rejects_unknown_name(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+            tensor_parallel_size=8,
+        )
+
+        with patch.dict(
+            os.environ,
+            {"VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE": "typo"},
+            clear=False,
+        ):
+            try:
+                MUSAPlatformBase.check_and_update_config(vllm_config)
+            except ValueError as exc:
+                message = str(exc)
+            else:
+                raise AssertionError("expected invalid profile to raise ValueError")
+
+            assert "VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE" in message
+            assert "balanced_long_prefill" in message
+            assert "aggressive_long_prefill" in message
+
+    def test_deepseek_v4_flashmla_sparse_defaults_block64(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+            use_mla=True,
+            index_topk=512,
+            cache_block_size=16,
+        )
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE", None)
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+        assert vllm_config.cache_config.block_size == 64
+
+    def test_deepseek_v4_flashmla_sparse_preserves_explicit_block64(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+            use_mla=True,
+            index_topk=512,
+            cache_block_size=256,
+        )
+
+        with patch.dict(
+            os.environ,
+            {"VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE": "64"},
+        ):
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+        assert vllm_config.cache_config.block_size == 64
+
+    def test_deepseek_v4_flashmla_sparse_allows_block256_opt_in(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+            use_mla=True,
+            index_topk=512,
+            cache_block_size=64,
+        )
+
+        with patch.dict(
+            os.environ,
+            {"VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE": "256"},
+        ):
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+        assert vllm_config.cache_config.block_size == 256
+
+    def test_deepseek_v4_flashmla_sparse_rejects_invalid_block_size(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["DeepseekV4ForCausalLM"],
+            use_mla=True,
+            index_topk=512,
+            cache_block_size=64,
+        )
+
+        with patch.dict(
+            os.environ,
+            {"VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE": "128"},
+        ):
+            with pytest.raises(ValueError, match="must be 64 or 256"):
+                MUSAPlatformBase.check_and_update_config(vllm_config)
+
+    def test_non_deepseek_v4_flashmla_sparse_ignores_block256_opt_in(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["OtherSparseMLAForCausalLM"],
+            use_mla=True,
+            index_topk=512,
+            cache_block_size=256,
+        )
+
+        with patch.dict(
+            os.environ,
+            {"VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE": "256"},
+        ):
+            MUSAPlatformBase.check_and_update_config(vllm_config)
+
+        assert vllm_config.cache_config.block_size == 64
 
     def test_dense_fp8_does_not_cap_cudagraph_capture_size(self):
         from vllm_musa.platform import MUSAPlatformBase
@@ -774,10 +1498,14 @@ class TestScaledMMKernelPatch:
         ).read_text()
 
         assert "torch.ops.vllm.musa_deepgemm_fp8_op" in source
+        assert "torch.ops.vllm.musa_fp8_small_m_gemv_op" in source
         assert "direct_register_custom_op(" in source
         assert '"musa_deepgemm_fp8_op"' in source
+        assert '"musa_fp8_small_m_gemv_op"' in source
         assert "_musa_deepgemm_fp8_op_fake" in source
+        assert "_musa_fp8_small_m_gemv_op_fake" in source
         assert "VLLM_MUSA_DEEPGEMM_ROW_MAJOR_ACT_SCALES" in source
+        assert "VLLM_MUSA_FP8_SMALL_M_GEMV" in source
 
     def test_musa_deepgemm_row_major_scale_gate(self, monkeypatch):
         from vllm_musa.model_executor.kernels.linear.scaled_mm import deep_gemm

--- a/tests/test_quant_fp8_oot_source.py
+++ b/tests/test_quant_fp8_oot_source.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Source checks for the MUSA QuantFP8 OOT registration."""
+
+from pathlib import Path
+
+
+def test_quant_fp8_oot_group_quant_uses_musa_helper():
+    repo_root = Path(__file__).resolve().parents[1]
+    model_executor_init = repo_root / "vllm_musa" / "model_executor" / "__init__.py"
+    quant_fp8_oot = (
+        repo_root
+        / "vllm_musa"
+        / "model_executor"
+        / "layers"
+        / "quantization"
+        / "input_quant_fp8.py"
+    )
+
+    init_source = model_executor_init.read_text()
+    source = quant_fp8_oot.read_text()
+
+    assert (
+        "import vllm_musa.model_executor.layers.quantization.input_quant_fp8"
+        in init_source
+    )
+    assert "@QuantFP8.register_oot" in source
+    assert "class MusaQuantFP8(QuantFP8)" in source
+    assert (
+        "self.is_group_quant and not self.static and current_platform.is_musa()"
+        in source
+    )
+    assert "if x.dim() != 2:" in source
+    assert "fp8_utils.per_token_group_quant_fp8" in source
+    assert "return self.forward_native(x, scale, scale_ub, use_triton)" in source
+
+
+def test_deepseek_v4_defaults_do_not_enable_group_quant_fallback():
+    repo_root = Path(__file__).resolve().parents[1]
+    source = (repo_root / "vllm_musa" / "deepseek_v4_fallbacks.py").read_text()
+
+    assert "VLLM_MUSA_ENABLE_TORCH_FP8_GROUP_QUANT_FALLBACK" not in source

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -345,3 +345,269 @@ def min_p_sampling_from_probs(
     return _min_p_sampling_from_probs_internal(
         probs, indices, *_to_tensor_scalar_tuple(min_p), deterministic, generator
     )
+
+
+def deepseek_v4_store_sparse_kv(
+    normed: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    write_mask: torch.Tensor,
+) -> None:
+    return torch.ops._C_musa_ops.deepseek_v4_store_sparse_kv(
+        normed,
+        kv_cache,
+        slot_mapping,
+        write_mask,
+    )
+
+
+def deepseek_v4_qnorm_rope_kv_insert(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    eps: float,
+    cache_block_size: int,
+) -> None:
+    if slot_mapping.shape[0] > q.shape[0]:
+        # Graph+MTP warmup can carry padded cache slots while q/kv only hold
+        # active rows. The native op stores one KV row per q/kv row.
+        slot_mapping = slot_mapping[: q.shape[0]].contiguous()
+    return torch.ops._C_musa_ops.deepseek_v4_qnorm_rope_kv_insert(
+        q,
+        kv,
+        kv_cache,
+        slot_mapping,
+        positions,
+        cos_sin_cache,
+        eps,
+        cache_block_size,
+    )
+
+
+def deepseek_v4_fused_q_kv_rmsnorm(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    q_weight: torch.Tensor,
+    kv_weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops._C_musa_ops.deepseek_v4_fused_q_kv_rmsnorm(
+        q,
+        kv,
+        q_weight,
+        kv_weight,
+        eps,
+    )
+
+
+def deepseek_v4_dequantize_and_gather_k_cache(
+    out: torch.Tensor,
+    k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor | None,
+    block_table: torch.Tensor,
+    block_size: int,
+    offset: int,
+) -> None:
+    return torch.ops._C_musa_ops.deepseek_v4_dequantize_and_gather_k_cache(
+        out,
+        k_cache,
+        seq_lens,
+        gather_lens,
+        block_table,
+        block_size,
+        offset,
+    )
+
+
+def deepseek_v4_compute_global_topk_indices_and_lens(
+    topk_indices: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    is_valid_token: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops._C_musa_ops.deepseek_v4_compute_global_topk_indices_and_lens(
+        topk_indices,
+        token_to_req_indices,
+        block_table,
+        block_size,
+        is_valid_token,
+    )
+
+
+def deepseek_v4_combine_topk_swa_indices(
+    topk_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    topk: int,
+    M: int,
+    N: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops._C_musa_ops.deepseek_v4_combine_topk_swa_indices(
+        topk_indices,
+        query_start_loc,
+        seq_lens,
+        gather_lens,
+        window_size,
+        compress_ratio,
+        topk,
+        M,
+        N,
+    )
+
+
+def deepseek_v4_indexer_topk_decode(
+    q_quant: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk: int,
+) -> None:
+    return torch.ops._C_musa_ops.deepseek_v4_indexer_topk_decode(
+        q_quant,
+        kv_cache,
+        weights,
+        seq_lens,
+        block_table,
+        topk_indices,
+        topk,
+    )
+
+
+def deepseek_v4_indexer_topk_prefill(
+    q_quant: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seq_lens: torch.Tensor,
+    token_to_seq: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk: int,
+) -> None:
+    return torch.ops._C_musa_ops.deepseek_v4_indexer_topk_prefill(
+        q_quant,
+        kv_cache,
+        weights,
+        block_table,
+        cu_seq_lens,
+        token_to_seq,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        topk_indices,
+        topk,
+    )
+
+
+def deepseek_v4_sparse_flashmla_decode(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor | None,
+    attn_sink: torch.Tensor | None,
+    extra_k_cache: torch.Tensor | None,
+    extra_indices: torch.Tensor | None,
+    extra_topk_length: torch.Tensor | None,
+    out: torch.Tensor,
+    softmax_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops._C_musa_ops.deepseek_v4_sparse_flashmla_decode(
+        q,
+        k_cache,
+        indices,
+        topk_length,
+        attn_sink,
+        extra_k_cache,
+        extra_indices,
+        extra_topk_length,
+        out,
+        softmax_scale,
+    )
+
+
+def deepseek_v4_fused_inv_rope_fp8_quant(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    quant_group_size: int,
+    tma_aligned_scales: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops._C_musa_ops.deepseek_v4_fused_inv_rope_fp8_quant(
+        o,
+        positions,
+        cos_sin_cache,
+        n_groups,
+        heads_per_group,
+        nope_dim,
+        rope_dim,
+        quant_group_size,
+        tma_aligned_scales,
+    )
+
+
+def deepseek_v4_topk_softplus_sqrt(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    routed_scaling_factor: float = 1.0,
+    e_score_correction_bias: torch.Tensor | None = None,
+    input_tokens: torch.Tensor | None = None,
+    hash_indices_table: torch.Tensor | None = None,
+) -> None:
+    return torch.ops._C_musa_ops.deepseek_v4_topk_softplus_sqrt(
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize,
+        routed_scaling_factor,
+        e_score_correction_bias,
+        input_tokens,
+        hash_indices_table,
+    )
+
+
+def deepseek_v4_mhc_pre(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    post_mix: torch.Tensor,
+    comb_mix: torch.Tensor,
+    layer_input: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> None:
+    return torch.ops._C_musa_ops.deepseek_v4_mhc_pre(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        post_mix,
+        comb_mix,
+        layer_input,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+    )

--- a/vllm_musa/deepseek_v4_fallbacks.py
+++ b/vllm_musa/deepseek_v4_fallbacks.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepSeek-V4 MUSA correctness fallback defaults."""
+
+import logging
+import os
+
+DEEPSEEK_V4_CORRECTNESS_FALLBACK_DEFAULTS = {
+    "VLLM_MUSA_ENABLE_TORCH_MHC_PRENORM_FALLBACK": "1",
+    "VLLM_MUSA_ENABLE_TORCH_FP8_EINSUM_FALLBACK": "1",
+    "VLLM_MUSA_ENABLE_TORCH_DEEPSEEK_V4_COMPRESSOR_FALLBACK": "1",
+    "VLLM_MUSA_DEEPSEEK_V4_COMPRESSOR_TRITON": "1",
+    "VLLM_MUSA_ENABLE_TORCH_SPARSE_ATTN_INDEXER_FALLBACK": "1",
+    "VLLM_MUSA_SPARSE_INDEXER_FALLBACK_TOPK": "16",
+}
+
+
+def enable_deepseek_v4_sparse_correctness_fallbacks(
+    logger: logging.Logger | None = None,
+) -> None:
+    changed = []
+    for name, value in DEEPSEEK_V4_CORRECTNESS_FALLBACK_DEFAULTS.items():
+        if name not in os.environ:
+            os.environ[name] = value
+            changed.append(name)
+
+    if changed and logger is not None:
+        logger.warning(
+            "Enabling DeepSeek-V4 MUSA correctness fallback defaults: %s. "
+            "These torch fallback paths let DeepSeek-V4 sparse FlashMLA run "
+            "correctly on MUSA but are not fused production kernels. Set an "
+            "individual variable to 0 before startup to opt out.",
+            ", ".join(sorted(changed)),
+        )

--- a/vllm_musa/deepseek_v4_jit/__init__.py
+++ b/vllm_musa/deepseek_v4_jit/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lazy JIT helpers for DeepSeek-V4 MUSA fallback paths."""

--- a/vllm_musa/deepseek_v4_jit/fp8_einsum.py
+++ b/vllm_musa/deepseek_v4_jit/fp8_einsum.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek-V4 FP8 einsum helpers for MUSA provider experiments."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+_GROUP_SIZE = 128
+_IMPL_ENV = "VLLM_MUSA_DEEPSEEK_V4_FP8_EINSUM_IMPL"
+
+
+def _impl_mode() -> str:
+    return os.getenv(_IMPL_ENV, "auto").strip().lower()
+
+
+def _is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return getattr(tensor, "device", None) is not None and tensor.device.type == "musa"
+
+
+def _normalize_weight(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    groups: int,
+) -> tuple[torch.Tensor, torch.Tensor, int, int]:
+    if weight.dim() == 2:
+        flat_out_dim, in_dim = weight.shape
+        if flat_out_dim % groups != 0:
+            raise ValueError(
+                "DeepSeek-V4 FP8 GEMV provider expected 2D weight rows to be "
+                f"divisible by groups={groups}, got {tuple(weight.shape)}"
+            )
+        out_dim = flat_out_dim // groups
+        weight = weight.reshape(groups, out_dim, in_dim)
+    elif weight.dim() == 3:
+        weight_groups, out_dim, in_dim = weight.shape
+        if weight_groups != groups:
+            raise ValueError(
+                "DeepSeek-V4 FP8 GEMV provider group mismatch: "
+                f"activation groups={groups}, weight groups={weight_groups}"
+            )
+    else:
+        raise ValueError(
+            "DeepSeek-V4 FP8 GEMV provider expects a 2D or 3D weight tensor, "
+            f"got {tuple(weight.shape)}"
+        )
+
+    if out_dim % _GROUP_SIZE != 0 or in_dim % _GROUP_SIZE != 0:
+        raise ValueError(
+            "DeepSeek-V4 FP8 GEMV provider requires 128-aligned dimensions, "
+            f"got out_dim={out_dim}, in_dim={in_dim}"
+        )
+    out_blocks = out_dim // _GROUP_SIZE
+    in_blocks = in_dim // _GROUP_SIZE
+
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if e8m0_dtype is not None and weight_scale.dtype == e8m0_dtype:
+        exp_bits = weight_scale.view(torch.uint8).to(torch.int32)
+        scales = (exp_bits << 23).view(torch.float32)
+    else:
+        scales = weight_scale.to(torch.float32)
+
+    if scales.dim() == 2 and groups == 1 and scales.shape == (out_blocks, in_blocks):
+        scales = scales.unsqueeze(0)
+    elif scales.dim() == 2 and scales.numel() == groups * out_blocks * in_blocks:
+        scales = scales.reshape(groups, out_blocks, in_blocks)
+    elif scales.shape == (groups, in_blocks, out_blocks):
+        scales = scales.transpose(-1, -2)
+
+    if scales.shape != (groups, out_blocks, in_blocks):
+        raise ValueError(
+            "DeepSeek-V4 FP8 GEMV provider scale shape mismatch: "
+            f"scale_shape={tuple(weight_scale.shape)}, normalized={tuple(scales.shape)}, "
+            f"expected={(groups, out_blocks, in_blocks)}"
+        )
+
+    return weight, scales, out_dim, in_dim
+
+
+def try_musa_deepseek_v4_fp8_einsum_gemv(
+    activation: torch.Tensor,
+    activation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+) -> tuple[bool, str]:
+    """Try the native MUSA GEMV path for ``bhr,hdr->bhd`` FP8 einsum."""
+    mode = _impl_mode()
+    if mode in {"torch", "fallback", "off", "0"}:
+        return False, f"disabled by {_IMPL_ENV}"
+    if equation != "bhr,hdr->bhd":
+        return False, f"unsupported equation {equation!r}"
+    if activation.dim() != 3 or out.dim() != 3:
+        return False, (
+            "expected activation/out shapes [tokens, groups, hidden] and "
+            f"[tokens, groups, out], got {tuple(activation.shape)} -> "
+            f"{tuple(out.shape)}"
+        )
+    if activation_scale.dim() != 3:
+        return False, f"expected activation_scale dim 3, got {activation_scale.dim()}"
+    if activation.dtype != torch.float8_e4m3fn:
+        return False, f"expected fp8 activation, got {activation.dtype}"
+    if weight.dtype != torch.float8_e4m3fn:
+        return False, f"expected fp8 weight, got {weight.dtype}"
+    tensors = (activation, activation_scale, weight, weight_scale, out)
+    if not all(_is_musa_tensor(tensor) for tensor in tensors):
+        return False, "all tensors must be on MUSA"
+
+    tokens, groups, in_dim = activation.shape
+    if activation_scale.shape != (tokens, groups, in_dim // _GROUP_SIZE):
+        return False, (
+            "activation_scale shape mismatch: "
+            f"{tuple(activation_scale.shape)} for activation={tuple(activation.shape)}"
+        )
+
+    try:
+        weight, scales, out_dim, normalized_in_dim = _normalize_weight(
+            weight,
+            weight_scale,
+            groups,
+        )
+    except Exception as exc:
+        if mode in {"gemv", "native", "force"}:
+            raise
+        return False, f"{type(exc).__name__}: {exc}"
+
+    if normalized_in_dim != in_dim or out.shape != (tokens, groups, out_dim):
+        return False, (
+            "shape mismatch after weight normalization: "
+            f"activation={tuple(activation.shape)}, weight={tuple(weight.shape)}, "
+            f"out={tuple(out.shape)}"
+        )
+
+    try:
+        from vllm_musa import _custom_ops as musa_ops
+
+        for group_idx in range(groups):
+            group_out = musa_ops.musa_fused_gemv(
+                activation[:, group_idx, :].contiguous(),
+                weight[group_idx].contiguous(),
+                activation_scale[:, group_idx, :].contiguous(),
+                scales[group_idx].contiguous(),
+            )
+            out[:, group_idx, :].copy_(group_out)
+    except Exception as exc:
+        if mode in {"gemv", "native", "force"}:
+            raise
+        return False, f"{type(exc).__name__}: {exc}"
+
+    return True, "musa_fused_gemv"

--- a/vllm_musa/deepseek_v4_jit/kernel_common.py
+++ b/vllm_musa/deepseek_v4_jit/kernel_common.py
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small TileLang compatibility helpers used by DeepSeek-V4 MUSA JIT paths."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+_TILELANG_MUSA_OPT1_DEVICE_COMPILE_FLAGS = [
+    "-fmusa-flush-denormals-to-zero",
+    "-fno-signed-zeros",
+    "-mllvm",
+    "-mtgpu-opt-level=1",
+]
+
+_TILELANG_MUSA_LS_DEVICE_COMPILE_FLAGS = [
+    *_TILELANG_MUSA_OPT1_DEVICE_COMPILE_FLAGS,
+    "-mllvm",
+    "-mtgpu-load-store-opt=1",
+    "-mllvm",
+    "-mtgpu-fold-global-ldst=1",
+    "-mllvm",
+    "-mtgpu-load-cluster-mutation=1",
+    "-mllvm",
+    "-mtgpu-store-cluster-mutation=1",
+    "-mllvm",
+    "-mtgpu-memory-sched-mutation=1",
+]
+
+_TILELANG_MUSA_DSA_DEVICE_COMPILE_FLAGS = [
+    "-fmusa-flush-denormals-to-zero",
+    "-fno-signed-zeros",
+    "-fno-strict-aliasing",
+    "-mllvm",
+    "-misched=mtgpu-max-ilp",
+    "-mllvm",
+    "-mtgpu-if-convert=1",
+    "-mllvm",
+    "-mtgpu-tiny-offset-hint=1",
+    "-mllvm",
+    "-misched-recompute-slotindex=1",
+    "-mllvm",
+    "-mtgpu-combine-fop-instr=1",
+]
+
+_TILELANG_MUSA_DSA_FULL_DEVICE_COMPILE_FLAGS = [
+    *_TILELANG_MUSA_DSA_DEVICE_COMPILE_FLAGS,
+    "-mllvm",
+    "-mtgpu-combine-instr-with-burst=1",
+    "-mllvm",
+    "-mtgpu-load-cluster-mutation=1",
+    "-mllvm",
+    "--num-dwords-of-load-in-mutation=64",
+]
+
+
+def _tilelang_musa_compile_profile_flags(
+    default_profile: str | None = None,
+) -> list[str] | None:
+    profile = (
+        os.environ.get("VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE", "")
+        .strip()
+        .lower()
+    )
+    if profile == "" and default_profile is not None:
+        profile = default_profile.strip().lower()
+    if profile in {"", "default", "none", "0"}:
+        return None
+    if profile == "opt1":
+        return _TILELANG_MUSA_OPT1_DEVICE_COMPILE_FLAGS
+    if profile == "ls":
+        return _TILELANG_MUSA_LS_DEVICE_COMPILE_FLAGS
+    if profile == "dsa":
+        return _TILELANG_MUSA_DSA_DEVICE_COMPILE_FLAGS
+    if profile == "dsa_full":
+        return _TILELANG_MUSA_DSA_FULL_DEVICE_COMPILE_FLAGS
+    raise ValueError(
+        "Unsupported VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE="
+        f"{profile!r}; expected one of default,opt1,ls,dsa,dsa_full"
+    )
+
+
+def _add_pass_config(
+    pass_configs: dict[Any, Any],
+    tilelang,
+    key_name: str,
+    value: Any,
+) -> None:
+    key = getattr(tilelang.PassConfigKey, key_name, None)
+    if key is not None:
+        pass_configs[key] = value
+
+
+def _tilelang_musa_pass_configs(tilelang, *, compile_profile: str | None = None):
+    """Return optional MUSA pass configs without requiring a specific TileLang build."""
+    old_pass_config = os.environ.get("VLLM_MUSA_DEEPSEEK_V4_TILELANG_PASS_CONFIG")
+    default_profile = "opt1" if old_pass_config == "1" else compile_profile
+    compile_flags = _tilelang_musa_compile_profile_flags(default_profile)
+    if old_pass_config != "1" and compile_flags is None:
+        return None
+
+    pass_configs = {}
+    if old_pass_config == "1":
+        _add_pass_config(pass_configs, tilelang, "TL_ENABLE_MUSA_BURST", True)
+        _add_pass_config(pass_configs, tilelang, "TL_ENABLE_REDUCE_BURST", True)
+    if os.environ.get("VLLM_MUSA_DEEPSEEK_V4_TILELANG_AGGRESSIVE_PASS_CONFIG") == "1":
+        _add_pass_config(pass_configs, tilelang, "TL_DISABLE_THREAD_STORAGE_SYNC", True)
+        _add_pass_config(pass_configs, tilelang, "TL_DISABLE_SAFE_MEMORY_ACCESS", True)
+        _add_pass_config(pass_configs, tilelang, "TL_ENABLE_LOWER_LDGSTG", True)
+        _add_pass_config(
+            pass_configs, tilelang, "TL_ENABLE_LOWER_LDGSTG_PREDICATED", True
+        )
+    if os.environ.get("VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_INDEX_PROMOTION") == "1":
+        _add_pass_config(
+            pass_configs, tilelang, "TL_DISABLE_INDEX_TYPE_PROMOTION", True
+        )
+    if os.environ.get("VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS") == "1":
+        _add_pass_config(pass_configs, tilelang, "TL_DISABLE_HOST_ASSERTS", True)
+    if compile_flags is not None:
+        _add_pass_config(
+            pass_configs, tilelang, "TL_DEVICE_COMPILE_FLAGS", compile_flags
+        )
+    return pass_configs or None
+
+
+def _tilelang_musa_burst_reduce_pass_configs(
+    tilelang,
+    *,
+    compile_profile: str | None = None,
+):
+    pass_configs = {}
+    _add_pass_config(pass_configs, tilelang, "TL_ENABLE_MUSA_BURST", True)
+    _add_pass_config(pass_configs, tilelang, "TL_ENABLE_REDUCE_BURST", True)
+    compile_flags = _tilelang_musa_compile_profile_flags(compile_profile)
+    if compile_flags is not None:
+        _add_pass_config(
+            pass_configs, tilelang, "TL_DEVICE_COMPILE_FLAGS", compile_flags
+        )
+    return pass_configs or None
+
+
+def _tilelang_musa_aggressive_pass_configs(
+    tilelang,
+    *,
+    disable_index_promotion: bool = True,
+    compile_profile: str | None = None,
+):
+    pass_configs = (
+        _tilelang_musa_burst_reduce_pass_configs(
+            tilelang,
+            compile_profile=compile_profile,
+        )
+        or {}
+    )
+    _add_pass_config(pass_configs, tilelang, "TL_DISABLE_THREAD_STORAGE_SYNC", True)
+    _add_pass_config(pass_configs, tilelang, "TL_DISABLE_SAFE_MEMORY_ACCESS", True)
+    _add_pass_config(pass_configs, tilelang, "TL_ENABLE_LOWER_LDGSTG", True)
+    _add_pass_config(pass_configs, tilelang, "TL_ENABLE_LOWER_LDGSTG_PREDICATED", True)
+    if disable_index_promotion:
+        _add_pass_config(
+            pass_configs, tilelang, "TL_DISABLE_INDEX_TYPE_PROMOTION", True
+        )
+    if os.environ.get("VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS") == "1":
+        _add_pass_config(pass_configs, tilelang, "TL_DISABLE_HOST_ASSERTS", True)
+    return pass_configs or None
+
+
+def _tilelang_musa_dsa_pass_configs(
+    tilelang,
+    *,
+    full: bool = False,
+    disable_index_promotion: bool = True,
+):
+    pass_configs = (
+        _tilelang_musa_aggressive_pass_configs(
+            tilelang,
+            disable_index_promotion=disable_index_promotion,
+        )
+        or {}
+    )
+    flags = (
+        _TILELANG_MUSA_DSA_FULL_DEVICE_COMPILE_FLAGS
+        if full
+        else _TILELANG_MUSA_DSA_DEVICE_COMPILE_FLAGS
+    )
+    _add_pass_config(pass_configs, tilelang, "TL_DEVICE_COMPILE_FLAGS", flags)
+    return pass_configs or None
+
+
+def _tilelang_jit(
+    tilelang,
+    name: str,
+    pass_configs=None,
+    *,
+    target: str | None = "musa",
+):
+    if pass_configs is None:
+        pass_configs = _tilelang_musa_pass_configs(tilelang)
+    base_kwargs = {}
+    if target is not None:
+        base_kwargs["target"] = target
+    if name:
+        base_kwargs["name"] = name
+    if pass_configs is not None:
+        base_kwargs["pass_configs"] = pass_configs
+    candidate_keys = (
+        ("target", "name", "pass_configs"),
+        ("target", "pass_configs"),
+        ("target", "name"),
+        ("target",),
+        ("name", "pass_configs"),
+        ("pass_configs",),
+        ("name",),
+        (),
+    )
+    candidates = [
+        {key: base_kwargs[key] for key in keys if key in base_kwargs}
+        for keys in candidate_keys
+    ]
+
+    seen = set()
+    last_error: TypeError | None = None
+    for kwargs in candidates:
+        key = tuple(sorted(kwargs))
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            return tilelang.jit(**kwargs)
+        except TypeError as exc:
+            message = str(exc)
+            if not any(
+                text in message
+                for text in ("name", "pass_configs", "target", "unexpected")
+            ):
+                raise
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    return tilelang.jit()
+
+
+def _patch_tilelang_musa_wrapper() -> bool:
+    """Patch TileLang's MUSA wrapper for host IR without ``T.call_packed``.
+
+    The TileLang build in the current S5000 container can lower simple MUSA
+    kernels, but its wrapper sorts device functions by searching the generated
+    host IR for ``T.call_packed("<kernel>")``. Some lowered kernels do not
+    contain that string, so compilation fails with ``ValueError: substring not
+    found`` before the generated MUSA source is wrapped. Falling back to the
+    device-module order preserves the upstream behavior for the single-kernel
+    JIT helpers used here and keeps fixed TileLang builds untouched.
+    """
+
+    try:
+        from tilelang import tvm
+        from tilelang.jit.adapter.musa_wrapper import TLMUSASourceWrapper
+        from tilelang.jit.adapter.utils import get_annotated_mod
+    except Exception:
+        return False
+
+    if getattr(TLMUSASourceWrapper, "_vllm_musa_no_call_packed_patch", False):
+        return True
+
+    original_parse = TLMUSASourceWrapper.parse_source_information
+
+    def patched_parse(self: Any):
+        try:
+            return original_parse(self)
+        except ValueError as exc:
+            if "substring not found" not in str(exc):
+                raise
+
+            if self.device_mod is None or self.host_mod is None:
+                with tvm.transform.PassContext(opt_level=3, config=self.pass_configs):
+                    device_mod, host_mod = get_annotated_mod(self.mod, self.target)
+                self.device_mod = device_mod
+                self.host_mod = host_mod
+
+            assert (
+                len(self.device_mod.functions) >= 1
+            ), "Device module should have at least one function."
+            assert (
+                len(self.host_mod.functions) == 1
+            ), "Only support one function in host module."
+
+            block_info_map = {}
+            grid_info_map = {}
+            dynamic_smem_buf_map = {}
+            use_cooperative_groups_map = {}
+            function_names = []
+
+            for g_var, func in self.device_mod.functions.items():
+                block_info = [1, 1, 1]
+                grid_info = [1, 1, 1]
+                function_name = g_var.name_hint
+                attrs = func.attrs
+                dynamic_smem_buf = None
+                use_cooperative_groups = False
+
+                if "use_cooperative_groups" in attrs:
+                    use_cooperative_groups = attrs["use_cooperative_groups"]
+                if "dyn_shared_memory_buf" in attrs:
+                    dynamic_smem_buf = int(attrs["dyn_shared_memory_buf"])
+                if "thread_extent" in attrs:
+                    for tag, extent in attrs["thread_extent"].items():
+                        if "threadIdx" in tag:
+                            block_info["xyz".index(tag[-1])] = extent
+                        elif "blockIdx" in tag:
+                            grid_info["xyz".index(tag[-1])] = extent
+
+                block_info_map[function_name] = block_info
+                grid_info_map[function_name] = grid_info
+                dynamic_smem_buf_map[function_name] = dynamic_smem_buf
+                use_cooperative_groups_map[function_name] = use_cooperative_groups
+                function_names.append(function_name)
+
+            self.block_info = block_info_map
+            self.grid_info = grid_info_map
+            self.dynamic_smem_buf = dynamic_smem_buf_map
+            self.use_cooperative_groups = use_cooperative_groups_map
+
+            for _, func in self.host_mod.functions.items():
+                if "tma_descriptor_args" in func.attrs:
+                    self.tma_descriptor_args = func.attrs["tma_descriptor_args"]
+                if "l2_persistent_map" in func.attrs:
+                    for function_name in function_names:
+                        self.l2_persistent_map[function_name] = func.attrs[
+                            "l2_persistent_map"
+                        ]
+
+            self.function_names = function_names
+
+    patched_parse._vllm_musa_original = original_parse
+    TLMUSASourceWrapper.parse_source_information = patched_parse
+    TLMUSASourceWrapper._vllm_musa_no_call_packed_patch = True
+    return True

--- a/vllm_musa/deepseek_v4_jit/qnorm_rope_kv_insert.py
+++ b/vllm_musa/deepseek_v4_jit/qnorm_rope_kv_insert.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TileLang-backed DeepSeek-V4 QNorm/RoPE/KV-cache insert helper.
+
+This module is intentionally imported lazily by the DeepSeek-V4 source patch.
+TileLang is optional in the current remote images, so import or compile failures
+must leave the existing torch correctness fallback available.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_HIDDEN_SIZE = 512
+_NOPE_DIM = 448
+_ROPE_DIM = 64
+_HALF_ROPE_DIM = _ROPE_DIM // 2
+_SCALE_DIM = _NOPE_DIM // 64
+_TOKEN_VALUE_BYTES = _NOPE_DIM + _ROPE_DIM * 2
+_TOKEN_SCALE_BYTES = _SCALE_DIM + 1
+_FP8_MAX = 448.0
+_AUTO_DISABLED_REASON: str | None = None
+
+
+def _is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return getattr(tensor, "device", None) is not None and tensor.device.type == "musa"
+
+
+def _dtype_name(dtype: torch.dtype) -> str:
+    if dtype == torch.int32:
+        return "int32"
+    if dtype == torch.int64:
+        return "int64"
+    return str(dtype).split(".")[-1]
+
+
+def _guard_tilelang_qnorm_rope_kv_insert(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    k_cache_2d: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    block_size: int,
+) -> tuple[bool, str]:
+    tensors = (q, kv, k_cache_2d, slot_mapping, positions, cos_sin_cache)
+    if not all(_is_musa_tensor(tensor) for tensor in tensors):
+        return False, "all tensors must be on MUSA"
+    if len({tensor.device for tensor in tensors}) != 1:
+        return False, "all tensors must be on the same MUSA device"
+    if q.dtype != torch.bfloat16 or kv.dtype != torch.bfloat16:
+        return False, f"expected bf16 q/kv, got q={q.dtype} kv={kv.dtype}"
+    if k_cache_2d.dtype != torch.uint8:
+        return False, f"expected uint8 cache, got {k_cache_2d.dtype}"
+    if cos_sin_cache.dtype != torch.float32:
+        return False, f"expected float32 cos_sin_cache, got {cos_sin_cache.dtype}"
+    if positions.dtype not in (torch.int32, torch.int64):
+        return False, f"unsupported positions dtype {positions.dtype}"
+    if slot_mapping.dtype not in (torch.int32, torch.int64):
+        return False, f"unsupported slot_mapping dtype {slot_mapping.dtype}"
+    if positions.dtype != torch.int64 or slot_mapping.dtype != torch.int64:
+        return False, "TileLang path currently requires int64 positions and slots"
+    if q.dim() != 3 or q.shape[-1] != _HIDDEN_SIZE:
+        return False, f"expected q shape [tokens, heads, 512], got {tuple(q.shape)}"
+    if kv.dim() != 2 or kv.shape[-1] != _HIDDEN_SIZE:
+        return False, f"expected kv shape [tokens, 512], got {tuple(kv.shape)}"
+    if q.shape[0] != kv.shape[0]:
+        return False, f"q/kv token mismatch: q={q.shape[0]} kv={kv.shape[0]}"
+    if positions.dim() != 1 or positions.shape[0] != kv.shape[0]:
+        return False, "positions must be 1D and match token count"
+    if slot_mapping.dim() != 1 or slot_mapping.shape[0] < kv.shape[0]:
+        return False, "slot_mapping must be 1D and cover every token"
+    if cos_sin_cache.dim() != 2 or cos_sin_cache.shape[-1] != _ROPE_DIM:
+        return False, (
+            "cos_sin_cache must have shape [positions, 64], got "
+            f"{tuple(cos_sin_cache.shape)}"
+        )
+    if not q.is_contiguous() or not kv.is_contiguous():
+        return False, "q and kv must be contiguous"
+    if cos_sin_cache.stride(-1) != 1:
+        return False, "cos_sin_cache must have contiguous last dimension"
+    if int(block_size) <= 0:
+        return False, f"block_size must be positive, got {block_size}"
+    if k_cache_2d.dim() != 2:
+        return False, "k_cache_2d must be a 2D uint8 tensor"
+    expected_cache_row = int(block_size) * (_TOKEN_VALUE_BYTES + _TOKEN_SCALE_BYTES)
+    if k_cache_2d.shape[1] != expected_cache_row:
+        return False, (
+            f"cache row bytes {k_cache_2d.shape[1]} != expected {expected_cache_row} "
+            f"for block_size={block_size}"
+        )
+    if k_cache_2d.stride(1) != 1:
+        return False, "k_cache_2d rows must have contiguous byte layout"
+    if k_cache_2d.stride(0) < expected_cache_row:
+        return False, (
+            f"k_cache_2d row stride {k_cache_2d.stride(0)} is smaller than "
+            f"logical row bytes {expected_cache_row}"
+        )
+    if (
+        k_cache_2d.storage_offset() % 4 != 0
+        or k_cache_2d.shape[1] % 4 != 0
+        or k_cache_2d.stride(0) % 4 != 0
+    ):
+        return False, "k_cache_2d must be viewable as uint32 for RoPE stores"
+    if not positions.is_contiguous() or not slot_mapping.is_contiguous():
+        return False, "positions and slot_mapping must be contiguous"
+    try:
+        cache_u8 = _tilelang_cache_u8_view(k_cache_2d)
+    except RuntimeError as exc:
+        return False, f"k_cache_2d cannot expose a physical row view: {exc}"
+    if not cache_u8.is_contiguous():
+        return False, "k_cache_2d physical row view must be contiguous for TileLang"
+    return True, ""
+
+
+def _tilelang_cache_u8_view(k_cache_2d: torch.Tensor) -> torch.Tensor:
+    if k_cache_2d.is_contiguous():
+        return k_cache_2d
+    row_stride = int(k_cache_2d.stride(0))
+    return k_cache_2d.as_strided(
+        (k_cache_2d.shape[0], row_stride),
+        (row_stride, 1),
+    )
+
+
+def try_tilelang_qnorm_rope_kv_insert(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    k_cache_2d: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    eps: float,
+    block_size: int,
+) -> tuple[bool, str]:
+    """Try the TileLang path and report whether it handled the call."""
+    global _AUTO_DISABLED_REASON
+    mode = (
+        os.environ.get("VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_IMPL", "native")
+        .strip()
+        .lower()
+    )
+    if mode in {"torch", "fallback", "0", "off"}:
+        return False, "disabled by VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_IMPL"
+    if mode == "auto" and _AUTO_DISABLED_REASON is not None:
+        return False, _AUTO_DISABLED_REASON
+
+    supported, reason = _guard_tilelang_qnorm_rope_kv_insert(
+        q, kv, k_cache_2d, slot_mapping, positions, cos_sin_cache, block_size
+    )
+    if not supported:
+        if mode in {"tilelang", "jit", "force"}:
+            raise NotImplementedError(reason)
+        return False, reason
+
+    try:
+        from vllm_musa.deepseek_v4_jit.tilelang_kernels import (
+            kv_rope_pack_kernel,
+            qnorm_rope_kernel,
+        )
+
+        q_out = torch.empty_like(q)
+        qnorm_rope_kernel()(
+            q,
+            q_out,
+            cos_sin_cache,
+            positions,
+            float(eps),
+        )
+        cache_u8 = _tilelang_cache_u8_view(k_cache_2d)
+        kv_rope_pack_kernel()(
+            kv,
+            cache_u8,
+            cache_u8.view(torch.uint32),
+            slot_mapping[: kv.shape[0]],
+            positions,
+            cos_sin_cache,
+            int(block_size),
+        )
+        q.copy_(q_out)
+    except Exception as exc:
+        if mode in {"tilelang", "jit", "force"}:
+            raise
+        _AUTO_DISABLED_REASON = f"{type(exc).__name__}: {exc}"
+        return False, _AUTO_DISABLED_REASON
+    return True, "tilelang"

--- a/vllm_musa/deepseek_v4_jit/tilelang_kernels.py
+++ b/vllm_musa/deepseek_v4_jit/tilelang_kernels.py
@@ -1,0 +1,863 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TileLang kernels for DeepSeek-V4 MUSA JIT helpers."""
+
+import math
+from functools import lru_cache
+
+import tilelang
+import tilelang.language as T
+
+from .kernel_common import (
+    _add_pass_config,
+    _patch_tilelang_musa_wrapper,
+    _tilelang_musa_aggressive_pass_configs,
+    _tilelang_musa_burst_reduce_pass_configs,
+    _tilelang_musa_pass_configs,
+)
+
+_patch_tilelang_musa_wrapper()
+
+HIDDEN_SIZE = 512
+NOPE_DIM = 448
+ROPE_DIM = 64
+HALF_ROPE_DIM = ROPE_DIM // 2
+SCALE_DIM = NOPE_DIM // 64
+TOKEN_VALUE_BYTES = NOPE_DIM + ROPE_DIM * 2
+TOKEN_SCALE_BYTES = SCALE_DIM + 1
+FP8_MAX = 448.0
+
+
+def _warp_reduce_sum(value):
+    mask = T.tvm_warp_activemask()
+    value += T.tvm_warp_shuffle_down(mask, value, 16, 32, 32)
+    value += T.tvm_warp_shuffle_down(mask, value, 8, 32, 32)
+    value += T.tvm_warp_shuffle_down(mask, value, 4, 32, 32)
+    value += T.tvm_warp_shuffle_down(mask, value, 2, 32, 32)
+    value += T.tvm_warp_shuffle_down(mask, value, 1, 32, 32)
+    return T.tvm_warp_shuffle(mask, value, 0, 32, 32)
+
+
+def _warp_reduce_max(value):
+    mask = T.tvm_warp_activemask()
+    value = T.max(value, T.tvm_warp_shuffle_down(mask, value, 16, 32, 32))
+    value = T.max(value, T.tvm_warp_shuffle_down(mask, value, 8, 32, 32))
+    value = T.max(value, T.tvm_warp_shuffle_down(mask, value, 4, 32, 32))
+    value = T.max(value, T.tvm_warp_shuffle_down(mask, value, 2, 32, 32))
+    value = T.max(value, T.tvm_warp_shuffle_down(mask, value, 1, 32, 32))
+    return T.tvm_warp_shuffle(mask, value, 0, 32, 32)
+
+
+def _mhc_pre_big_fuse_pass_configs(tilelang_module, mode: str):
+    mode = mode.strip().lower()
+    if mode == "none":
+        return None
+    if mode == "safe":
+        return _tilelang_musa_pass_configs(tilelang_module)
+    if mode == "burst":
+        return _tilelang_musa_burst_reduce_pass_configs(tilelang_module)
+    if mode == "aggressive":
+        return _tilelang_musa_aggressive_pass_configs(
+            tilelang_module,
+            disable_index_promotion=False,
+        )
+    if mode == "aggressive_index32":
+        return _tilelang_musa_aggressive_pass_configs(
+            tilelang_module,
+            disable_index_promotion=True,
+        )
+    raise ValueError(
+        "MHC pre big-fuse pass_config must be one of "
+        "'safe', 'burst', 'aggressive', 'aggressive_index32', or 'none', "
+        f"got {mode!r}"
+    )
+
+
+def _mhc_tme_ws_pass_configs(tilelang_module):
+    pass_configs = {}
+    _add_pass_config(pass_configs, tilelang_module, "TL_ENABLE_MUSA_TMA_PREFETCH", True)
+    _add_pass_config(
+        pass_configs,
+        tilelang_module,
+        "TL_DISABLE_WARP_SPECIALIZED",
+        False,
+    )
+    _add_pass_config(pass_configs, tilelang_module, "TL_DISABLE_TMA_LOWER", False)
+    _add_pass_config(
+        pass_configs,
+        tilelang_module,
+        "TL_DISABLE_THREAD_STORAGE_SYNC",
+        True,
+    )
+    return pass_configs or None
+
+
+@lru_cache(maxsize=None)
+def mhc_pre_split_sinkhorn_kernel(hc_mult: int, sinkhorn_repeat: int):
+    hc_mult3 = hc_mult * (2 + hc_mult)
+
+    @tilelang.jit(target="musa", pass_configs=_tilelang_musa_pass_configs(tilelang))
+    def _mhc_pre_split_sinkhorn_kernel():
+        num_tokens = T.dynamic("num_tokens")
+
+        @T.prim_func
+        def _kernel(
+            mixes: T.Tensor((num_tokens, hc_mult3), T.float32),
+            hc_scale: T.Tensor((3,), T.float32),
+            hc_base: T.Tensor((hc_mult3,), T.float32),
+            pre_mix: T.Tensor((num_tokens, hc_mult), T.float32),
+            post_mix: T.Tensor((num_tokens, hc_mult), T.float32),
+            comb_mix: T.Tensor((num_tokens, hc_mult * hc_mult), T.float32),
+            hc_pre_eps: T.float32,
+            hc_sinkhorn_eps: T.float32,
+            hc_post_mult_value: T.float32,
+        ):
+            with T.Kernel(num_tokens, threads=64) as token_id:
+                mixes_shared = T.alloc_shared((hc_mult3,), T.float32)
+                T.copy(mixes[token_id, 0], mixes_shared)
+
+                for j in T.Parallel(hc_mult):
+                    pre_mix[token_id, j] = (
+                        T.sigmoid(mixes_shared[j] * hc_scale[0] + hc_base[j])
+                        + hc_pre_eps
+                    )
+                for j in T.Parallel(hc_mult):
+                    post_mix[token_id, j] = (
+                        T.sigmoid(
+                            mixes_shared[j + hc_mult] * hc_scale[1]
+                            + hc_base[j + hc_mult]
+                        )
+                        * hc_post_mult_value
+                    )
+
+                cm = T.alloc_fragment((hc_mult, hc_mult), T.float32)
+                for j, k in T.Parallel(hc_mult, hc_mult):
+                    cm[j, k] = (
+                        mixes_shared[j * hc_mult + k + hc_mult * 2] * hc_scale[2]
+                        + hc_base[j * hc_mult + k + hc_mult * 2]
+                    )
+
+                row_sum = T.alloc_fragment((hc_mult,), T.float32)
+                col_sum = T.alloc_fragment((hc_mult,), T.float32)
+                row_max = T.alloc_fragment((hc_mult,), T.float32)
+                T.reduce_max(cm, row_max, dim=1)
+                for j, k in T.Parallel(hc_mult, hc_mult):
+                    cm[j, k] = T.exp(cm[j, k] - row_max[j])
+                T.reduce_sum(cm, row_sum, dim=1)
+                for j, k in T.Parallel(hc_mult, hc_mult):
+                    cm[j, k] = cm[j, k] / row_sum[j] + hc_sinkhorn_eps
+
+                T.reduce_sum(cm, col_sum, dim=0)
+                for j, k in T.Parallel(hc_mult, hc_mult):
+                    cm[j, k] = cm[j, k] / (col_sum[k] + hc_sinkhorn_eps)
+
+                for _ in T.serial(sinkhorn_repeat - 1):
+                    T.reduce_sum(cm, row_sum, dim=1)
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        cm[j, k] = cm[j, k] / (row_sum[j] + hc_sinkhorn_eps)
+                    T.reduce_sum(cm, col_sum, dim=0)
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        cm[j, k] = cm[j, k] / (col_sum[k] + hc_sinkhorn_eps)
+
+                for j, k in T.Parallel(hc_mult, hc_mult):
+                    comb_mix[token_id, j * hc_mult + k] = cm[j, k]
+
+        return _kernel
+
+    return _mhc_pre_split_sinkhorn_kernel()
+
+
+@lru_cache(maxsize=None)
+def mhc_prenorm_splitk_x_tme_cast_kernel(
+    mhc_mult3: int,
+    hc_hidden_size: int,
+    split_k: int,
+    token_block: int = 32,
+    hidden_block: int = 128,
+    num_stages: int = 2,
+    threads: int = 384,
+):
+    num_tokens = T.dynamic("num_tokens")
+    assert mhc_mult3 <= 32
+    assert hc_hidden_size % hidden_block == 0
+    assert hc_hidden_size % split_k == 0
+    split_size = hc_hidden_size // split_k
+    assert split_size % hidden_block == 0
+    assert hidden_block in (64, 128)
+    assert num_stages == 2
+    assert token_block == 32
+    assert threads >= 384
+    mbarrier_list = [128, 128, 128] * num_stages
+
+    @tilelang.jit(
+        target="musa",
+        pass_configs=_mhc_tme_ws_pass_configs(tilelang),
+    )
+    def _mhc_prenorm_splitk_x_tme_cast_kernel():
+        @T.prim_func
+        def _kernel(
+            x: T.Tensor((num_tokens, hc_hidden_size), T.bfloat16),
+            fn: T.Tensor((mhc_mult3, hc_hidden_size), T.float32),
+            out_partial: T.Tensor(
+                (split_k, num_tokens, mhc_mult3),
+                T.float32,
+            ),
+            sqrsum_partial: T.Tensor((split_k, num_tokens), T.float32),
+        ):
+            with T.Kernel(
+                T.ceildiv(num_tokens, token_block),
+                split_k,
+                threads=threads,
+            ) as (px, bz):
+                x_bf16_shared = T.alloc_shared(
+                    (token_block, hidden_block),
+                    T.bfloat16,
+                )
+                x_fp32_shared = T.alloc_shared(
+                    (token_block, hidden_block),
+                    T.float32,
+                )
+                fn_shared = T.alloc_shared((32, hidden_block), T.float32)
+                out_frag = T.alloc_fragment((token_block, 32), T.float32)
+                sq_part4 = T.alloc_fragment((token_block, 4), T.float32)
+                mbars = T.alloc_barrier(mbarrier_list)
+                k_base = bz * split_size
+
+                with T.ws(0):
+                    T.clear(out_frag)
+                    T.clear(sq_part4)
+
+                for pz in T.serial(split_size // hidden_block):
+                    with T.ws(1):
+                        T.mbarrier_wait_parity(
+                            mbarrier=mbars[2],
+                            parity=(pz % 2) ^ 1,
+                        )
+                        T.copy(
+                            x[
+                                px * token_block : (px + 1) * token_block,
+                                k_base
+                                + pz * hidden_block : k_base
+                                + (pz + 1) * hidden_block,
+                            ],
+                            x_bf16_shared,
+                            barrier=mbars[0],
+                            annotations={"musa_tma_k_major": T.int32(1)},
+                        )
+                        T.copy(
+                            fn[
+                                0:32,
+                                k_base
+                                + pz * hidden_block : k_base
+                                + (pz + 1) * hidden_block,
+                            ],
+                            fn_shared,
+                            barrier=mbars[1],
+                            eviction_policy="evict_first",
+                        )
+                        T.mbarrier_arrive(mbarrier=mbars[0])
+                        T.mbarrier_arrive(mbarrier=mbars[1])
+
+                    with T.ws(0):
+                        T.mbarrier_wait_parity(
+                            mbarrier=mbars[0],
+                            parity=pz % 2,
+                        )
+                        T.mbarrier_wait_parity(
+                            mbarrier=mbars[1],
+                            parity=pz % 2,
+                        )
+                        for i, k in T.Parallel(token_block, hidden_block):
+                            x_fp32_shared[i, k] = T.cast(
+                                x_bf16_shared[i, k],
+                                T.float32,
+                            )
+                        for jj in T.serial(hidden_block // 4):
+                            for i, j in T.Parallel(token_block, 4):
+                                v = T.cast(
+                                    x_bf16_shared[i, jj * 4 + j],
+                                    T.float32,
+                                )
+                                sq_part4[i, j] += v * v
+                        T.gemm(
+                            x_fp32_shared,
+                            fn_shared,
+                            out_frag,
+                            clear_accum=False,
+                            transpose_B=True,
+                        )
+                        T.mbarrier_arrive(mbarrier=mbars[2])
+
+                with T.ws(0):
+                    sq_l = T.alloc_fragment((token_block,), T.float32)
+                    T.reduce_sum(sq_part4, sq_l)
+                    for i in T.Parallel(token_block):
+                        t = px * token_block + i
+                        if t < num_tokens:
+                            sqrsum_partial[bz, t] = sq_l[i]
+                    for i, j in T.Parallel(token_block, 32):
+                        t = px * token_block + i
+                        if t < num_tokens and j < mhc_mult3:
+                            out_partial[bz, t, j] = out_frag[i, j]
+
+        return _kernel
+
+    return _mhc_prenorm_splitk_x_tme_cast_kernel()
+
+
+@lru_cache(maxsize=None)
+def mhc_pre_big_fuse_kernel(
+    hidden_size: int,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+    hc_mult: int = 4,
+    threads: int = 256,
+    hidden_block: int = 512,
+    pass_config: str = "burst",
+):
+    num_tokens = T.dynamic("num_tokens")
+    hc_mult3 = hc_mult * (2 + hc_mult)
+    assert hc_mult == 4
+    assert hc_mult3 <= 32
+    assert threads in (128, 256)
+    assert n_splits > 0
+    assert sinkhorn_repeat > 0
+    assert hidden_block > 0
+    assert hidden_size % hidden_block == 0
+
+    @tilelang.jit(
+        target="musa",
+        pass_configs=_mhc_pre_big_fuse_pass_configs(tilelang, pass_config),
+    )
+    def _mhc_pre_big_fuse_kernel():
+        @T.prim_func
+        def _kernel(
+            gemm_out_mul: T.Tensor((n_splits, num_tokens, hc_mult3), T.float32),
+            gemm_out_sqrsum: T.Tensor((n_splits, num_tokens), T.float32),
+            hc_scale: T.Tensor((3,), T.float32),
+            hc_base: T.Tensor((hc_mult3,), T.float32),
+            residual: T.Tensor((num_tokens, hc_mult, hidden_size), T.bfloat16),
+            post_mix: T.Tensor((num_tokens, hc_mult), T.float32),
+            comb_mix: T.Tensor((num_tokens, hc_mult * hc_mult), T.float32),
+            layer_input: T.Tensor((num_tokens, hidden_size), T.bfloat16),
+        ):
+            with T.Kernel(num_tokens, threads=threads) as token_id:
+                mixes_shared = T.alloc_shared((hc_mult3,), T.float32)
+                pre_mix_shared = T.alloc_shared((hc_mult,), T.float32)
+                tx = T.get_thread_binding()
+
+                if tx < 32:
+                    rms = T.alloc_fragment((1,), T.float32)
+                    mixes = T.alloc_fragment((hc_mult3,), T.float32)
+                    T.clear(mixes)
+                    if n_splits == 1:
+                        rms[0] = gemm_out_sqrsum[0, token_id]
+                    else:
+                        rms_part = T.alloc_fragment((1,), T.float32)
+                        rms_part[0] = 0.0
+                        for split_base in T.serial(T.ceildiv(n_splits, 32)):
+                            split_id = split_base * 32 + tx
+                            rms_part[0] += T.if_then_else(
+                                split_id < n_splits,
+                                gemm_out_sqrsum[split_id, token_id],
+                                0.0,
+                            )
+                        rms[0] = T.warp_reduce_sum(rms_part[0])
+                    rms[0] = T.rsqrt(rms[0] / float(hc_mult * hidden_size) + rms_eps)
+                    for j in T.Parallel(hc_mult3):
+                        mixes[j] = 0.0
+                        for split_id in T.serial(n_splits):
+                            mixes[j] += gemm_out_mul[split_id, token_id, j]
+                        mixes[j] *= rms[0]
+                    T.copy(mixes, mixes_shared, disable_tma=True)
+
+                T.sync_threads()
+
+                if tx < 32:
+                    cm = T.alloc_fragment((hc_mult, hc_mult), T.float32)
+                    for j in T.Parallel(hc_mult):
+                        pre_mix_shared[j] = (
+                            T.sigmoid(mixes_shared[j] * hc_scale[0] + hc_base[j])
+                            + hc_pre_eps
+                        )
+                    for j in T.Parallel(hc_mult):
+                        post_mix[token_id, j] = (
+                            T.sigmoid(
+                                mixes_shared[j + hc_mult] * hc_scale[1]
+                                + hc_base[j + hc_mult]
+                            )
+                            * hc_post_mult_value
+                        )
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        cm[j, k] = (
+                            mixes_shared[j * hc_mult + k + hc_mult * 2] * hc_scale[2]
+                            + hc_base[j * hc_mult + k + hc_mult * 2]
+                        )
+
+                    row_sum = T.alloc_fragment((hc_mult,), T.float32)
+                    col_sum = T.alloc_fragment((hc_mult,), T.float32)
+                    row_max = T.alloc_fragment((hc_mult,), T.float32)
+                    T.reduce_max(cm, row_max, dim=1)
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        cm[j, k] = T.exp(cm[j, k] - row_max[j])
+                    T.reduce_sum(cm, row_sum, dim=1)
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        cm[j, k] = cm[j, k] / row_sum[j] + hc_sinkhorn_eps
+
+                    T.reduce_sum(cm, col_sum, dim=0)
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        cm[j, k] = cm[j, k] / (col_sum[k] + hc_sinkhorn_eps)
+
+                    for _ in T.serial(sinkhorn_repeat - 1):
+                        T.reduce_sum(cm, row_sum, dim=1)
+                        for j, k in T.Parallel(hc_mult, hc_mult):
+                            cm[j, k] = cm[j, k] / (row_sum[j] + hc_sinkhorn_eps)
+                        T.reduce_sum(cm, col_sum, dim=0)
+                        for j, k in T.Parallel(hc_mult, hc_mult):
+                            cm[j, k] = cm[j, k] / (col_sum[k] + hc_sinkhorn_eps)
+
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        comb_mix[token_id, j * hc_mult + k] = cm[j, k]
+
+                T.sync_threads()
+
+                for hidden_base in T.Pipelined(
+                    hidden_size // hidden_block,
+                    num_stages=1,
+                ):
+                    layer = T.alloc_fragment((hidden_block,), T.float32)
+                    T.clear(layer)
+
+                    for hc_id in T.serial(hc_mult):
+                        pre = pre_mix_shared[hc_id]
+                        for i in T.Parallel(hidden_block):
+                            h = hidden_base * hidden_block + i
+                            layer[i] += pre * T.cast(
+                                residual[token_id, hc_id, h],
+                                T.float32,
+                            )
+
+                    T.copy(
+                        layer,
+                        layer_input[token_id, hidden_base * hidden_block],
+                        disable_tma=True,
+                    )
+
+        return _kernel
+
+    return _mhc_pre_big_fuse_kernel()
+
+
+@lru_cache(maxsize=None)
+def mhc_pre_big_fuse_decode_split_kernel(
+    hidden_size: int,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+    hc_mult: int = 4,
+    threads: int = 256,
+    hidden_block: int = 512,
+    pass_config: str = "burst",
+):
+    num_tokens = T.dynamic("num_tokens")
+    hc_mult3 = hc_mult * (2 + hc_mult)
+    num_hidden_tiles = hidden_size // hidden_block
+    assert hc_mult == 4
+    assert hc_mult3 <= 32
+    assert threads in (128, 256)
+    assert n_splits > 0
+    assert sinkhorn_repeat > 0
+    assert hidden_block > 0
+    assert hidden_size % hidden_block == 0
+
+    @tilelang.jit(
+        target="musa",
+        pass_configs=_mhc_pre_big_fuse_pass_configs(tilelang, pass_config),
+    )
+    def _mhc_pre_big_fuse_decode_split_kernel():
+        @T.prim_func
+        def _kernel(
+            gemm_out_mul: T.Tensor((n_splits, num_tokens, hc_mult3), T.float32),
+            gemm_out_sqrsum: T.Tensor((n_splits, num_tokens), T.float32),
+            hc_scale: T.Tensor((3,), T.float32),
+            hc_base: T.Tensor((hc_mult3,), T.float32),
+            residual: T.Tensor((num_tokens, hc_mult, hidden_size), T.bfloat16),
+            post_mix: T.Tensor((num_tokens, hc_mult), T.float32),
+            comb_mix: T.Tensor((num_tokens, hc_mult * hc_mult), T.float32),
+            layer_input: T.Tensor((num_tokens, hidden_size), T.bfloat16),
+        ):
+            with T.Kernel(
+                num_tokens,
+                num_hidden_tiles,
+                threads=threads,
+            ) as (token_id, hidden_tile_id):
+                tx = T.get_thread_binding()
+                mixes_shared = T.alloc_shared((hc_mult3,), T.float32)
+                rms_for_layer = T.alloc_fragment((1,), T.float32)
+                pre_mix = T.alloc_fragment((hc_mult,), T.float32)
+
+                rms_for_layer[0] = 0.0
+                for split_id in T.serial(n_splits):
+                    rms_for_layer[0] += gemm_out_sqrsum[split_id, token_id]
+                rms_for_layer[0] = T.rsqrt(
+                    rms_for_layer[0] / float(hc_mult * hidden_size) + rms_eps
+                )
+                for j in T.serial(hc_mult):
+                    pre_mix[j] = 0.0
+                    for split_id in T.serial(n_splits):
+                        pre_mix[j] += gemm_out_mul[split_id, token_id, j]
+                    pre_mix[j] = (
+                        T.sigmoid(
+                            pre_mix[j] * rms_for_layer[0] * hc_scale[0] + hc_base[j]
+                        )
+                        + hc_pre_eps
+                    )
+
+                if tx < 32:
+                    rms = T.alloc_fragment((1,), T.float32)
+                    mixes = T.alloc_fragment((hc_mult3,), T.float32)
+                    T.clear(mixes)
+                    if n_splits == 1:
+                        rms[0] = gemm_out_sqrsum[0, token_id]
+                    else:
+                        rms_part = T.alloc_fragment((1,), T.float32)
+                        rms_part[0] = 0.0
+                        for split_base in T.serial(T.ceildiv(n_splits, 32)):
+                            split_id = split_base * 32 + tx
+                            rms_part[0] += T.if_then_else(
+                                split_id < n_splits,
+                                gemm_out_sqrsum[split_id, token_id],
+                                0.0,
+                            )
+                        rms[0] = T.warp_reduce_sum(rms_part[0])
+                    rms[0] = T.rsqrt(rms[0] / float(hc_mult * hidden_size) + rms_eps)
+                    if hidden_tile_id == 0:
+                        for j in T.Parallel(hc_mult3):
+                            mixes[j] = 0.0
+                            for split_id in T.serial(n_splits):
+                                mixes[j] += gemm_out_mul[split_id, token_id, j]
+                            mixes[j] *= rms[0]
+                        T.copy(mixes, mixes_shared, disable_tma=True)
+
+                T.sync_threads()
+
+                if tx < 32 and hidden_tile_id == 0:
+                    cm = T.alloc_fragment((hc_mult, hc_mult), T.float32)
+                    for j in T.Parallel(hc_mult):
+                        post_mix[token_id, j] = (
+                            T.sigmoid(
+                                mixes_shared[j + hc_mult] * hc_scale[1]
+                                + hc_base[j + hc_mult]
+                            )
+                            * hc_post_mult_value
+                        )
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        cm[j, k] = (
+                            mixes_shared[j * hc_mult + k + hc_mult * 2] * hc_scale[2]
+                            + hc_base[j * hc_mult + k + hc_mult * 2]
+                        )
+
+                    row_sum = T.alloc_fragment((hc_mult,), T.float32)
+                    col_sum = T.alloc_fragment((hc_mult,), T.float32)
+                    row_max = T.alloc_fragment((hc_mult,), T.float32)
+                    T.reduce_max(cm, row_max, dim=1)
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        cm[j, k] = T.exp(cm[j, k] - row_max[j])
+                    T.reduce_sum(cm, row_sum, dim=1)
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        cm[j, k] = cm[j, k] / row_sum[j] + hc_sinkhorn_eps
+
+                    T.reduce_sum(cm, col_sum, dim=0)
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        cm[j, k] = cm[j, k] / (col_sum[k] + hc_sinkhorn_eps)
+
+                    for _ in T.serial(sinkhorn_repeat - 1):
+                        T.reduce_sum(cm, row_sum, dim=1)
+                        for j, k in T.Parallel(hc_mult, hc_mult):
+                            cm[j, k] = cm[j, k] / (row_sum[j] + hc_sinkhorn_eps)
+                        T.reduce_sum(cm, col_sum, dim=0)
+                        for j, k in T.Parallel(hc_mult, hc_mult):
+                            cm[j, k] = cm[j, k] / (col_sum[k] + hc_sinkhorn_eps)
+
+                    for j, k in T.Parallel(hc_mult, hc_mult):
+                        comb_mix[token_id, j * hc_mult + k] = cm[j, k]
+
+                layer = T.alloc_fragment((hidden_block,), T.float32)
+                T.clear(layer)
+                for hc_id in T.serial(hc_mult):
+                    pre = pre_mix[hc_id]
+                    for i in T.Parallel(hidden_block):
+                        h = hidden_tile_id * hidden_block + i
+                        layer[i] += pre * T.cast(
+                            residual[token_id, hc_id, h],
+                            T.float32,
+                        )
+
+                for i in T.Parallel(hidden_block):
+                    layer_input[token_id, hidden_tile_id * hidden_block + i] = T.cast(
+                        layer[i],
+                        T.bfloat16,
+                    )
+
+        return _kernel
+
+    return _mhc_pre_big_fuse_decode_split_kernel()
+
+
+@tilelang.jit(target="musa", pass_configs=_tilelang_musa_pass_configs(tilelang))
+def qnorm_rope_kernel():
+    num_tokens = T.dynamic("num_tokens")
+    num_heads = T.dynamic("num_heads")
+    num_positions = T.dynamic("num_positions")
+    threads = 256
+    warps_per_cta = threads // 32
+
+    @T.prim_func
+    def _qnorm_rope_kernel(
+        q: T.Tensor((num_tokens, num_heads, HIDDEN_SIZE), T.bfloat16),
+        out: T.Tensor((num_tokens, num_heads, HIDDEN_SIZE), T.bfloat16),
+        cos_sin_cache: T.Tensor((num_positions, ROPE_DIM), T.float32),
+        positions: T.Tensor((num_tokens,), T.int64),
+        eps: T.float32,
+    ):
+        with T.Kernel(num_tokens, num_heads, threads=threads) as (
+            token_id,
+            head_id,
+        ):
+            tx = T.get_thread_binding()
+            lane = tx % 32
+            warp = tx // 32
+            partial_sumsq = T.alloc_local((1,), T.float32)
+            warp_sumsq = T.alloc_shared((warps_per_cta,), T.float32)
+
+            partial_sumsq[0] = 0.0
+            for col_base in T.serial(0, HIDDEN_SIZE, threads):
+                col = col_base + tx
+                if col < HIDDEN_SIZE:
+                    value = T.cast(q[token_id, head_id, col], T.float32)
+                    partial_sumsq[0] += value * value
+
+            partial_sumsq[0] = _warp_reduce_sum(partial_sumsq[0])
+            if lane == 0:
+                warp_sumsq[warp] = partial_sumsq[0]
+            T.sync_threads()
+
+            partial_sumsq[0] = T.if_then_else(tx < warps_per_cta, warp_sumsq[tx], 0.0)
+            if warp == 0:
+                partial_sumsq[0] = _warp_reduce_sum(partial_sumsq[0])
+                if lane == 0:
+                    warp_sumsq[0] = T.rsqrt(partial_sumsq[0] / float(HIDDEN_SIZE) + eps)
+            T.sync_threads()
+
+            for col_base in T.serial(0, NOPE_DIM, threads):
+                col = col_base + tx
+                if col < NOPE_DIM:
+                    value = T.cast(q[token_id, head_id, col], T.float32)
+                    out[token_id, head_id, col] = T.cast(
+                        value * warp_sumsq[0], T.bfloat16
+                    )
+
+            if tx < HALF_ROPE_DIM:
+                pos = positions[token_id]
+                even_col = NOPE_DIM + tx * 2
+                odd_col = even_col + 1
+                even = T.cast(q[token_id, head_id, even_col], T.float32) * warp_sumsq[0]
+                odd = T.cast(q[token_id, head_id, odd_col], T.float32) * warp_sumsq[0]
+                c = cos_sin_cache[pos, tx]
+                s = cos_sin_cache[pos, HALF_ROPE_DIM + tx]
+                out[token_id, head_id, even_col] = T.cast(
+                    even * c - odd * s, T.bfloat16
+                )
+                out[token_id, head_id, odd_col] = T.cast(even * s + odd * c, T.bfloat16)
+
+    return _qnorm_rope_kernel
+
+
+@tilelang.jit(target="musa", pass_configs=_tilelang_musa_pass_configs(tilelang))
+def kv_rope_pack_kernel():
+    num_tokens = T.dynamic("num_tokens")
+    num_pages = T.dynamic("num_pages")
+    page_bytes = T.dynamic("page_bytes")
+    page_u32 = T.dynamic("page_u32")
+    num_positions = T.dynamic("num_positions")
+    threads = 256
+    tile_dim = 64
+    rope_pack_elems = 2
+
+    def pow2_scale_byte_and_inv(value):
+        clamped = T.max(value, 1.0e-4)
+        bits = T.reinterpret("uint32", clamped)
+        exp = (bits >> 23) & 0xFF
+        man_bits = bits & ((1 << 23) - 1)
+        exp_scale = T.Cast("int32", exp - 127 + T.if_then_else(man_bits != 0, 1, 0))
+        scale_byte = T.Cast("uint8", exp_scale + 127)
+        inv_scale = T.reinterpret("float32", (127 - exp_scale) << 23)
+        return scale_byte, inv_scale
+
+    def abs_f32(value):
+        return T.if_then_else(value < 0.0, -value, value)
+
+    @T.prim_func
+    def _kv_rope_pack_kernel(
+        kv: T.Tensor((num_tokens, HIDDEN_SIZE), T.bfloat16),
+        cache_u8: T.Tensor((num_pages, page_bytes), T.uint8),
+        cache_u32: T.Tensor((num_pages, page_u32), T.uint32),
+        slot_mapping: T.Tensor((num_tokens,), T.int64),
+        positions: T.Tensor((num_tokens,), T.int64),
+        cos_sin_cache: T.Tensor((num_positions, ROPE_DIM), T.float32),
+        block_size: T.int32,
+    ):
+        with T.Kernel(num_tokens, threads=threads) as token_id:
+            tx = T.get_thread_binding()
+            lane = tx % 32
+            warp = tx // 32
+            loc = slot_mapping[token_id]
+
+            if loc >= 0:
+                loc_i32 = T.Cast("int32", loc)
+                page_idx = loc_i32 // block_size
+                token_offset = loc_i32 % block_size
+
+                if warp < SCALE_DIM:
+                    vals = T.alloc_local((2,), dtype=T.bfloat16)
+                    fvals = T.alloc_local((2,), dtype=T.float32)
+                    local_amax = T.alloc_local((1,), dtype=T.float32)
+                    tile_amax = T.alloc_local((1,), dtype=T.float32)
+                    elem_base = warp * tile_dim + lane * 2
+
+                    local_amax[0] = 0.0
+                    for vec in T.vectorized(2):
+                        vals[vec] = kv[token_id, elem_base + vec]
+                        fvals[vec] = T.cast(vals[vec], T.float32)
+                        local_amax[0] = T.max(local_amax[0], abs_f32(fvals[vec]))
+
+                    tile_amax[0] = _warp_reduce_max(local_amax[0])
+                    scale_byte, inv_scale = pow2_scale_byte_and_inv(
+                        tile_amax[0] / FP8_MAX
+                    )
+                    if lane == 0:
+                        cache_u8[
+                            page_idx,
+                            block_size * TOKEN_VALUE_BYTES
+                            + token_offset * TOKEN_SCALE_BYTES
+                            + warp,
+                        ] = scale_byte
+                    tile_offset = token_offset * TOKEN_VALUE_BYTES + elem_base
+                    for vec in T.vectorized(2):
+                        cache_u8[
+                            page_idx,
+                            tile_offset + vec,
+                        ] = T.reinterpret(
+                            "uint8",
+                            T.Cast(
+                                "float8_e4m3fn",
+                                T.clamp(fvals[vec] * inv_scale, -FP8_MAX, FP8_MAX),
+                            ),
+                        )
+                else:
+                    pos = positions[token_id]
+                    elem = lane * rope_pack_elems
+                    even_col = NOPE_DIM + elem
+                    odd_col = even_col + 1
+                    even = T.cast(kv[token_id, even_col], T.float32)
+                    odd = T.cast(kv[token_id, odd_col], T.float32)
+                    pair_idx = elem // 2
+                    c = cos_sin_cache[pos, pair_idx]
+                    s = cos_sin_cache[pos, HALF_ROPE_DIM + pair_idx]
+                    rope_even = T.cast(even * c - odd * s, T.bfloat16)
+                    rope_odd = T.cast(even * s + odd * c, T.bfloat16)
+                    lo = T.reinterpret("uint16", rope_even)
+                    hi = T.reinterpret("uint16", rope_odd)
+                    rope_offset_u32 = (token_offset * TOKEN_VALUE_BYTES + NOPE_DIM) // (
+                        2 * rope_pack_elems
+                    ) + lane
+                    cache_u32[page_idx, rope_offset_u32] = T.Cast("uint32", lo) | (
+                        T.Cast("uint32", hi) << 16
+                    )
+                    if lane == 0:
+                        cache_u8[
+                            page_idx,
+                            block_size * TOKEN_VALUE_BYTES
+                            + token_offset * TOKEN_SCALE_BYTES
+                            + SCALE_DIM,
+                        ] = T.Cast("uint8", 0)
+
+    return _kv_rope_pack_kernel
+
+
+@lru_cache(maxsize=None)
+def mhc_post_kernel(hidden_size: int, hidden_block: int = 256, threads: int = 256):
+    hidden_block = math.gcd(hidden_block, hidden_size)
+    if hidden_block <= 0 or hidden_size % hidden_block != 0:
+        raise ValueError(
+            f"invalid MHC post hidden_block={hidden_block} for hidden={hidden_size}"
+        )
+
+    @tilelang.jit(target="musa", pass_configs=_tilelang_musa_pass_configs(tilelang))
+    def _mhc_post_kernel():
+        num_tokens = T.dynamic("num_tokens")
+
+        @T.prim_func
+        def _kernel(
+            x: T.Tensor((num_tokens, hidden_size), T.bfloat16),
+            residual: T.Tensor((num_tokens, 4, hidden_size), T.bfloat16),
+            post_mix: T.Tensor((num_tokens, 4), T.float32),
+            comb_mix: T.Tensor((num_tokens, 4, 4), T.float32),
+            out: T.Tensor((num_tokens, 4, hidden_size), T.bfloat16),
+        ):
+            with T.Kernel(num_tokens, hidden_size // hidden_block, threads=threads) as (
+                token_id,
+                block_id,
+            ):
+                tx = T.get_thread_binding()
+                hidden_idx = block_id * hidden_block + tx
+                if tx < hidden_block:
+                    x_value = T.cast(x[token_id, hidden_idx], T.float32)
+                    r0 = T.cast(residual[token_id, 0, hidden_idx], T.float32)
+                    r1 = T.cast(residual[token_id, 1, hidden_idx], T.float32)
+                    r2 = T.cast(residual[token_id, 2, hidden_idx], T.float32)
+                    r3 = T.cast(residual[token_id, 3, hidden_idx], T.float32)
+
+                    acc0 = (
+                        post_mix[token_id, 0] * x_value
+                        + comb_mix[token_id, 0, 0] * r0
+                        + comb_mix[token_id, 1, 0] * r1
+                        + comb_mix[token_id, 2, 0] * r2
+                        + comb_mix[token_id, 3, 0] * r3
+                    )
+                    acc1 = (
+                        post_mix[token_id, 1] * x_value
+                        + comb_mix[token_id, 0, 1] * r0
+                        + comb_mix[token_id, 1, 1] * r1
+                        + comb_mix[token_id, 2, 1] * r2
+                        + comb_mix[token_id, 3, 1] * r3
+                    )
+                    acc2 = (
+                        post_mix[token_id, 2] * x_value
+                        + comb_mix[token_id, 0, 2] * r0
+                        + comb_mix[token_id, 1, 2] * r1
+                        + comb_mix[token_id, 2, 2] * r2
+                        + comb_mix[token_id, 3, 2] * r3
+                    )
+                    acc3 = (
+                        post_mix[token_id, 3] * x_value
+                        + comb_mix[token_id, 0, 3] * r0
+                        + comb_mix[token_id, 1, 3] * r1
+                        + comb_mix[token_id, 2, 3] * r2
+                        + comb_mix[token_id, 3, 3] * r3
+                    )
+
+                    out[token_id, 0, hidden_idx] = T.cast(acc0, T.bfloat16)
+                    out[token_id, 1, hidden_idx] = T.cast(acc1, T.bfloat16)
+                    out[token_id, 2, hidden_idx] = T.cast(acc2, T.bfloat16)
+                    out[token_id, 3, hidden_idx] = T.cast(acc3, T.bfloat16)
+
+        return _kernel
+
+    return _mhc_post_kernel()

--- a/vllm_musa/deepseek_v4_mhc.py
+++ b/vllm_musa/deepseek_v4_mhc.py
@@ -1,0 +1,807 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepSeek-V4 MHC helpers for MUSA runtime and diagnostic paths."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+_MHC_PRE_DEEPGEMM_SPLIT_K_ENV = "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_DEEPGEMM_SPLIT_K"
+_MHC_PRE_BIG_FUSE_THREADS_ENV = "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_BIG_FUSE_THREADS"
+_MHC_PRE_BIG_FUSE_HIDDEN_BLOCK_ENV = (
+    "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_BIG_FUSE_HIDDEN_BLOCK"
+)
+_MHC_PRE_BIG_FUSE_PASS_CONFIG_ENV = "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_BIG_FUSE_PASS_CONFIG"
+_MHC_PRE_DECODE_PRENORM_IMPL_ENV = "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_DECODE_PRENORM_IMPL"
+
+
+def mhc_pre_musa(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    impl = os.getenv("VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL", "auto").lower()
+    if impl == "auto":
+        impl = _select_mhc_pre_auto_impl(residual)
+    if impl in {"native", "musa", "mu"}:
+        return _mhc_pre_native_provider(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+    if impl in {"torch", "fallback"}:
+        return mhc_pre_torch_fallback(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+    if impl in {"tilelang", "jit"}:
+        return _mhc_pre_tilelang_provider(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+    if impl in {"deepgemm_big_fuse", "deepgemm-big-fuse"}:
+        return _mhc_pre_deepgemm_big_fuse_provider(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+    raise ValueError(f"unsupported DeepSeek-V4 MHC pre impl: {impl!r}")
+
+
+def _select_mhc_pre_auto_impl(residual: torch.Tensor) -> str:
+    max_tilelang_tokens = int(
+        os.getenv("VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS", "16")
+    )
+    if max_tilelang_tokens <= 0:
+        return "native"
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    num_tokens = residual.numel() // (hc_mult * hidden_size)
+    if (
+        hc_mult == 4
+        and hidden_size in {4096, 7168}
+        and num_tokens <= max_tilelang_tokens
+    ):
+        return "tilelang"
+    return "native"
+
+
+def mhc_pre_musa_fallback(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return mhc_pre_musa(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+    )
+
+
+def mhc_pre_torch_fallback(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert residual.dtype == torch.bfloat16
+    assert fn.dtype == torch.float32
+    assert hc_scale.dtype == torch.float32
+    assert hc_base.dtype == torch.float32
+
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    hc_mult2 = hc_mult * hc_mult
+    hc_mult3 = hc_mult * 2 + hc_mult2
+    hc_hidden_size = hc_mult * hidden_size
+    assert fn.shape == (hc_mult3, hc_hidden_size)
+    assert hc_scale.shape == (3,)
+    assert hc_base.shape == (hc_mult3,)
+
+    outer_shape = residual.shape[:-2]
+    residual_flat = residual.reshape(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    x_float = residual_flat.reshape(num_tokens, hc_hidden_size).to(torch.float32)
+
+    mixes = x_float @ fn.t()
+    rms = torch.rsqrt(x_float.square().sum(dim=-1) / float(hc_hidden_size) + rms_eps)
+    mixes = mixes * rms.unsqueeze(-1)
+
+    pre_mix = (
+        torch.sigmoid(mixes[:, :hc_mult] * hc_scale[0] + hc_base[:hc_mult]) + hc_pre_eps
+    )
+    post_mix = (
+        torch.sigmoid(
+            mixes[:, hc_mult : 2 * hc_mult] * hc_scale[1]
+            + hc_base[hc_mult : 2 * hc_mult]
+        )
+        * hc_post_mult_value
+    )
+    comb_mix = mixes[:, 2 * hc_mult :].reshape(num_tokens, hc_mult, hc_mult) * hc_scale[
+        2
+    ] + hc_base[2 * hc_mult :].reshape(hc_mult, hc_mult)
+    comb_mix = torch.softmax(comb_mix, dim=-1) + hc_sinkhorn_eps
+    comb_mix = comb_mix / (comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps)
+    for _ in range(sinkhorn_repeat - 1):
+        comb_mix = comb_mix / (comb_mix.sum(dim=-1, keepdim=True) + hc_sinkhorn_eps)
+        comb_mix = comb_mix / (comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps)
+
+    layer_input = (
+        (pre_mix.unsqueeze(-1) * residual_flat.to(torch.float32))
+        .sum(dim=1)
+        .to(torch.bfloat16)
+    )
+
+    return (
+        post_mix.reshape(*outer_shape, hc_mult, 1),
+        comb_mix.reshape(*outer_shape, hc_mult, hc_mult),
+        layer_input.reshape(*outer_shape, hidden_size),
+    )
+
+
+def select_mhc_prenorm_split_k(num_tokens: int, hc_hidden_size: int) -> int:
+    """Return the measured default split-K for DeepSeek-V4 MHC PreNorm."""
+    if hc_hidden_size == 16384:
+        if num_tokens <= 64:
+            return 64
+        if num_tokens <= 128:
+            return 16
+        if num_tokens <= 256:
+            return 8
+        if num_tokens <= 1024:
+            return 32
+        if num_tokens <= 2048:
+            return 16
+        return 4
+
+    return 16 if num_tokens <= 1024 else 8
+
+
+def _get_env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def _get_mhc_pre_deepgemm_split_k(
+    num_tokens: int,
+    hc_hidden_size: int,
+) -> int:
+    split_k = _get_env_int(
+        _MHC_PRE_DEEPGEMM_SPLIT_K_ENV,
+        select_mhc_prenorm_split_k(num_tokens, hc_hidden_size),
+    )
+    if split_k <= 0:
+        raise ValueError(f"{_MHC_PRE_DEEPGEMM_SPLIT_K_ENV} must be > 0, got {split_k}")
+    if hc_hidden_size % split_k != 0:
+        raise ValueError(
+            "DeepGEMM MHC prenorm requires K divisible by split_k, "
+            f"got K={hc_hidden_size}, split_k={split_k}"
+        )
+    return split_k
+
+
+def _select_mhc_pre_big_fuse_prenorm_impl(
+    num_tokens: int,
+    hc_hidden_size: int,
+) -> str:
+    impl = os.getenv(_MHC_PRE_DECODE_PRENORM_IMPL_ENV, "deepgemm").strip().lower()
+    if impl in {"", "0", "false", "off", "deepgemm"}:
+        return "deepgemm"
+    if impl in {"1", "true", "on", "auto", "tilelang"}:
+        if hc_hidden_size == 16384 and num_tokens <= 64:
+            return "tilelang"
+        return "deepgemm"
+    raise ValueError(
+        f"{_MHC_PRE_DECODE_PRENORM_IMPL_ENV} must be one of "
+        "'deepgemm', 'tilelang', 'auto', '0', or '1', got {impl!r}"
+    )
+
+
+def _mhc_prenorm_gemm_sqrsum_tilelang_decode_partials(
+    residual_flat: torch.Tensor,
+    fn: torch.Tensor,
+    *,
+    split_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    x_flat = residual_flat.view(residual_flat.shape[0], -1).bfloat16()
+    num_tokens, hc_hidden_size = x_flat.shape
+    mhc_mult3 = fn.shape[0]
+    if split_k <= 0:
+        raise ValueError(f"TileLang MHC prenorm split_k must be > 0, got {split_k}")
+    if num_tokens > 64 or hc_hidden_size != 16384:
+        raise NotImplementedError(
+            "TileLang decode MHC prenorm partials only support "
+            f"num_tokens <= 64 and K=16384, got num_tokens={num_tokens}, "
+            f"K={hc_hidden_size}"
+        )
+    if hc_hidden_size % split_k != 0:
+        raise ValueError(
+            "TileLang MHC prenorm requires K divisible by split_k, "
+            f"got K={hc_hidden_size}, split_k={split_k}"
+        )
+    split_size = hc_hidden_size // split_k
+    if split_size % 128 != 0:
+        raise ValueError(
+            "TileLang decode MHC prenorm partials require split_size "
+            f"divisible by 128, got split_size={split_size}"
+        )
+
+    d_part = torch.empty(
+        split_k,
+        num_tokens,
+        mhc_mult3,
+        dtype=torch.float32,
+        device=residual_flat.device,
+    )
+    s_part = torch.empty(
+        split_k,
+        num_tokens,
+        dtype=torch.float32,
+        device=residual_flat.device,
+    )
+
+    from vllm_musa.deepseek_v4_jit.tilelang_kernels import (
+        mhc_prenorm_splitk_x_tme_cast_kernel,
+    )
+
+    mhc_prenorm_splitk_x_tme_cast_kernel(
+        mhc_mult3,
+        hc_hidden_size,
+        split_k=split_k,
+        token_block=32,
+        hidden_block=128,
+        num_stages=2,
+    )(
+        x_flat,
+        fn.float().contiguous(),
+        d_part,
+        s_part,
+    )
+    return d_part, s_part
+
+
+def _resolve_mhc_pre_big_fuse_config(
+    num_tokens: int,
+    n_splits: int,
+) -> tuple[int, int, str]:
+    is_tiny_decode = num_tokens <= 32
+    is_decode_like = num_tokens <= 64
+    is_mid_prefill = 128 < num_tokens <= 512
+
+    threads = _get_env_int(_MHC_PRE_BIG_FUSE_THREADS_ENV, 0)
+    if threads <= 0:
+        threads = 128 if is_tiny_decode else 256 if is_decode_like else 128
+    if threads not in (128, 256):
+        raise ValueError(
+            f"{_MHC_PRE_BIG_FUSE_THREADS_ENV} must be 128 or 256, got {threads}"
+        )
+
+    hidden_block = _get_env_int(_MHC_PRE_BIG_FUSE_HIDDEN_BLOCK_ENV, 0)
+    if hidden_block <= 0:
+        hidden_block = 512 if is_tiny_decode or is_mid_prefill else 1024
+
+    pass_config = os.getenv(_MHC_PRE_BIG_FUSE_PASS_CONFIG_ENV, "auto").strip().lower()
+    if pass_config == "auto":
+        pass_config = (
+            "aggressive_index32"
+            if (is_decode_like or is_mid_prefill) and n_splits != 1
+            else "safe"
+        )
+    return threads, hidden_block, pass_config
+
+
+def _mhc_prenorm_gemm_sqrsum_deepgemm(
+    residual_flat: torch.Tensor,
+    fn: torch.Tensor,
+    *,
+    split_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    try:
+        from deep_gemm.interface import tf32_hc_prenorm_gemm
+    except ImportError:
+        from deep_gemm import tf32_hc_prenorm_gemm
+
+    x_flat = residual_flat.view(residual_flat.shape[0], -1).bfloat16()
+    num_tokens, hc_hidden_size = x_flat.shape
+    mhc_mult3 = fn.shape[0]
+    if split_k <= 0:
+        raise ValueError(f"DeepGEMM MHC prenorm split_k must be > 0, got {split_k}")
+    if hc_hidden_size % split_k != 0:
+        raise ValueError(
+            "DeepGEMM MHC prenorm requires K divisible by split_k, "
+            f"got K={hc_hidden_size}, split_k={split_k}"
+        )
+
+    if split_k == 1:
+        d_out = torch.empty(
+            num_tokens,
+            mhc_mult3,
+            dtype=torch.float32,
+            device=residual_flat.device,
+        )
+        s_out = torch.empty(
+            num_tokens,
+            dtype=torch.float32,
+            device=residual_flat.device,
+        )
+        tf32_hc_prenorm_gemm(
+            x_flat,
+            fn.float().contiguous(),
+            d_out,
+            s_out,
+            num_splits=1,
+        )
+        return d_out.unsqueeze(0), s_out.unsqueeze(0)
+
+    d_part = torch.empty(
+        split_k,
+        num_tokens,
+        mhc_mult3,
+        dtype=torch.float32,
+        device=residual_flat.device,
+    )
+    s_part = torch.empty(
+        split_k,
+        num_tokens,
+        dtype=torch.float32,
+        device=residual_flat.device,
+    )
+    tf32_hc_prenorm_gemm(
+        x_flat,
+        fn.float().contiguous(),
+        d_part,
+        s_part,
+        num_splits=split_k,
+    )
+    return d_part, s_part
+
+
+def _mhc_pre_deepgemm_big_fuse_provider(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert residual.dtype == torch.bfloat16
+    assert fn.dtype == torch.float32
+    assert hc_scale.dtype == torch.float32
+    assert hc_base.dtype == torch.float32
+
+    _require_contiguous("residual", residual)
+    _require_contiguous("fn", fn)
+    _require_contiguous("hc_scale", hc_scale)
+    _require_contiguous("hc_base", hc_base)
+
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    if hc_mult != 4:
+        raise NotImplementedError(
+            f"MHC pre DeepGEMM big-fuse provider only supports hc_mult=4, "
+            f"got {hc_mult}"
+        )
+
+    hc_mult2 = hc_mult * hc_mult
+    hc_mult3 = hc_mult * (2 + hc_mult)
+    hc_hidden_size = hc_mult * hidden_size
+    if hc_mult3 > 32:
+        raise NotImplementedError(
+            "MHC pre DeepGEMM big-fuse provider requires hc_mult3 <= 32, "
+            f"got {hc_mult3}"
+        )
+    if fn.shape != (hc_mult3, hc_hidden_size):
+        raise ValueError(
+            "MHC pre DeepGEMM big-fuse provider fn mismatch: "
+            f"fn={fn.shape}, expected={(hc_mult3, hc_hidden_size)}"
+        )
+    if hc_scale.shape != (3,) or hc_base.shape != (hc_mult3,):
+        raise ValueError(
+            "MHC pre DeepGEMM big-fuse provider scale/base mismatch: "
+            f"hc_scale={hc_scale.shape}, hc_base={hc_base.shape}"
+        )
+
+    outer_shape = residual.shape[:-2]
+    residual_flat = residual.view(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    split_k = _get_mhc_pre_deepgemm_split_k(num_tokens, hc_hidden_size)
+    prenorm_impl = _select_mhc_pre_big_fuse_prenorm_impl(
+        num_tokens,
+        hc_hidden_size,
+    )
+    threads, hidden_block, pass_config = _resolve_mhc_pre_big_fuse_config(
+        num_tokens,
+        split_k,
+    )
+    if hidden_block <= 0 or hidden_size % hidden_block != 0:
+        raise NotImplementedError(
+            "MHC pre DeepGEMM big-fuse provider requires hidden_size divisible "
+            f"by hidden_block, got hidden_size={hidden_size}, "
+            f"hidden_block={hidden_block}"
+        )
+
+    post_mix = torch.empty(
+        (num_tokens, hc_mult),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    comb_mix = torch.empty(
+        (num_tokens, hc_mult2),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    layer_input = torch.empty(
+        (num_tokens, hidden_size),
+        dtype=torch.bfloat16,
+        device=residual.device,
+    )
+    if prenorm_impl == "tilelang":
+        gemm_out_mul, gemm_out_sqrsum = (
+            _mhc_prenorm_gemm_sqrsum_tilelang_decode_partials(
+                residual_flat,
+                fn,
+                split_k=split_k,
+            )
+        )
+    else:
+        gemm_out_mul, gemm_out_sqrsum = _mhc_prenorm_gemm_sqrsum_deepgemm(
+            residual_flat,
+            fn,
+            split_k=split_k,
+        )
+
+    _require_contiguous("gemm_out_mul", gemm_out_mul)
+    _require_contiguous("gemm_out_sqrsum", gemm_out_sqrsum)
+
+    from vllm_musa.deepseek_v4_jit.tilelang_kernels import (
+        mhc_pre_big_fuse_decode_split_kernel,
+        mhc_pre_big_fuse_kernel,
+    )
+
+    kernel_factory = (
+        mhc_pre_big_fuse_decode_split_kernel
+        if num_tokens <= 64
+        else mhc_pre_big_fuse_kernel
+    )
+    kernel_factory(
+        hidden_size,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        n_splits=gemm_out_mul.shape[0],
+        hc_mult=hc_mult,
+        threads=threads,
+        hidden_block=hidden_block,
+        pass_config=pass_config,
+    )(
+        gemm_out_mul,
+        gemm_out_sqrsum,
+        hc_scale,
+        hc_base,
+        residual_flat,
+        post_mix,
+        comb_mix,
+        layer_input,
+    )
+
+    return (
+        post_mix.view(*outer_shape, hc_mult, 1),
+        comb_mix.view(*outer_shape, hc_mult, hc_mult),
+        layer_input.view(*outer_shape, hidden_size),
+    )
+
+
+def _mhc_pre_native_provider(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert residual.dtype == torch.bfloat16
+    assert fn.dtype == torch.float32
+    assert hc_scale.dtype == torch.float32
+    assert hc_base.dtype == torch.float32
+
+    _require_contiguous("residual", residual)
+    _require_contiguous("fn", fn)
+    _require_contiguous("hc_scale", hc_scale)
+    _require_contiguous("hc_base", hc_base)
+
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    if hc_mult != 4:
+        raise NotImplementedError(
+            f"MHC pre native provider only supports hc_mult=4, got {hc_mult}"
+        )
+    hc_mult3 = hc_mult * (2 + hc_mult)
+    hc_hidden_size = hc_mult * hidden_size
+    if fn.shape != (hc_mult3, hc_hidden_size):
+        raise ValueError(
+            "MHC pre native provider fn mismatch: "
+            f"fn={fn.shape}, expected={(hc_mult3, hc_hidden_size)}"
+        )
+    if hc_scale.shape != (3,) or hc_base.shape != (hc_mult3,):
+        raise ValueError(
+            "MHC pre native provider scale/base mismatch: "
+            f"hc_scale={hc_scale.shape}, hc_base={hc_base.shape}"
+        )
+
+    outer_shape = residual.shape[:-2]
+    residual_flat = residual.view(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    post_mix = torch.empty(
+        (num_tokens, hc_mult), dtype=torch.float32, device=residual.device
+    )
+    comb_mix = torch.empty(
+        (num_tokens, hc_mult, hc_mult),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    layer_input = torch.empty(
+        (num_tokens, hidden_size), dtype=torch.bfloat16, device=residual.device
+    )
+
+    from vllm_musa import _custom_ops as _musa_custom_ops
+
+    _musa_custom_ops.deepseek_v4_mhc_pre(
+        residual_flat,
+        fn,
+        hc_scale,
+        hc_base,
+        post_mix,
+        comb_mix,
+        layer_input,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+    )
+    return (
+        post_mix.view(*outer_shape, hc_mult, 1),
+        comb_mix.view(*outer_shape, hc_mult, hc_mult),
+        layer_input.view(*outer_shape, hidden_size),
+    )
+
+
+def _mhc_pre_tilelang_provider(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert residual.dtype == torch.bfloat16
+    assert fn.dtype == torch.float32
+    assert hc_scale.dtype == torch.float32
+    assert hc_base.dtype == torch.float32
+
+    _require_contiguous("residual", residual)
+    _require_contiguous("fn", fn)
+    _require_contiguous("hc_scale", hc_scale)
+    _require_contiguous("hc_base", hc_base)
+
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    if hc_mult != 4:
+        raise NotImplementedError(
+            f"MHC pre TileLang provider only supports hc_mult=4, got {hc_mult}"
+        )
+
+    hc_mult3 = hc_mult * (2 + hc_mult)
+    hc_hidden_size = hc_mult * hidden_size
+    if fn.shape != (hc_mult3, hc_hidden_size):
+        raise ValueError(
+            "MHC pre TileLang provider fn mismatch: "
+            f"fn={fn.shape}, expected={(hc_mult3, hc_hidden_size)}"
+        )
+    if hidden_size % 256 != 0:
+        raise NotImplementedError(
+            "MHC pre TileLang provider requires hidden_size divisible by 256, "
+            f"got {hidden_size}"
+        )
+
+    from vllm_musa.deepseek_v4_jit.tilelang_kernels import (
+        mhc_pre_split_sinkhorn_kernel,
+    )
+
+    outer_shape = residual.shape[:-2]
+    residual_flat = residual.view(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    x_float = residual_flat.view(num_tokens, hc_hidden_size).to(torch.float32)
+    mixes = x_float @ fn.t()
+    rms = torch.rsqrt(x_float.square().sum(dim=-1) / float(hc_hidden_size) + rms_eps)
+    mixes = (mixes * rms.unsqueeze(-1)).contiguous()
+
+    post_mix = torch.empty(
+        (num_tokens, hc_mult), dtype=torch.float32, device=residual.device
+    )
+    pre_mix = torch.empty(
+        (num_tokens, hc_mult), dtype=torch.float32, device=residual.device
+    )
+    comb_mix = torch.empty(
+        (num_tokens, hc_mult * hc_mult),
+        dtype=torch.float32,
+        device=residual.device,
+    )
+
+    mhc_pre_split_sinkhorn_kernel(hc_mult, sinkhorn_repeat)(
+        mixes,
+        hc_scale,
+        hc_base,
+        pre_mix,
+        post_mix,
+        comb_mix,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+    )
+    layer_input = (
+        (pre_mix.unsqueeze(-1) * residual_flat.to(torch.float32))
+        .sum(dim=1)
+        .to(torch.bfloat16)
+    )
+
+    return (
+        post_mix.view(*outer_shape, hc_mult, 1),
+        comb_mix.view(*outer_shape, hc_mult, hc_mult),
+        layer_input.view(*outer_shape, hidden_size),
+    )
+
+
+def mhc_post_musa(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    impl = os.getenv("VLLM_MUSA_DEEPSEEK_V4_MHC_POST_IMPL", "tilelang").lower()
+    if impl in {"tilelang", "jit", "native", "musa", "mu"}:
+        return _mhc_post_tilelang_provider(x, residual, post_layer_mix, comb_res_mix)
+    if impl in {"torch", "fallback"}:
+        return mhc_post_torch_fallback(x, residual, post_layer_mix, comb_res_mix)
+    raise ValueError(f"unsupported DeepSeek-V4 MHC post impl: {impl!r}")
+
+
+def mhc_post_musa_fallback(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    return mhc_post_musa(x, residual, post_layer_mix, comb_res_mix)
+
+
+def mhc_post_torch_fallback(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    outer_shape = residual.shape[:-2]
+    hc = residual.shape[-2]
+    hidden = residual.shape[-1]
+    residual_flat = residual.reshape(-1, hc, hidden).to(torch.float32)
+    x_flat = x.reshape(-1, hidden).to(torch.float32)
+    post_flat = post_layer_mix.reshape(-1, hc, 1).to(torch.float32)
+    comb_flat = comb_res_mix.reshape(-1, hc, hc).to(torch.float32)
+
+    out = torch.einsum("tij,tih->tjh", comb_flat, residual_flat)
+    out = out + post_flat * x_flat.unsqueeze(1)
+    return out.to(residual.dtype).reshape(*outer_shape, hc, hidden)
+
+
+def _require_contiguous(name: str, tensor: torch.Tensor) -> None:
+    if not tensor.is_contiguous():
+        raise NotImplementedError(f"MHC TileLang provider requires contiguous {name}")
+
+
+def _mhc_post_tilelang_provider(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    assert x.dtype == torch.bfloat16
+    assert residual.dtype == torch.bfloat16
+    assert post_layer_mix.dtype == torch.float32
+    assert comb_res_mix.dtype == torch.float32
+
+    _require_contiguous("x", x)
+    _require_contiguous("residual", residual)
+    _require_contiguous("post_layer_mix", post_layer_mix)
+    _require_contiguous("comb_res_mix", comb_res_mix)
+
+    outer_shape = residual.shape[:-2]
+    hc = residual.shape[-2]
+    hidden = residual.shape[-1]
+    if hc != 4:
+        raise NotImplementedError(
+            f"MHC post TileLang provider only supports hc_mult=4, got {hc}"
+        )
+
+    x_flat = x.view(-1, hidden)
+    residual_flat = residual.view(-1, hc, hidden)
+    post_flat = post_layer_mix.view(-1, hc, 1).squeeze(-1)
+    comb_flat = comb_res_mix.view(-1, hc, hc)
+    if x_flat.shape[0] != residual_flat.shape[0]:
+        raise ValueError(
+            "MHC post TileLang provider token mismatch: "
+            f"x={x_flat.shape}, residual={residual_flat.shape}"
+        )
+
+    from vllm_musa.deepseek_v4_jit.tilelang_kernels import mhc_post_kernel
+
+    out = torch.empty_like(residual_flat)
+    mhc_post_kernel(hidden)(x_flat, residual_flat, post_flat, comb_flat, out)
+    return out.view(*outer_shape, hc, hidden)

--- a/vllm_musa/jit_kernel/csrc/rope.py
+++ b/vllm_musa/jit_kernel/csrc/rope.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 
 import torch
-
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_musa.jit_kernel.csrc.jit import load_musa_jit

--- a/vllm_musa/model_executor/__init__.py
+++ b/vllm_musa/model_executor/__init__.py
@@ -5,6 +5,7 @@ import vllm_musa.model_executor.layers.fused_moe.router.grouped_topk_router
 import vllm_musa.model_executor.layers.fused_moe.unquantized_fused_moe_method
 import vllm_musa.model_executor.layers.layernorm
 import vllm_musa.model_executor.layers.quantization.fp8
+import vllm_musa.model_executor.layers.quantization.input_quant_fp8
 import vllm_musa.model_executor.layers.quantization.utils.fp8_utils
 import vllm_musa.model_executor.layers.rotary_embedding.base
 import vllm_musa.model_executor.layers.utils

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -30,6 +30,54 @@ def _use_row_major_activation_scales(use_deep_gemm_e8m0: bool) -> bool:
     return value not in ("0", "false", "no", "off")
 
 
+def _read_int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+
+
+_MUSA_FP8_SMALL_M_GEMV_ENABLED = os.getenv(
+    "VLLM_MUSA_FP8_SMALL_M_GEMV", "0"
+).lower() in ("1", "true", "yes", "on")
+_MUSA_FP8_SMALL_M_GEMV_MAX_M = _read_int_env("VLLM_MUSA_FP8_SMALL_M_GEMV_MAX_M", 3)
+
+
+def _should_use_musa_fp8_small_m_gemv(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    use_deep_gemm_e8m0: bool,
+) -> bool:
+    if (
+        not _MUSA_FP8_SMALL_M_GEMV_ENABLED
+        or not current_platform.is_musa()
+        or use_deep_gemm_e8m0
+        or group_size != 128
+        or input.dim() != 2
+        or weight.dim() != 2
+        or weight_scale.dim() != 2
+        or input.shape[0] < 1
+        or input.shape[0] > _MUSA_FP8_SMALL_M_GEMV_MAX_M
+        or input.shape[1] != weight.shape[1]
+        or weight.shape[1] % group_size != 0
+        or input.dtype != torch.bfloat16
+        or weight.dtype != current_platform.fp8_dtype()
+        or weight_scale.dtype != torch.float32
+        or not input.is_contiguous()
+        or not weight.is_contiguous()
+        or not weight_scale.is_contiguous()
+    ):
+        return False
+
+    expected_scale_shape = (
+        (weight.shape[0] + group_size - 1) // group_size,
+        weight.shape[1] // group_size,
+    )
+    return tuple(weight_scale.shape) == expected_scale_shape
+
+
 class MUSADeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
     apply_input_quant: ClassVar[bool] = False
 
@@ -117,6 +165,14 @@ def run_deepgemm(
     group_size: int,
     use_deep_gemm_e8m0: bool,
 ) -> torch.Tensor:
+    if _should_use_musa_fp8_small_m_gemv(
+        input, weight, weight_scale, group_size, use_deep_gemm_e8m0
+    ):
+        return torch.ops.vllm.musa_fp8_small_m_gemv_op(
+            input,
+            weight,
+            weight_scale,
+        )
     return torch.ops.vllm.musa_deepgemm_fp8_op(
         input,
         weight,
@@ -133,6 +189,8 @@ def _musa_deepgemm_fp8_op(
     group_size: int,
     use_deep_gemm_e8m0: bool,
 ) -> torch.Tensor:
+    if not input.is_contiguous():
+        input = input.contiguous()
     q_input, input_scale = per_token_group_quant_fp8(
         input,
         group_size=group_size,
@@ -154,6 +212,44 @@ def _musa_deepgemm_fp8_op(
     return output
 
 
+def _musa_fp8_small_m_gemv_op(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    output = torch.empty(
+        (input.shape[0], weight.shape[0]),
+        dtype=torch.bfloat16,
+        device=input.device,
+    )
+    torch.ops._C_musa_ops.musa_fused_gemv(
+        input,
+        weight,
+        output,
+        None,
+        weight_scale,
+        False,
+        False,
+        False,
+        None,
+        1e-6,
+    )
+    return output
+
+
+def _musa_fp8_small_m_gemv_op_fake(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    del weight_scale
+    return torch.empty(
+        (input.shape[0], weight.shape[0]),
+        dtype=torch.bfloat16,
+        device=input.device,
+    )
+
+
 def _musa_deepgemm_fp8_op_fake(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -167,6 +263,12 @@ def _musa_deepgemm_fp8_op_fake(
         device=input.device,
     )
 
+
+direct_register_custom_op(
+    "musa_fp8_small_m_gemv_op",
+    _musa_fp8_small_m_gemv_op,
+    fake_impl=_musa_fp8_small_m_gemv_op_fake,
+)
 
 direct_register_custom_op(
     "musa_deepgemm_fp8_op",

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+
 import torch
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
@@ -302,18 +304,29 @@ def fused_experts_impl(
 
 import vllm.model_executor.layers.fused_moe.fused_moe
 
-# MUSA-0201: PR #34's v0.18.0-style fused_experts_impl override hijacked
-# vllm v0.20.0's modular_kernel dispatch with a blanket BS=1 GEMV fast path.
-# A/B on DeepSeek-V2-Lite-FP8 (audit 2026-05-27) showed:
-#   - 1024/256 cookbook: override 59.5 tok/s vs upstream 75.3 tok/s (-26.5%)
-#   - 256/2048 decode:   override 86.2 tok/s vs upstream 80.9 tok/s (+6.6%)
-# The decode advantage is real but the prefill cost is 10x. The right shape
-# is a hybrid dispatcher (per-expert token-count threshold), to be tracked
-# as a separate follow-up ticket. For now, let vllm upstream
-# fused_experts_impl run unhijacked so prefill scales normally.
-#
-# The TritonExperts._supports_quant_scheme patch is independent (it expands
-# MUSA's supported FP8 quant key list) and stays in place.
+_upstream_fused_moe = vllm.model_executor.layers.fused_moe.fused_moe
+if not hasattr(_upstream_fused_moe, "_musa_original_fused_experts_impl"):
+    _upstream_fused_moe._musa_original_fused_experts_impl = (
+        _upstream_fused_moe.fused_experts_impl
+    )
+
+
+def _musa_fused_experts_impl_dispatch(*args, **kwargs) -> torch.Tensor:
+    # MUSA-0201: PR #34's v0.18.0-style fused_experts_impl override hijacked
+    # vLLM v0.20.0's modular_kernel dispatch globally and hurt some prefill
+    # workloads. DeepSeek-V4-Flash-Base TP8 graph+MTP decode, however, depends
+    # on this native GEMV MoE path for the accepted 40+ tok/s baseline.
+    # Keep the upstream implementation as the default for other models, and
+    # let platform.py opt DeepSeek-V4 in per serving process.
+    if os.environ.get("VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV", "0") == "1":
+        return fused_experts_impl(*args, **kwargs)
+    return _upstream_fused_moe._musa_original_fused_experts_impl(*args, **kwargs)
+
+
+_upstream_fused_moe.fused_experts_impl = _musa_fused_experts_impl_dispatch
+
+# The TritonExperts._supports_quant_scheme patch is independent; it expands
+# MUSA's supported FP8 quant key list and stays in place for upstream dispatch.
 vllm.model_executor.layers.fused_moe.fused_moe.TritonExperts._supports_quant_scheme = (
     _supports_quant_scheme
 )

--- a/vllm_musa/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm_musa/model_executor/layers/quantization/input_quant_fp8.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.platforms import current_platform
+
+from vllm_musa.model_executor.layers.quantization.utils import fp8_utils
+from vllm_musa.utils.environ import envs
+
+
+@QuantFP8.register_oot
+class MusaQuantFP8(QuantFP8):
+    def forward_oot(
+        self,
+        x: torch.Tensor,
+        scale: torch.Tensor | None = None,
+        scale_ub: torch.Tensor | None = None,
+        use_triton: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if envs.VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get():
+            return self.forward_native(x, scale, scale_ub, use_triton)
+
+        if self.is_group_quant and not self.static and current_platform.is_musa():
+            assert scale is None, "Dynamic group quantization does not use scale"
+            assert scale_ub is None, "Dynamic group quantization does not use scale_ub"
+            if x.dim() != 2:
+                return self.forward_native(x, scale, scale_ub, use_triton)
+            return fp8_utils.per_token_group_quant_fp8(
+                x,
+                group_size=self.group_size,
+                column_major_scales=self.column_major_scales,
+                tma_aligned_scales=self.tma_aligned_scales,
+                dtype=current_platform.fp8_dtype(),
+                use_ue8m0=self.use_ue8m0,
+            )
+
+        return self.forward_native(x, scale, scale_ub, use_triton)

--- a/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
@@ -10,6 +10,11 @@ from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import get_tma_aligned_size, is_deep_gemm_e8m0_used
 
 
+def _upcast_e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
+    exp_bits = scale.view(torch.uint8).to(torch.int32)
+    return (exp_bits << 23).view(torch.float32)
+
+
 def deepgemm_post_process_fp8_weight_block(
     wq: torch.Tensor,
     ws: torch.Tensor,
@@ -18,6 +23,10 @@ def deepgemm_post_process_fp8_weight_block(
     is_bmm: bool = False,
     bmm_batch_size: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    del quant_block_shape, is_bmm, bmm_batch_size
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if e8m0_dtype is not None and ws.dtype == e8m0_dtype and not use_e8m0:
+        return wq, _upcast_e8m0_to_fp32(ws)
     return wq, ws
 
 
@@ -55,6 +64,8 @@ def per_token_group_quant_fp8(
         f"by `group_size` {group_size}"
     )
     assert x.stride(-1) == 1, "`x` groups must be contiguous"
+    if current_platform.is_musa() and x.dim() == 2 and not x.is_contiguous():
+        x = x.contiguous()
 
     fp8_min, fp8_max = get_fp8_min_max()
 

--- a/vllm_musa/patches/__init__.py
+++ b/vllm_musa/patches/__init__.py
@@ -9,7 +9,9 @@ to ensure compatibility with the MUSA Triton version.
 
 import importlib.util
 import os
+import sys
 from pathlib import Path
+from types import ModuleType
 
 from vllm.logger import init_logger
 
@@ -35,22 +37,105 @@ def _get_patch_files():
     return patch_files
 
 
+def _load_patch_module(patch_file: Path) -> ModuleType | None:
+    """Load a patch module.
+
+    Patch files may define a PATCHES list of (old_str, new_str) tuples and an
+    optional normalize_source(source: str) -> str hook for idempotent cleanup.
+    """
+    spec = importlib.util.spec_from_file_location("patch_config", patch_file)
+    if spec is None or spec.loader is None:
+        return None
+
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+        return module
+    except Exception as e:
+        logger.warning(f"Failed to load patch config from {patch_file}: {e}")
+        return None
+
+
 def _load_patch_config(patch_file: Path) -> list[tuple[str, str]]:
     """Load patch configuration from a patch file.
 
     Patch files should define a PATCHES list of (old_str, new_str) tuples.
     """
-    spec = importlib.util.spec_from_file_location("patch_config", patch_file)
-    if spec is None or spec.loader is None:
+    module = _load_patch_module(patch_file)
+    if module is None:
         return []
+    return getattr(module, "PATCHES", [])
 
-    module = importlib.util.module_from_spec(spec)
+
+def _normalize_source(
+    patch_module: ModuleType,
+    source: str,
+    module_name: str,
+) -> str:
+    normalizer = getattr(patch_module, "normalize_source", None)
+    if not callable(normalizer):
+        return source
     try:
-        spec.loader.exec_module(module)
-        return getattr(module, "PATCHES", [])
+        normalized = normalizer(source)
     except Exception as e:
-        logger.warning(f"Failed to load patch config from {patch_file}: {e}")
-        return []
+        logger.warning(f"Failed to normalize patched source for {module_name}: {e}")
+        return source
+    if not isinstance(normalized, str):
+        logger.warning(
+            "Ignoring non-string normalized source returned for %s", module_name
+        )
+        return source
+    return normalized
+
+
+def _resolve_module_origin(module_name: str) -> str | None:
+    """Resolve a module source file without importing the target module."""
+    parts = module_name.split(".")
+    if parts and parts[0] == "vllm":
+        roots: list[Path] = []
+        try:
+            root_spec = importlib.util.find_spec("vllm")
+        except (ModuleNotFoundError, ImportError):
+            root_spec = None
+        if root_spec is not None:
+            if root_spec.submodule_search_locations:
+                roots.extend(Path(p) for p in root_spec.submodule_search_locations)
+            elif root_spec.origin is not None:
+                roots.append(Path(root_spec.origin).parent)
+        for sys_path in sys.path:
+            if not sys_path:
+                sys_path = os.getcwd()
+            candidate_root = Path(sys_path) / "vllm"
+            if candidate_root.is_dir():
+                roots.append(candidate_root)
+
+        seen: set[Path] = set()
+        for root in roots:
+            root = root.resolve()
+            if root in seen:
+                continue
+            seen.add(root)
+            rel = Path(*parts[1:]) if len(parts) > 1 else Path()
+            module_file = (root / rel).with_suffix(".py")
+            if module_file.is_file():
+                return str(module_file)
+            package_file = root / rel / "__init__.py"
+            if package_file.is_file():
+                return str(package_file)
+
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (ModuleNotFoundError, ImportError) as e:
+        logger.debug(
+            f"Module {module_name} not found or has import issues: {e}, "
+            "skipping patch (this is expected for version-specific patches "
+            "or when modules are not yet fully initialized)"
+        )
+        return None
+    if spec is None or spec.origin is None:
+        logger.debug(f"Module {module_name} not found, skipping patch")
+        return None
+    return spec.origin
 
 
 def apply_patches(force: bool = False):
@@ -66,34 +151,33 @@ def apply_patches(force: bool = False):
 
     for module_name, patch_file in patch_files:
         try:
-            # Find the module spec
-            try:
-                spec = importlib.util.find_spec(module_name)
-            except (ModuleNotFoundError, ImportError) as e:
-                # Module doesn't exist in this vLLM version (e.g., vllm.worker.worker
-                # exists in vLLM 0.10.x but not in 0.13.0 where V0 engine was removed)
-                # or has circular import issues during spec discovery
-                logger.debug(
-                    f"Module {module_name} not found or has import issues: {e}, "
-                    "skipping patch (this is expected for version-specific patches "
-                    "or when modules are not yet fully initialized)"
-                )
-                continue
-            if spec is None or spec.origin is None:
-                logger.debug(f"Module {module_name} not found, skipping patch")
+            # Resolve source path without importing the patched module. Several
+            # DeepSeek-V4 modules import MUSA attention helpers during module
+            # import, so importlib.find_spec(module_name) can trip plugin
+            # circularity before the patches that would make the import safe.
+            origin = _resolve_module_origin(module_name)
+            if origin is None:
                 continue
 
             # Read the source file
             try:
-                with open(spec.origin, "r") as f:
+                with open(origin, "r") as f:
                     source = f.read()
             except (IOError, OSError) as e:
-                logger.debug(f"Cannot read {spec.origin}: {e}, skipping patch")
+                logger.debug(f"Cannot read {origin}: {e}, skipping patch")
                 continue
 
-            # Load patches from patch file
-            patches = _load_patch_config(patch_file)
-            if not patches:
+            # Load patches from patch file. Loading can also install
+            # monkey-patches for patch modules that intentionally use an empty
+            # PATCHES list.
+            patch_module = _load_patch_module(patch_file)
+            if patch_module is None:
+                continue
+            patches = getattr(patch_module, "PATCHES", [])
+
+            patched_source = _normalize_source(patch_module, source, module_name)
+            source_normalized = patched_source != source
+            if not patches and not source_normalized:
                 continue
 
             # Check if any patches are needed.
@@ -103,8 +187,12 @@ def apply_patches(force: bool = False):
             # `new not in source` to detect "patch already applied" state.
             # Behaviour-preserving for REPLACEMENT-style patches where `new`
             # differs entirely from `old`.
-            needs_patch = any(
-                old in source and new not in source for old, new in patches
+            needs_patch = (
+                any(
+                    old in patched_source and new not in patched_source
+                    for old, new in patches
+                )
+                or source_normalized
             )
             if not needs_patch:
                 logger.debug(f"No patches needed for {module_name}")
@@ -116,12 +204,19 @@ def apply_patches(force: bool = False):
             # re-apply on every import and accumulate (e.g., MUSA-0088's
             # cuda_communicator.py grew 10 duplicate `elif current_platform.is_musa()`
             # blocks before MUSA-0089 caught it and manual sed -i restored).
-            patched_source = source
             applied_count = 0
             for old, new in patches:
                 if old in patched_source and new not in patched_source:
                     patched_source = patched_source.replace(old, new)
                     applied_count += 1
+            patched_source = _normalize_source(
+                patch_module,
+                patched_source,
+                module_name,
+            )
+            if patched_source == source:
+                logger.debug(f"No source changes produced for {module_name}")
+                continue
 
             # Write back the patched source ATOMICALLY via tempfile + rename.
             # Rationale: vLLM's spawn-based multiproc executor starts N worker
@@ -141,13 +236,13 @@ def apply_patches(force: bool = False):
             import tempfile  # noqa: I001 — local import keeps top-level imports stable
 
             tmp_fd, tmp_path = tempfile.mkstemp(
-                prefix=os.path.basename(spec.origin) + ".",
-                dir=os.path.dirname(spec.origin),
+                prefix=os.path.basename(origin) + ".",
+                dir=os.path.dirname(origin),
             )
             try:
                 with os.fdopen(tmp_fd, "w") as f:
                     f.write(patched_source)
-                os.rename(tmp_path, spec.origin)
+                os.rename(tmp_path, origin)
             except Exception:
                 # Best-effort cleanup on error.
                 try:

--- a/vllm_musa/patches/vllm__distributed__device_communicators__custom_all_reduce.patch.py
+++ b/vllm_musa/patches/vllm__distributed__device_communicators__custom_all_reduce.patch.py
@@ -5,7 +5,7 @@ Patch for vllm.distributed.device.communicators.custom_all_reduce.
 """
 
 PATCHES = [
-    # Patch CustomAllreduce.max_size
+    # Patch CustomAllreduce.max_size.
     (
         "max_size=8192 * 1024,",
         "max_size=16 * 8192 * 1024,",
@@ -15,7 +15,7 @@ PATCHES = [
         "if cuda_visible_devices:",
         "if cuda_visible_devices and current_platform.is_cuda():",
     ),
-    # Patch CustomAllreduce enable musa's custom_allreduce
+    # Patch CustomAllreduce enable musa's custom_allreduce.
     (
         "if not current_platform.is_rocm() and not _can_p2p(rank, world_size):",
         "if not current_platform.is_rocm() and not current_platform.is_musa() and not _can_p2p(rank, world_size):",
@@ -28,7 +28,7 @@ PATCHES = [
     # MUSA-0062 (torch 2.7.1): removed MUSA-0052's `world_size > 2` CAR
     # gate, re-enabling custom_all_reduce on MUSA for TP>2. The
     # compile-path safety (Inductor lowering past the Python alignment
-    # gate) was handled at the kernel level — see generated/musa0062/.
+    # gate) was handled at the kernel level; see generated/musa0062/.
     #
     # MUSA-0069 (torch >= 2.9): added a torch-version-aware `world_size
     # > 2` disable because the kernel rejected non-vector-aligned

--- a/vllm_musa/patches/vllm__distributed__parallel_state.patch.py
+++ b/vllm_musa/patches/vllm__distributed__parallel_state.patch.py
@@ -169,9 +169,7 @@ if _ENABLED:
             if not _is_musa():
                 return _orig_load_model(self, target_model)
             tp1 = _get_draft_tp1_group()
-            _log.info(
-                "MUSA-0124: constructing draft model under TP=1 context"
-            )
+            _log.info("MUSA-0124: constructing draft model under TP=1 context")
             with patch_tensor_parallel_group(tp1):
                 return _orig_load_model(self, target_model)
 
@@ -200,6 +198,5 @@ if _ENABLED:
         )
 else:
     _log.debug(
-        "MUSA-0124: draft-TP=1 patch dormant (set VLLM_MUSA_DRAFT_TP1=1 "
-        "to enable)"
+        "MUSA-0124: draft-TP=1 patch dormant (set VLLM_MUSA_DRAFT_TP1=1 " "to enable)"
     )

--- a/vllm_musa/patches/vllm__model_executor__layers__deepseek_compressor.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__layers__deepseek_compressor.patch.py
@@ -1,0 +1,1133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch DeepSeek-V4 compressor/cache paths with MUSA-specific gates.
+"""
+
+PATCHES = [
+    (
+        """from dataclasses import dataclass
+from typing import Any, ClassVar, cast
+""",
+        """import os
+from dataclasses import dataclass
+from typing import Any, ClassVar, cast
+""",
+    ),
+    (
+        """from vllm.forward_context import get_forward_context
+""",
+        """from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
+""",
+    ),
+    (
+        """class DeepseekCompressor(nn.Module):
+""",
+        """logger = init_logger(__name__)
+
+
+def _musa_deepseek_v4_is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or tensor.device.type == "musa"
+    )
+
+
+def _musa_deepseek_v4_apply_gptj_rope(
+    x: torch.Tensor,
+    position: torch.Tensor,
+    compress_ratio: int,
+    rope_head_dim: int,
+    cos_sin_cache: torch.Tensor,
+) -> torch.Tensor:
+    out = x.to(torch.float32).clone()
+    nope_head_dim = out.shape[-1] - rope_head_dim
+    compressed_pos = (
+        torch.div(position, compress_ratio, rounding_mode="floor")
+        * compress_ratio
+    ).to(torch.long)
+    cos_sin = cos_sin_cache[compressed_pos].to(torch.float32)
+    cos, sin = cos_sin.split(rope_head_dim // 2, dim=-1)
+    rope = out[..., nope_head_dim : nope_head_dim + rope_head_dim]
+    even = rope[..., 0::2]
+    odd = rope[..., 1::2]
+    rotated = torch.empty_like(rope)
+    rotated[..., 0::2] = even * cos - odd * sin
+    rotated[..., 1::2] = odd * cos + even * sin
+    out[..., nope_head_dim : nope_head_dim + rope_head_dim] = rotated
+    return out
+
+
+def _musa_deepseek_v4_e2m1_nibble(x: torch.Tensor) -> torch.Tensor:
+    abs_x = torch.minimum(
+        x.abs(), torch.full((), 6.0, dtype=torch.float32, device=x.device)
+    )
+    code = torch.where(
+        abs_x <= 0.25,
+        0,
+        torch.where(
+            abs_x <= 0.75,
+            1,
+            torch.where(
+                abs_x <= 1.25,
+                2,
+                torch.where(
+                    abs_x <= 1.75,
+                    3,
+                    torch.where(
+                        abs_x <= 2.5,
+                        4,
+                        torch.where(abs_x <= 3.5, 5, torch.where(abs_x <= 5.0, 6, 7)),
+                    ),
+                ),
+            ),
+        ),
+    ).to(torch.uint8)
+    sign = ((x < 0) & (code != 0)).to(torch.uint8)
+    return code | (sign << 3)
+
+
+def _musa_deepseek_v4_compressor_gemm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    x_bf16 = x.to(torch.bfloat16).to(torch.float32)
+    weight_bf16 = weight.to(torch.bfloat16).to(torch.float32)
+    return torch.nn.functional.linear(
+        x_bf16, weight_bf16
+    )
+
+
+def _musa_deepseek_v4_store_sparse_kv(
+    normed: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_slot_idx: torch.Tensor,
+    kv_cache_block_size: int,
+    rope_head_dim: int,
+) -> None:
+    fp8_dim = normed.shape[-1] - rope_head_dim
+    quant_block = 64
+    token_stride = fp8_dim + rope_head_dim * 2
+    scale_dim = fp8_dim // quant_block + 1
+    fp8_max = 448.0
+
+    block_idx = int(
+        torch.div(kv_slot_idx, kv_cache_block_size, rounding_mode="floor").item()
+    )
+    pos_in_block = int(kv_slot_idx.remainder(kv_cache_block_size).item())
+    if (
+        block_idx < 0
+        or block_idx >= kv_cache.shape[0]
+        or pos_in_block < 0
+        or pos_in_block >= kv_cache_block_size
+    ):
+        return
+    cache_block = kv_cache[block_idx].view(torch.uint8).flatten()
+    token_base = pos_in_block * token_stride
+    scale_base = kv_cache_block_size * token_stride + pos_in_block * scale_dim
+    quant_input = normed.to(torch.bfloat16).to(torch.float32)
+
+    for block_id in range(fp8_dim // quant_block):
+        start = block_id * quant_block
+        chunk = quant_input[start : start + quant_block]
+        amax = torch.maximum(
+            chunk.abs().amax(),
+            torch.full((), 1.0e-4, dtype=torch.float32, device=chunk.device),
+        )
+        exponent = torch.ceil(torch.log2(amax / fp8_max))
+        inv_scale = torch.exp2(-exponent)
+        qbytes = (
+            (chunk * inv_scale)
+            .clamp(-fp8_max, fp8_max)
+            .to(torch.float8_e4m3fn)
+            .view(torch.uint8)
+        )
+        cache_block[token_base + start : token_base + start + quant_block] = qbytes
+        cache_block[scale_base + block_id] = (
+            exponent + 127.0
+        ).clamp(0, 255).to(torch.uint8)
+    cache_block[scale_base + scale_dim - 1] = 0
+
+    rope_bytes = (
+        normed[fp8_dim : fp8_dim + rope_head_dim]
+        .to(torch.bfloat16)
+        .contiguous()
+        .view(torch.uint8)
+    )
+    cache_block[token_base + fp8_dim : token_base + token_stride] = rope_bytes
+
+
+def _musa_deepseek_v4_store_indexer_fp8(
+    normed: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_slot_idx: torch.Tensor,
+    kv_cache_block_size: int,
+) -> None:
+    head_dim = normed.shape[-1]
+    scale_dim = 4
+    fp8_max = 448.0
+    block_idx = int(
+        torch.div(kv_slot_idx, kv_cache_block_size, rounding_mode="floor").item()
+    )
+    pos_in_block = int(kv_slot_idx.remainder(kv_cache_block_size).item())
+    if (
+        block_idx < 0
+        or block_idx >= kv_cache.shape[0]
+        or pos_in_block < 0
+        or pos_in_block >= kv_cache_block_size
+    ):
+        return
+    cache_block = kv_cache[block_idx].view(torch.uint8).flatten()
+    token_base = pos_in_block * head_dim
+    scale_base = kv_cache_block_size * head_dim + pos_in_block * scale_dim
+    quant_input = normed.to(torch.bfloat16).to(torch.float32)
+    amax = torch.maximum(
+        quant_input.abs().amax(),
+        torch.full((), 1.0e-4, dtype=torch.float32, device=quant_input.device),
+    )
+    exponent = torch.ceil(torch.log2(amax / fp8_max))
+    scale = torch.exp2(exponent)
+    qbytes = (
+        (quant_input / scale)
+        .clamp(-fp8_max, fp8_max)
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+    )
+    cache_block[token_base : token_base + head_dim] = qbytes
+    cache_block[scale_base : scale_base + scale_dim] = (
+        scale.reshape(1).to(torch.float32).view(torch.uint8)
+    )
+
+
+def _musa_deepseek_v4_store_indexer_mxfp4(
+    normed: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_slot_idx: torch.Tensor,
+    kv_cache_block_size: int,
+) -> None:
+    head_dim = normed.shape[-1]
+    quant_block = MXFP4_BLOCK_SIZE
+    token_stride = head_dim // 2
+    scale_dim = head_dim // quant_block
+    block_idx = int(
+        torch.div(kv_slot_idx, kv_cache_block_size, rounding_mode="floor").item()
+    )
+    pos_in_block = int(kv_slot_idx.remainder(kv_cache_block_size).item())
+    if (
+        block_idx < 0
+        or block_idx >= kv_cache.shape[0]
+        or pos_in_block < 0
+        or pos_in_block >= kv_cache_block_size
+    ):
+        return
+    cache_block = kv_cache[block_idx].view(torch.uint8).flatten()
+    token_base = pos_in_block * token_stride
+    scale_base = kv_cache_block_size * token_stride + pos_in_block * scale_dim
+
+    x = normed.to(torch.bfloat16).to(torch.float32).reshape(scale_dim, quant_block)
+    even = x[:, 0::2]
+    odd = x[:, 1::2]
+    amax = torch.maximum(even.abs().amax(dim=1), odd.abs().amax(dim=1))
+    amax = torch.maximum(
+        amax, torch.full_like(amax, 1.0e-4, dtype=torch.float32)
+    )
+    exponent = torch.ceil(torch.log2(amax / 6.0)).clamp(-127.0, 127.0)
+    inv_scale = torch.exp2(-exponent).unsqueeze(-1)
+    lo = _musa_deepseek_v4_e2m1_nibble(even * inv_scale)
+    hi = _musa_deepseek_v4_e2m1_nibble(odd * inv_scale)
+    packed = (lo | (hi << 4)).reshape(-1)
+    cache_block[token_base : token_base + token_stride] = packed
+    cache_block[scale_base : scale_base + scale_dim] = (
+        exponent + 127.0
+    ).to(torch.uint8)
+
+
+def _musa_deepseek_v4_is_current_stream_capturing() -> bool:
+    cuda_module = getattr(torch, "cuda", None)
+    if cuda_module is None:
+        return False
+    is_capturing = getattr(cuda_module, "is_current_stream_capturing", None)
+    if is_capturing is None:
+        return False
+    try:
+        return bool(is_capturing())
+    except Exception:
+        return False
+
+
+def _musa_deepseek_v4_vectorized_eager_compressor_enabled() -> bool:
+    return (
+        os.getenv(
+            "VLLM_MUSA_DEEPSEEK_V4_COMPRESSOR_VECTORIZE_EAGER",
+            "0",
+        )
+        == "1"
+    )
+
+
+def _musa_deepseek_v4_native_sparse_store_enabled() -> bool:
+    return (
+        os.getenv(
+            "VLLM_MUSA_DEEPSEEK_V4_NATIVE_SPARSE_STORE",
+            "0",
+        )
+        == "1"
+    )
+
+
+def _musa_deepseek_v4_triton_compressor_enabled() -> bool:
+    return (
+        os.getenv(
+            "VLLM_MUSA_DEEPSEEK_V4_COMPRESSOR_TRITON",
+            "1",
+        )
+        == "1"
+    )
+
+
+def _musa_deepseek_v4_native_store_sparse_kv(
+    normed: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_slots: torch.Tensor,
+    kv_cache_block_size: int,
+    write_mask: torch.Tensor,
+) -> None:
+    if kv_cache_block_size != kv_cache.shape[1]:
+        raise AssertionError(
+            "native DeepSeek-V4 sparse store expects kv_cache_block_size "
+            f"to match kv_cache.shape[1], got {kv_cache_block_size} and "
+            f"{kv_cache.shape[1]}"
+        )
+    from vllm_musa import _custom_ops as _musa_custom_ops
+
+    _musa_custom_ops.deepseek_v4_store_sparse_kv(
+        normed.to(torch.bfloat16).contiguous(),
+        kv_cache,
+        kv_slots.contiguous(),
+        write_mask.to(torch.bool).contiguous(),
+    )
+
+
+def _musa_deepseek_v4_save_partial_states_capture(
+    kv: torch.Tensor,
+    score: torch.Tensor,
+    positions: torch.Tensor,
+    ape: torch.Tensor,
+    state_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_size: int,
+    compress_ratio: int,
+) -> torch.Tensor:
+    num_actual = min(slot_mapping.shape[0], kv.shape[0])
+    state_width = state_cache.shape[-1] // 2
+    kv_width = kv.shape[-1]
+    state_capacity = state_cache.shape[0] * block_size
+
+    slots = slot_mapping[:num_actual].to(torch.long)
+    valid = (slots >= 0) & (slots < state_capacity)
+    safe_slots = slots.clamp(0, state_capacity - 1)
+    block_idx = torch.div(safe_slots, block_size, rounding_mode="floor")
+    pos_in_block = safe_slots.remainder(block_size)
+
+    ape_rows = positions[:num_actual].remainder(compress_ratio).to(torch.long)
+    score_with_ape = score[:num_actual] + ape[ape_rows]
+
+    existing_kv = state_cache[block_idx, pos_in_block, :kv_width]
+    state_cache[block_idx, pos_in_block, :kv_width] = torch.where(
+        valid.unsqueeze(-1), kv[:num_actual], existing_kv
+    )
+
+    existing_score = state_cache[
+        block_idx,
+        pos_in_block,
+        state_width : state_width + kv_width,
+    ]
+    state_cache[
+        block_idx,
+        pos_in_block,
+        state_width : state_width + kv_width,
+    ] = torch.where(valid.unsqueeze(-1), score_with_ape, existing_score)
+    return valid
+
+
+def _musa_deepseek_v4_gather_compressed_states_capture(
+    module: "DeepseekCompressor",
+    positions: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    state_cache: torch.Tensor,
+    block_size: int,
+    num_actual: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    window = module.coff * module.compress_ratio
+    device = positions.device
+    offsets = torch.arange(window, device=device, dtype=positions.dtype)
+    rel_positions = positions[:num_actual].unsqueeze(-1) - window + 1 + offsets
+
+    valid_pos = rel_positions >= 0
+    block_indices = torch.div(rel_positions, block_size, rounding_mode="floor")
+    valid_block_index = (
+        valid_pos
+        & (block_indices >= 0)
+        & (block_indices < block_table.shape[1])
+    )
+    safe_block_indices = block_indices.clamp(0, block_table.shape[1] - 1).to(
+        torch.long
+    )
+
+    req_indices = token_to_req_indices[:num_actual].to(torch.long).clamp(
+        0, block_table.shape[0] - 1
+    )
+    block_numbers = block_table[req_indices.unsqueeze(-1), safe_block_indices].to(
+        torch.long
+    )
+    valid_blocks = (
+        valid_block_index
+        & (block_numbers >= 0)
+        & (block_numbers < state_cache.shape[0])
+    )
+    safe_block_numbers = block_numbers.clamp(0, state_cache.shape[0] - 1)
+    block_offsets = rel_positions.remainder(block_size).to(torch.long)
+
+    flat_indices = safe_block_numbers * block_size + block_offsets
+    flat_state = state_cache.reshape(
+        state_cache.shape[0] * state_cache.shape[1],
+        state_cache.shape[2],
+    )
+    gathered = flat_state.index_select(0, flat_indices.reshape(-1)).reshape(
+        num_actual,
+        window,
+        state_cache.shape[-1],
+    )
+
+    head_offsets = (
+        (offsets >= module.compress_ratio).to(torch.long) * module.head_dim
+    )
+    head_cols = head_offsets.unsqueeze(-1) + torch.arange(
+        module.head_dim,
+        device=device,
+        dtype=torch.long,
+    )
+    head_cols = head_cols.unsqueeze(0).expand(num_actual, -1, -1)
+    state_width = state_cache.shape[-1] // 2
+
+    kv_rows = torch.gather(gathered, 2, head_cols)
+    score_rows = torch.gather(gathered, 2, head_cols + state_width)
+    valid_expanded = valid_blocks.unsqueeze(-1)
+    kv_rows = torch.where(valid_expanded, kv_rows, torch.zeros_like(kv_rows))
+    score_rows = torch.where(
+        valid_expanded,
+        score_rows,
+        torch.full_like(score_rows, -1.0e20),
+    )
+    weights = torch.softmax(score_rows, dim=1)
+    compressed = (kv_rows * weights).sum(dim=1)
+    has_rows = valid_blocks.any(dim=1)
+    return compressed, has_rows
+
+
+def _musa_deepseek_v4_cache_u8_2d(kv_cache: torch.Tensor) -> torch.Tensor:
+    return kv_cache.view(torch.uint8).reshape(kv_cache.shape[0], -1)
+
+
+def _musa_deepseek_v4_write_cache_rows_capture(
+    cache_u8: torch.Tensor,
+    block_idx: torch.Tensor,
+    cols: torch.Tensor,
+    values: torch.Tensor,
+    write_mask: torch.Tensor,
+) -> None:
+    rows = block_idx.unsqueeze(-1).expand_as(cols)
+    existing = cache_u8[rows, cols]
+    cache_u8[rows, cols] = torch.where(write_mask.unsqueeze(-1), values, existing)
+
+
+def _musa_deepseek_v4_store_sparse_kv_capture(
+    normed: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_slots: torch.Tensor,
+    kv_cache_block_size: int,
+    rope_head_dim: int,
+    write_mask: torch.Tensor,
+) -> None:
+    if rope_head_dim == 64 and _musa_deepseek_v4_native_sparse_store_enabled():
+        return _musa_deepseek_v4_native_store_sparse_kv(
+            normed, kv_cache, kv_slots, kv_cache_block_size, write_mask
+        )
+    fp8_dim = normed.shape[-1] - rope_head_dim
+    quant_block = 64
+    token_stride = fp8_dim + rope_head_dim * 2
+    scale_dim = fp8_dim // quant_block + 1
+    fp8_max = 448.0
+
+    cache_u8 = _musa_deepseek_v4_cache_u8_2d(kv_cache)
+    cache_capacity = kv_cache.shape[0] * kv_cache_block_size
+    slots = kv_slots.to(torch.long)
+    valid_slots = (slots >= 0) & (slots < cache_capacity)
+    safe_slots = slots.clamp(0, cache_capacity - 1)
+    block_idx = torch.div(safe_slots, kv_cache_block_size, rounding_mode="floor")
+    pos_in_block = safe_slots.remainder(kv_cache_block_size)
+    final_write_mask = write_mask & valid_slots
+
+    quant_input = normed[:, :fp8_dim].to(torch.bfloat16).to(torch.float32)
+    chunks = quant_input.reshape(normed.shape[0], fp8_dim // quant_block, quant_block)
+    amax = torch.maximum(
+        chunks.abs().amax(dim=-1),
+        torch.full_like(chunks[..., 0], 1.0e-4, dtype=torch.float32),
+    )
+    exponent = torch.ceil(torch.log2(amax / fp8_max))
+    inv_scale = torch.exp2(-exponent).unsqueeze(-1)
+    qbytes = (
+        (chunks * inv_scale)
+        .clamp(-fp8_max, fp8_max)
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+        .reshape(normed.shape[0], fp8_dim)
+    )
+    rope_bytes = (
+        normed[:, fp8_dim : fp8_dim + rope_head_dim]
+        .to(torch.bfloat16)
+        .contiguous()
+        .view(torch.uint8)
+        .reshape(normed.shape[0], rope_head_dim * 2)
+    )
+    value_bytes = torch.cat([qbytes, rope_bytes], dim=-1)
+    value_cols = pos_in_block.unsqueeze(-1) * token_stride + torch.arange(
+        token_stride,
+        device=normed.device,
+        dtype=torch.long,
+    )
+    _musa_deepseek_v4_write_cache_rows_capture(
+        cache_u8, block_idx, value_cols, value_bytes, final_write_mask
+    )
+
+    scale_values = torch.cat(
+        [
+            (exponent + 127.0).clamp(0, 255).to(torch.uint8),
+            torch.zeros((normed.shape[0], 1), device=normed.device, dtype=torch.uint8),
+        ],
+        dim=-1,
+    )
+    scale_cols = (
+        kv_cache_block_size * token_stride
+        + pos_in_block.unsqueeze(-1) * scale_dim
+        + torch.arange(scale_dim, device=normed.device, dtype=torch.long)
+    )
+    _musa_deepseek_v4_write_cache_rows_capture(
+        cache_u8, block_idx, scale_cols, scale_values, final_write_mask
+    )
+
+
+def _musa_deepseek_v4_store_indexer_fp8_capture(
+    normed: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_slots: torch.Tensor,
+    kv_cache_block_size: int,
+    write_mask: torch.Tensor,
+) -> None:
+    head_dim = normed.shape[-1]
+    scale_dim = 4
+    fp8_max = 448.0
+    cache_u8 = _musa_deepseek_v4_cache_u8_2d(kv_cache)
+    cache_capacity = kv_cache.shape[0] * kv_cache_block_size
+    slots = kv_slots.to(torch.long)
+    valid_slots = (slots >= 0) & (slots < cache_capacity)
+    safe_slots = slots.clamp(0, cache_capacity - 1)
+    block_idx = torch.div(safe_slots, kv_cache_block_size, rounding_mode="floor")
+    pos_in_block = safe_slots.remainder(kv_cache_block_size)
+    final_write_mask = write_mask & valid_slots
+
+    quant_input = normed.to(torch.bfloat16).to(torch.float32)
+    amax = torch.maximum(
+        quant_input.abs().amax(dim=-1),
+        torch.full((normed.shape[0],), 1.0e-4, dtype=torch.float32, device=normed.device),
+    )
+    exponent = torch.ceil(torch.log2(amax / fp8_max))
+    scale = torch.exp2(exponent)
+    qbytes = (
+        (quant_input / scale.unsqueeze(-1))
+        .clamp(-fp8_max, fp8_max)
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+        .reshape(normed.shape[0], head_dim)
+    )
+    value_cols = pos_in_block.unsqueeze(-1) * head_dim + torch.arange(
+        head_dim,
+        device=normed.device,
+        dtype=torch.long,
+    )
+    _musa_deepseek_v4_write_cache_rows_capture(
+        cache_u8, block_idx, value_cols, qbytes, final_write_mask
+    )
+
+    scale_bytes = scale.to(torch.float32).contiguous().view(torch.uint8).reshape(
+        normed.shape[0], scale_dim
+    )
+    scale_cols = (
+        kv_cache_block_size * head_dim
+        + pos_in_block.unsqueeze(-1) * scale_dim
+        + torch.arange(scale_dim, device=normed.device, dtype=torch.long)
+    )
+    _musa_deepseek_v4_write_cache_rows_capture(
+        cache_u8, block_idx, scale_cols, scale_bytes, final_write_mask
+    )
+
+
+def _musa_deepseek_v4_store_indexer_mxfp4_capture(
+    normed: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_slots: torch.Tensor,
+    kv_cache_block_size: int,
+    write_mask: torch.Tensor,
+) -> None:
+    head_dim = normed.shape[-1]
+    quant_block = MXFP4_BLOCK_SIZE
+    token_stride = head_dim // 2
+    scale_dim = head_dim // quant_block
+    cache_u8 = _musa_deepseek_v4_cache_u8_2d(kv_cache)
+    cache_capacity = kv_cache.shape[0] * kv_cache_block_size
+    slots = kv_slots.to(torch.long)
+    valid_slots = (slots >= 0) & (slots < cache_capacity)
+    safe_slots = slots.clamp(0, cache_capacity - 1)
+    block_idx = torch.div(safe_slots, kv_cache_block_size, rounding_mode="floor")
+    pos_in_block = safe_slots.remainder(kv_cache_block_size)
+    final_write_mask = write_mask & valid_slots
+
+    x = normed.to(torch.bfloat16).to(torch.float32).reshape(
+        normed.shape[0], scale_dim, quant_block
+    )
+    even = x[..., 0::2]
+    odd = x[..., 1::2]
+    amax = torch.maximum(even.abs().amax(dim=-1), odd.abs().amax(dim=-1))
+    amax = torch.maximum(amax, torch.full_like(amax, 1.0e-4, dtype=torch.float32))
+    exponent = torch.ceil(torch.log2(amax / 6.0)).clamp(-127.0, 127.0)
+    inv_scale = torch.exp2(-exponent).unsqueeze(-1)
+    lo = _musa_deepseek_v4_e2m1_nibble(even * inv_scale)
+    hi = _musa_deepseek_v4_e2m1_nibble(odd * inv_scale)
+    packed = (lo | (hi << 4)).reshape(normed.shape[0], token_stride)
+    value_cols = pos_in_block.unsqueeze(-1) * token_stride + torch.arange(
+        token_stride,
+        device=normed.device,
+        dtype=torch.long,
+    )
+    _musa_deepseek_v4_write_cache_rows_capture(
+        cache_u8, block_idx, value_cols, packed, final_write_mask
+    )
+
+    scale_values = (exponent + 127.0).to(torch.uint8)
+    scale_cols = (
+        kv_cache_block_size * token_stride
+        + pos_in_block.unsqueeze(-1) * scale_dim
+        + torch.arange(scale_dim, device=normed.device, dtype=torch.long)
+    )
+    _musa_deepseek_v4_write_cache_rows_capture(
+        cache_u8, block_idx, scale_cols, scale_values, final_write_mask
+    )
+
+
+def _musa_deepseek_v4_compressor_forward_capture(
+    module: "DeepseekCompressor",
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    rotary_emb,
+) -> None:
+    num_tokens, _ = x.shape
+    kv_score = _musa_deepseek_v4_compressor_gemm(
+        x, module.fused_wkv_wgate.weight
+    )
+    kv, score = kv_score.split(
+        [module.coff * module.head_dim, module.coff * module.head_dim],
+        dim=-1,
+    )
+
+    attn_metadata = get_forward_context().attn_metadata
+    if not isinstance(attn_metadata, dict):
+        return
+
+    state_metadata = cast(
+        CompressorMetadata, attn_metadata[module.state_cache.prefix]
+    )
+    token_to_req_indices = state_metadata.token_to_req_indices
+    if token_to_req_indices is None:
+        return
+    slot_mapping = state_metadata.slot_mapping
+    num_actual = min(slot_mapping.shape[0], num_tokens)
+    block_table = state_metadata.block_table
+    block_size = state_metadata.block_size
+    state_cache = module.state_cache.kv_cache
+
+    valid_state_slots = _musa_deepseek_v4_save_partial_states_capture(
+        kv,
+        score,
+        positions,
+        module.ape,
+        state_cache,
+        slot_mapping,
+        block_size,
+        module.compress_ratio,
+    )
+    compressed, has_rows = _musa_deepseek_v4_gather_compressed_states_capture(
+        module,
+        positions,
+        token_to_req_indices,
+        block_table,
+        state_cache,
+        block_size,
+        num_actual,
+    )
+    variance = compressed.pow(2).mean(dim=-1, keepdim=True)
+    normed = (
+        compressed
+        * torch.rsqrt(variance + module.rms_norm_eps)
+        * module.norm.weight.to(torch.float32)
+    )
+    normed = _musa_deepseek_v4_apply_gptj_rope(
+        normed,
+        positions[:num_actual],
+        module.compress_ratio,
+        module.rope_head_dim,
+        rotary_emb.cos_sin_cache,
+    )
+
+    k_cache_metadata = cast(Any, attn_metadata[module.k_cache_prefix])
+    kv_cache = module._static_forward_context[module.k_cache_prefix].kv_cache
+    kv_slot_mapping = k_cache_metadata.slot_mapping[:num_actual]
+    compress_boundary = (
+        (positions[:num_actual] + 1).remainder(module.compress_ratio) == 0
+    )
+    write_mask = valid_state_slots & compress_boundary & has_rows
+
+    if module.head_dim == 512:
+        _musa_deepseek_v4_store_sparse_kv_capture(
+            normed,
+            kv_cache,
+            kv_slot_mapping,
+            kv_cache.shape[1],
+            module.rope_head_dim,
+            write_mask,
+        )
+    elif module.use_fp4_cache:
+        _musa_deepseek_v4_store_indexer_mxfp4_capture(
+            normed,
+            kv_cache,
+            kv_slot_mapping,
+            kv_cache.shape[1],
+            write_mask,
+        )
+    else:
+        _musa_deepseek_v4_store_indexer_fp8_capture(
+            normed,
+            kv_cache,
+            kv_slot_mapping,
+            kv_cache.shape[1],
+            write_mask,
+        )
+
+
+def _musa_deepseek_v4_compressor_forward_triton(
+    module: "DeepseekCompressor",
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    rotary_emb,
+) -> None:
+    num_tokens, _ = x.shape
+    kv_score = _musa_deepseek_v4_compressor_gemm(
+        x, module.fused_wkv_wgate.weight
+    )
+    kv, score = kv_score.split(
+        [module.coff * module.head_dim, module.coff * module.head_dim],
+        dim=-1,
+    )
+
+    attn_metadata = get_forward_context().attn_metadata
+    if not isinstance(attn_metadata, dict):
+        return
+
+    state_metadata = cast(
+        CompressorMetadata, attn_metadata[module.state_cache.prefix]
+    )
+    token_to_req_indices = state_metadata.token_to_req_indices
+    if token_to_req_indices is None:
+        return
+    slot_mapping = state_metadata.slot_mapping
+    num_actual = min(slot_mapping.shape[0], num_tokens)
+    block_table = state_metadata.block_table
+    block_size = state_metadata.block_size
+
+    state_cache = module.state_cache.kv_cache
+    state_width = state_cache.shape[-1] // 2
+
+    _save_partial_states_kernel[(num_actual,)](
+        kv,
+        kv.stride(0),
+        score,
+        score.stride(0),
+        module.ape,
+        module.ape.stride(0),
+        positions,
+        state_cache,
+        state_cache.stride(0),
+        state_cache.stride(1),
+        slot_mapping,
+        block_size,
+        HEAD_SIZE=kv.shape[-1],
+        TRITON_BLOCK_SIZE=triton.next_power_of_2(kv.shape[-1]),
+        STATE_WIDTH=state_width,
+        COMPRESS_RATIO=module.compress_ratio,
+    )
+
+    cos_sin_cache = rotary_emb.cos_sin_cache
+    k_cache_metadata = cast(Any, attn_metadata[module.k_cache_prefix])
+    kv_cache = module._static_forward_context[module.k_cache_prefix].kv_cache
+
+    module._fused_kernel[(num_actual,)](
+        state_cache,
+        state_cache.stride(0),
+        state_cache.stride(1),
+        token_to_req_indices,
+        positions,
+        slot_mapping,
+        block_table,
+        block_table.stride(0),
+        block_size,
+        module.norm.weight,
+        module.rms_norm_eps,
+        cos_sin_cache,
+        cos_sin_cache.stride(0),
+        kv_cache,
+        k_cache_metadata.slot_mapping,
+        kv_cache.shape[1],
+        HEAD_SIZE=module.head_dim,
+        TRITON_BLOCK_SIZE=triton.next_power_of_2(module.head_dim),
+        STATE_WIDTH=state_width,
+        COMPRESS_RATIO=module.compress_ratio,
+        OVERLAP=module.overlap,
+        ROPE_HEAD_DIM=module.rope_head_dim,
+        FP8_MAX=448.0,
+        QUANT_BLOCK=module._quant_block,
+        TOKEN_STRIDE=module._token_stride,
+        SCALE_DIM=module._scale_dim,
+        KV_BLOCK_STRIDE=kv_cache.stride(0),
+        num_warps=module._num_warps,
+    )
+
+
+def _musa_deepseek_v4_compressor_forward(
+    module: "DeepseekCompressor",
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    rotary_emb,
+) -> None:
+    if _musa_deepseek_v4_triton_compressor_enabled():
+        return _musa_deepseek_v4_compressor_forward_triton(
+            module, x, positions, rotary_emb
+        )
+    if (
+        _musa_deepseek_v4_is_current_stream_capturing()
+        or _musa_deepseek_v4_vectorized_eager_compressor_enabled()
+    ):
+        return _musa_deepseek_v4_compressor_forward_capture(
+            module, x, positions, rotary_emb
+        )
+    num_tokens, _ = x.shape
+    kv_score = _musa_deepseek_v4_compressor_gemm(
+        x, module.fused_wkv_wgate.weight
+    )
+    kv, score = kv_score.split(
+        [module.coff * module.head_dim, module.coff * module.head_dim],
+        dim=-1,
+    )
+
+    attn_metadata = get_forward_context().attn_metadata
+    if not isinstance(attn_metadata, dict):
+        return
+
+    state_metadata = cast(
+        CompressorMetadata, attn_metadata[module.state_cache.prefix]
+    )
+    token_to_req_indices = state_metadata.token_to_req_indices
+    slot_mapping = state_metadata.slot_mapping
+    num_actual = min(slot_mapping.shape[0], num_tokens)
+    block_table = state_metadata.block_table
+    block_size = state_metadata.block_size
+
+    state_cache = module.state_cache.kv_cache
+    state_width = state_cache.shape[-1] // 2
+    kv_width = kv.shape[-1]
+
+    valid_slots = slot_mapping[:num_actual]
+    state_cache_capacity = state_cache.shape[0] * block_size
+    valid_mask = (valid_slots >= 0) & (valid_slots < state_cache_capacity)
+    if bool(torch.any(valid_mask).item()):
+        valid_indices = torch.nonzero(valid_mask, as_tuple=False).flatten()
+        slots = valid_slots[valid_indices].to(torch.long)
+        block_idx = torch.div(slots, block_size, rounding_mode="floor")
+        pos_in_block = slots.remainder(block_size)
+        state_cache[block_idx, pos_in_block, :kv_width] = kv[valid_indices]
+        ape_rows = positions[:num_actual][valid_indices].remainder(
+            module.compress_ratio
+        ).to(torch.long)
+        state_cache[block_idx, pos_in_block, state_width : state_width + kv_width] = (
+            score[valid_indices] + module.ape[ape_rows]
+        )
+
+    cos_sin_cache = rotary_emb.cos_sin_cache
+    k_cache_metadata = cast(Any, attn_metadata[module.k_cache_prefix])
+    kv_cache = module._static_forward_context[module.k_cache_prefix].kv_cache
+    kv_slot_mapping = k_cache_metadata.slot_mapping
+    native_sparse_store = (
+        module.head_dim == 512
+        and module.rope_head_dim == 64
+        and _musa_deepseek_v4_native_sparse_store_enabled()
+    )
+    native_sparse_normed_rows: list[torch.Tensor] = []
+    native_sparse_slots: list[torch.Tensor] = []
+
+    for token_idx in range(num_actual):
+        slot = slot_mapping[token_idx]
+        if slot < 0:
+            continue
+        position = positions[token_idx]
+        if int((position + 1).item()) % module.compress_ratio != 0:
+            continue
+        kv_slot_idx = kv_slot_mapping[token_idx]
+        if kv_slot_idx < 0:
+            continue
+
+        req_idx = token_to_req_indices[token_idx].to(torch.long)
+        start = int((position - module.coff * module.compress_ratio + 1).item())
+        kv_rows = []
+        score_rows = []
+        for offset_idx in range(module.coff * module.compress_ratio):
+            pos = start + offset_idx
+            if pos < 0:
+                continue
+            block_index = pos // block_size
+            if block_index >= block_table.shape[1]:
+                continue
+            block_number = block_table[req_idx, block_index].to(torch.long)
+            if block_number < 0:
+                continue
+            if int(block_number.item()) >= state_cache.shape[0]:
+                continue
+            block_offset = pos % block_size
+            head_offset = module.head_dim if offset_idx >= module.compress_ratio else 0
+            kv_rows.append(
+                state_cache[
+                    block_number,
+                    block_offset,
+                    head_offset : head_offset + module.head_dim,
+                ].to(torch.float32)
+            )
+            score_rows.append(
+                state_cache[
+                    block_number,
+                    block_offset,
+                    state_width + head_offset : state_width + head_offset + module.head_dim,
+                ].to(torch.float32)
+            )
+        if not kv_rows:
+            continue
+        kv_stack = torch.stack(kv_rows, dim=0)
+        score_stack = torch.stack(score_rows, dim=0)
+        weights = torch.softmax(score_stack, dim=0)
+        compressed = (kv_stack * weights).sum(dim=0)
+        variance = compressed.pow(2).sum() / module.head_dim
+        normed = (
+            compressed
+            * torch.rsqrt(variance + module.rms_norm_eps)
+            * module.norm.weight.to(torch.float32)
+        )
+        normed = _musa_deepseek_v4_apply_gptj_rope(
+            normed,
+            position,
+            module.compress_ratio,
+            module.rope_head_dim,
+            cos_sin_cache,
+        )
+        if module.head_dim == 512:
+            if native_sparse_store:
+                native_sparse_normed_rows.append(normed)
+                native_sparse_slots.append(kv_slot_idx.to(torch.long))
+            else:
+                _musa_deepseek_v4_store_sparse_kv(
+                    normed,
+                    kv_cache,
+                    kv_slot_idx.to(torch.long),
+                    kv_cache.shape[1],
+                    module.rope_head_dim,
+                )
+        elif module.use_fp4_cache:
+            _musa_deepseek_v4_store_indexer_mxfp4(
+                normed,
+                kv_cache,
+                kv_slot_idx.to(torch.long),
+                kv_cache.shape[1],
+            )
+        else:
+            _musa_deepseek_v4_store_indexer_fp8(
+                normed,
+                kv_cache,
+                kv_slot_idx.to(torch.long),
+                kv_cache.shape[1],
+            )
+
+    if native_sparse_store and native_sparse_normed_rows:
+        native_normed = torch.stack(native_sparse_normed_rows, dim=0)
+        native_slots = torch.stack(native_sparse_slots, dim=0)
+        native_mask = torch.ones(
+            (native_normed.shape[0],),
+            dtype=torch.bool,
+            device=native_normed.device,
+        )
+        _musa_deepseek_v4_native_store_sparse_kv(
+            native_normed,
+            kv_cache,
+            native_slots,
+            kv_cache.shape[1],
+            native_mask,
+        )
+
+
+class DeepseekCompressor(nn.Module):
+""",
+    ),
+    (
+        """    def forward(
+        self,
+        # [num_tokens, hidden_size]
+        x: torch.Tensor,
+        # [num_tokens]
+        positions: torch.Tensor,
+        rotary_emb,
+    ) -> None:
+        num_tokens, _ = x.shape
+""",
+        """    def forward(
+        self,
+        # [num_tokens, hidden_size]
+        x: torch.Tensor,
+        # [num_tokens]
+        positions: torch.Tensor,
+        rotary_emb,
+    ) -> None:
+        if (
+            _musa_deepseek_v4_is_musa_tensor(x)
+            and os.getenv(
+                "VLLM_MUSA_ENABLE_TORCH_DEEPSEEK_V4_COMPRESSOR_FALLBACK",
+                "0",
+            )
+            == "1"
+        ):
+            # Do not log from forward: this path may run while TorchDynamo is
+            # active, where logger calls cause graph breaks.
+            return _musa_deepseek_v4_compressor_forward(
+                self, x, positions, rotary_emb
+            )
+        if _musa_deepseek_v4_is_musa_tensor(x):
+            raise NotImplementedError(
+                "DeepSeek-V4 compressor/cache updates are not implemented for "
+                "MUSA yet. A MUSA implementation of the fused compress, "
+                "RMSNorm/RoPE, FP8/MXFP4 quantization, and KV-cache insert "
+                "path is required before model execution can proceed."
+            )
+        num_tokens, _ = x.shape
+""",
+    ),
+    (
+        """        if (
+            current_platform.is_musa()
+            or getattr(torch.version, "musa", None) is not None
+            or x.device.type == "musa"
+        ):
+            raise NotImplementedError(
+                "DeepSeek-V4 compressor/cache updates are not implemented for "
+                "MUSA yet. A MUSA implementation of the fused compress, "
+                "RMSNorm/RoPE, FP8/MXFP4 quantization, and KV-cache insert "
+                "path is required before model execution can proceed."
+            )
+        num_tokens, _ = x.shape
+""",
+        """        if (
+            _musa_deepseek_v4_is_musa_tensor(x)
+            and os.getenv(
+                "VLLM_MUSA_ENABLE_TORCH_DEEPSEEK_V4_COMPRESSOR_FALLBACK",
+                "0",
+            )
+            == "1"
+        ):
+            # Do not log from forward: this path may run while TorchDynamo is
+            # active, where logger calls cause graph breaks.
+            return _musa_deepseek_v4_compressor_forward(
+                self, x, positions, rotary_emb
+            )
+        if _musa_deepseek_v4_is_musa_tensor(x):
+            raise NotImplementedError(
+                "DeepSeek-V4 compressor/cache updates are not implemented for "
+                "MUSA yet. A MUSA implementation of the fused compress, "
+                "RMSNorm/RoPE, FP8/MXFP4 quantization, and KV-cache insert "
+                "path is required before model execution can proceed."
+            )
+        num_tokens, _ = x.shape
+""",
+    ),
+    (
+        """        STATE_WIDTH=state_width,
+        COMPRESS_RATIO=module.compress_ratio,
+        launch_pdl=False,
+""",
+        """        STATE_WIDTH=state_width,
+        COMPRESS_RATIO=module.compress_ratio,
+        # launch_pdl omitted: MUSA Triton rejects this kwarg.
+""",
+    ),
+    (
+        """        STATE_WIDTH=state_width,
+        COMPRESS_RATIO=self.compress_ratio,
+        launch_pdl=False,
+""",
+        """        STATE_WIDTH=state_width,
+        COMPRESS_RATIO=self.compress_ratio,
+        # launch_pdl omitted: MUSA Triton rejects this kwarg.
+""",
+    ),
+    (
+        """        KV_BLOCK_STRIDE=kv_cache.stride(0),
+        num_warps=module._num_warps,
+        launch_pdl=False,
+""",
+        """        KV_BLOCK_STRIDE=kv_cache.stride(0),
+        num_warps=module._num_warps,
+        # launch_pdl omitted: MUSA Triton rejects this kwarg.
+""",
+    ),
+    (
+        """        KV_BLOCK_STRIDE=kv_cache.stride(0),
+        num_warps=self._num_warps,
+        launch_pdl=False,
+""",
+        """        KV_BLOCK_STRIDE=kv_cache.stride(0),
+        num_warps=self._num_warps,
+        # launch_pdl omitted: MUSA Triton rejects this kwarg.
+""",
+    ),
+    (
+        """def _musa_deepseek_v4_cache_u8_2d(kv_cache: torch.Tensor) -> torch.Tensor:
+    return kv_cache.view(torch.uint8).reshape(kv_cache.shape[0], -1)
+""",
+        """def _musa_deepseek_v4_cache_u8_2d(kv_cache: torch.Tensor) -> torch.Tensor:
+    cache_u8 = kv_cache.view(torch.uint8)
+    row_stride = int(kv_cache.stride(0)) * kv_cache.element_size()
+    if cache_u8.stride(-1) != 1:
+        raise RuntimeError(
+            "DeepSeek-V4 MUSA cache writer expects byte-contiguous cache rows, "
+            f"got shape={tuple(kv_cache.shape)} stride={tuple(kv_cache.stride())}"
+        )
+    return cache_u8.as_strided((kv_cache.shape[0], row_stride), (row_stride, 1))
+""",
+    ),
+]
+
+RELOAD_AFTER_PATCH = True

--- a/vllm_musa/patches/vllm__model_executor__layers__deepseek_v4_attention.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__layers__deepseek_v4_attention.patch.py
@@ -1,0 +1,839 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch DeepSeek-V4 attention to use MUSA sparse FlashMLA backend shims.
+"""
+
+
+def normalize_source(source: str) -> str:
+    """Remove stale MUSA-3044 prewarm WIP from already-patched vLLM sources."""
+    source = source.replace(
+        """from vllm_musa.v1.attention.ops.flashmla import (
+    flash_mla_sparse_fwd,
+    flash_mla_with_kvcache,
+    prewarm_flash_mla_sparse_prefill,
+)
+""",
+        """from vllm_musa.v1.attention.ops.flashmla import (
+    flash_mla_sparse_fwd,
+    flash_mla_with_kvcache,
+)
+""",
+    )
+    source = source.replace(
+        """        prewarm_flash_mla_sparse_prefill(
+            num_heads=self.padded_heads,
+            device=self.attn_sink.device,
+            sm_scale=self.scale,
+            attn_sink=self.attn_sink,
+        )
+""",
+        "",
+    )
+    return source
+
+
+PATCHES = [
+    (
+        """from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+""",
+        """import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+""",
+    ),
+    (
+        """from vllm.logger import init_logger
+""",
+        """from vllm.logger import init_logger
+from vllm.platforms import current_platform
+""",
+    ),
+    (
+        """from vllm.v1.attention.backends.mla.flashmla_sparse import (
+    DeepseekV4FlashMLASparseBackend,
+    FlashMLASparseBackend,
+    FlashMLASparseMetadata,
+)
+""",
+        """from vllm.v1.attention.backends.mla.flashmla_sparse import (
+    FlashMLASparseBackend,
+    FlashMLASparseMetadata,
+)
+from vllm_musa.v1.attention.backends.mla.flashmla_sparse import (
+    MUSADeepseekV4FlashMLASparseBackend as DeepseekV4FlashMLASparseBackend,
+)
+""",
+    ),
+    (
+        """from vllm.v1.attention.ops.flashmla import (
+    flash_mla_sparse_fwd,
+    flash_mla_with_kvcache,
+)
+""",
+        """from vllm_musa.v1.attention.ops.flashmla import (
+    flash_mla_sparse_fwd,
+    flash_mla_with_kvcache,
+)
+""",
+    ),
+    (
+        'assert cap is not None, "DeepseekV4 attention requires a CUDA device"',
+        'assert cap is not None, "DeepseekV4 attention requires a MUSA device"',
+    ),
+    (
+        """def _musa_deepseek_v4_dequant_weight(
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+) -> torch.Tensor:
+    group_size = 128
+    groups, out_dim, in_dim = b.shape
+    out_blocks = out_dim // group_size
+    in_blocks = in_dim // group_size
+    scales = b_scale.to(torch.float32)
+    if scales.dim() == 2:
+        scales = scales.reshape(groups, out_blocks, in_blocks)
+    elif scales.shape == (groups, in_blocks, out_blocks):
+        scales = scales.transpose(-1, -2)
+    assert scales.shape == (groups, out_blocks, in_blocks)
+    b_blocks = b.to(torch.float32).reshape(
+        groups, out_blocks, group_size, in_blocks, group_size
+    )
+    return (b_blocks * scales[:, :, None, :, None]).reshape(groups, out_dim, in_dim)
+""",
+        """def _musa_deepseek_v4_dequant_weight(
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    groups: int,
+) -> torch.Tensor:
+    group_size = 128
+    if b.dim() == 2:
+        flat_out_dim, in_dim = b.shape
+        if flat_out_dim % groups != 0:
+            raise ValueError(
+                "MUSA DeepSeek-V4 FP8 einsum fallback expected 2D weight "
+                f"rows to be divisible by groups={groups}, got {b.shape}"
+            )
+        out_dim = flat_out_dim // groups
+        b = b.reshape(groups, out_dim, in_dim)
+    elif b.dim() == 3:
+        b_groups, out_dim, in_dim = b.shape
+        if b_groups != groups:
+            raise ValueError(
+                "MUSA DeepSeek-V4 FP8 einsum fallback group mismatch: "
+                f"a/groups={groups}, b/groups={b_groups}"
+            )
+    else:
+        raise ValueError(
+            "MUSA DeepSeek-V4 FP8 einsum fallback expects a 2D or 3D "
+            f"weight tensor, got shape={tuple(b.shape)}"
+        )
+    out_blocks = out_dim // group_size
+    in_blocks = in_dim // group_size
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if e8m0_dtype is not None and b_scale.dtype == e8m0_dtype:
+        exp_bits = b_scale.view(torch.uint8).to(torch.int32)
+        scales = (exp_bits << 23).view(torch.float32)
+    else:
+        scales = b_scale.to(torch.float32)
+    if scales.dim() == 2:
+        if scales.numel() != groups * out_blocks * in_blocks:
+            raise ValueError(
+                "MUSA DeepSeek-V4 FP8 einsum fallback scale element mismatch: "
+                f"scale_shape={tuple(b_scale.shape)}, expected elements="
+                f"{groups * out_blocks * in_blocks}"
+            )
+        scales = scales.reshape(groups, out_blocks, in_blocks)
+    elif scales.shape == (groups, in_blocks, out_blocks):
+        scales = scales.transpose(-1, -2)
+    assert scales.shape == (groups, out_blocks, in_blocks)
+    b_blocks = b.to(torch.float32).reshape(
+        groups, out_blocks, group_size, in_blocks, group_size
+    )
+    return (b_blocks * scales[:, :, None, :, None]).reshape(groups, out_dim, in_dim)
+""",
+    ),
+    (
+        "    b_deq = _musa_deepseek_v4_dequant_weight(b, b_scale)\n",
+        "    b_deq = _musa_deepseek_v4_dequant_weight(b, b_scale, a.shape[1])\n",
+    ),
+    (
+        """logger = init_logger(__name__)
+""",
+        """logger = init_logger(__name__)
+
+
+def _musa_deepseek_v4_disable_aux_overlap() -> bool:
+    return os.getenv("VLLM_MUSA_DEEPSEEK_V4_DISABLE_AUX_OVERLAP", "0") == "1"
+
+
+def _musa_deepseek_v4_is_current_stream_capturing() -> bool:
+    capturing = False
+    for module_name in ("musa", "cuda"):
+        module = getattr(torch, module_name, None)
+        if module is None:
+            continue
+        is_capturing = getattr(module, "is_current_stream_capturing", None)
+        if is_capturing is None:
+            continue
+        try:
+            capturing = capturing or bool(is_capturing())
+        except Exception:
+            continue
+    return capturing
+
+
+def _musa_deepseek_v4_use_native_sparse_kv_store(k_cache: torch.Tensor) -> bool:
+    if k_cache.dim() < 3:
+        return False
+    if os.getenv("VLLM_MUSA_DEEPSEEK_V4_NATIVE_SPARSE_KV_STORE", "1") == "0":
+        return False
+    return True
+
+
+def _musa_deepseek_v4_qnorm_rope_kv_insert_mode() -> str:
+    return os.getenv(
+        "VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_IMPL", "native"
+    ).strip().lower()
+
+
+def _musa_deepseek_v4_apply_gptj_rope(
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    nope_dim: int = 448,
+    rope_dim: int = 64,
+) -> torch.Tensor:
+    x_float = x.to(torch.float32)
+    rope = x_float[..., nope_dim : nope_dim + rope_dim]
+    cos_sin = cos_sin_cache.index_select(0, positions.to(torch.long)).to(torch.float32)
+    cos, sin = cos_sin.split(rope_dim // 2, dim=-1)
+    while cos.dim() < rope.dim():
+        cos = cos.unsqueeze(-2)
+        sin = sin.unsqueeze(-2)
+    even = rope[..., 0::2]
+    odd = rope[..., 1::2]
+    rotated = torch.empty_like(rope)
+    rotated[..., 0::2] = even * cos - odd * sin
+    rotated[..., 1::2] = even * sin + odd * cos
+    x_float[..., nope_dim : nope_dim + rope_dim] = rotated
+    return x_float
+
+
+def _musa_deepseek_v4_quant_insert(
+    kv: torch.Tensor,
+    k_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_size: int,
+) -> None:
+    fp8_dim = 448
+    rope_dim = 64
+    token_data_bytes = fp8_dim + rope_dim * 2
+    scale_bytes = 8
+    quant_block = 64
+    fp8_max = 448.0
+    valid_slots = slot_mapping[: kv.shape[0]]
+    if _musa_deepseek_v4_use_native_sparse_kv_store(k_cache):
+        from vllm_musa import _custom_ops as _musa_custom_ops
+
+        write_mask = valid_slots >= 0
+        _musa_custom_ops.deepseek_v4_store_sparse_kv(
+            kv[: valid_slots.shape[0]].to(torch.bfloat16).contiguous(),
+            k_cache,
+            valid_slots.contiguous(),
+            write_mask.to(torch.bool).contiguous(),
+        )
+        return
+
+    k_cache_2d = k_cache.view(k_cache.shape[0], -1) if k_cache.dim() >= 3 else k_cache
+    if _musa_deepseek_v4_is_current_stream_capturing():
+        kv_valid = kv[: valid_slots.shape[0]].to(kv.dtype).to(torch.float32)
+        slots = valid_slots.clamp_min(0).to(torch.long)
+    else:
+        valid_mask = valid_slots >= 0
+        if not torch.any(valid_mask):
+            return
+        kv_valid = kv[: valid_slots.shape[0]][valid_mask].to(kv.dtype).to(torch.float32)
+        slots = valid_slots[valid_mask].to(torch.long)
+    block_idx = torch.div(slots, block_size, rounding_mode="floor")
+    pos_in_block = slots.remainder(block_size)
+
+    for block_id in range(fp8_dim // quant_block):
+        start = block_id * quant_block
+        chunk = kv_valid[:, start : start + quant_block]
+        amax = torch.maximum(
+            chunk.abs().amax(dim=-1),
+            torch.full((chunk.shape[0],), 1.0e-4, device=chunk.device),
+        )
+        exponent = torch.ceil(torch.log2(amax / fp8_max))
+        scale = torch.exp2(exponent).unsqueeze(-1)
+        qbytes = (
+            (chunk / scale)
+            .clamp(-fp8_max, fp8_max)
+            .to(torch.float8_e4m3fn)
+            .view(torch.uint8)
+        )
+        offsets = (
+            pos_in_block.unsqueeze(1) * token_data_bytes
+            + start
+            + torch.arange(quant_block, device=kv.device).unsqueeze(0)
+        )
+        k_cache_2d[block_idx.unsqueeze(1), offsets] = qbytes
+        scale_offsets = block_size * token_data_bytes + pos_in_block * scale_bytes
+        k_cache_2d[block_idx, scale_offsets + block_id] = (
+            exponent + 127.0
+        ).clamp(0, 255).to(torch.uint8)
+    scale_offsets = block_size * token_data_bytes + pos_in_block * scale_bytes
+    k_cache_2d[block_idx, scale_offsets + 7] = 0
+
+    rope_bytes = (
+        kv_valid[:, fp8_dim : fp8_dim + rope_dim]
+        .to(torch.bfloat16)
+        .contiguous()
+        .view(torch.uint8)
+    )
+    rope_offsets = (
+        pos_in_block.unsqueeze(1) * token_data_bytes
+        + fp8_dim
+        + torch.arange(rope_dim * 2, device=kv.device).unsqueeze(0)
+    )
+    k_cache_2d[block_idx.unsqueeze(1), rope_offsets] = rope_bytes
+
+
+def _musa_try_native_deepseek_v4_qnorm_rope_kv_insert(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    k_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    eps: float,
+    block_size: int,
+) -> bool:
+    mode = _musa_deepseek_v4_qnorm_rope_kv_insert_mode()
+    if mode in {"torch", "fallback", "0", "off", "tilelang", "jit"}:
+        return False
+
+    try:
+        from vllm_musa import _custom_ops as _musa_custom_ops
+
+        native_slot_mapping = slot_mapping
+        if slot_mapping.shape[0] > q.shape[0]:
+            # Graph+MTP warmup may carry padded cache slots while q/kv only
+            # contain active rows. Match the torch fallback's cache-store
+            # contract by bounding stores to the active q/kv row count.
+            native_slot_mapping = slot_mapping[: q.shape[0]].contiguous()
+
+        _musa_custom_ops.deepseek_v4_qnorm_rope_kv_insert(
+            q,
+            kv,
+            k_cache,
+            native_slot_mapping,
+            positions,
+            cos_sin_cache,
+            eps,
+            block_size,
+        )
+    except Exception as exc:
+        if mode == "auto":
+            logger.warning_once(
+                "MUSA native DeepSeek-V4 QNorm/RoPE/KV insert path did not "
+                "handle this call; trying the next provider. Reason: %s: %s",
+                type(exc).__name__,
+                exc,
+            )
+            return False
+        raise
+    return True
+
+
+def _musa_try_tilelang_deepseek_v4_qnorm_rope_kv_insert(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    k_cache_2d: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    eps: float,
+    block_size: int,
+) -> bool:
+    try:
+        from vllm_musa.deepseek_v4_jit.qnorm_rope_kv_insert import (
+            try_tilelang_qnorm_rope_kv_insert,
+        )
+    except Exception as exc:
+        logger.warning_once(
+            "TileLang DeepSeek-V4 QNorm/RoPE/KV insert path is unavailable; "
+            "using torch correctness fallback. Import error: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    handled, reason = try_tilelang_qnorm_rope_kv_insert(
+        q,
+        kv,
+        k_cache_2d,
+        slot_mapping,
+        positions,
+        cos_sin_cache,
+        eps,
+        block_size,
+    )
+    if not handled and not reason.startswith("disabled by "):
+        logger.warning_once(
+            "TileLang DeepSeek-V4 QNorm/RoPE/KV insert path did not handle "
+            "this call; using torch correctness fallback. Reason: %s",
+            reason,
+        )
+    return handled
+
+
+def _musa_fused_deepseek_v4_qnorm_rope_kv_insert_fallback(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    k_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    eps: float,
+    block_size: int,
+) -> None:
+    k_cache_2d = (
+        k_cache.view(k_cache.shape[0], -1) if k_cache.dim() >= 3 else k_cache
+    )
+    if _musa_try_native_deepseek_v4_qnorm_rope_kv_insert(
+        q,
+        kv,
+        k_cache,
+        slot_mapping,
+        positions,
+        cos_sin_cache,
+        eps,
+        block_size,
+    ):
+        return
+    if _musa_try_tilelang_deepseek_v4_qnorm_rope_kv_insert(
+        q,
+        kv,
+        k_cache_2d,
+        slot_mapping,
+        positions,
+        cos_sin_cache,
+        eps,
+        block_size,
+    ):
+        return
+    mode = _musa_deepseek_v4_qnorm_rope_kv_insert_mode()
+    if mode not in {"torch", "fallback", "0", "off", "auto"}:
+        raise RuntimeError(
+            "MUSA DeepSeek-V4 QNorm/RoPE/KV insert has no enabled provider "
+            f"for mode={mode!r}"
+        )
+    q_float = q.to(torch.float32)
+    variance = q_float.pow(2).mean(dim=-1, keepdim=True)
+    q_float = q_float * torch.rsqrt(variance + eps)
+    q_rope = _musa_deepseek_v4_apply_gptj_rope(q_float, positions, cos_sin_cache)
+    q.copy_(q_rope.to(q.dtype))
+    kv_rope = _musa_deepseek_v4_apply_gptj_rope(kv, positions, cos_sin_cache).to(
+        kv.dtype
+    )
+    _musa_deepseek_v4_quant_insert(kv_rope, k_cache, slot_mapping, block_size)
+
+
+def _musa_deepseek_v4_dequant_activation(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+) -> torch.Tensor:
+    group_size = 128
+    bsz, groups, hidden = a.shape
+    scale_blocks = hidden // group_size
+    a_blocks = a.to(torch.float32).reshape(bsz, groups, scale_blocks, group_size)
+    return (a_blocks * a_scale.to(torch.float32).unsqueeze(-1)).reshape(
+        bsz, groups, hidden
+    )
+
+
+def _musa_deepseek_v4_dequant_weight(
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    groups: int,
+) -> torch.Tensor:
+    group_size = 128
+    if b.dim() == 2:
+        flat_out_dim, in_dim = b.shape
+        if flat_out_dim % groups != 0:
+            raise ValueError(
+                "MUSA DeepSeek-V4 FP8 einsum fallback expected 2D weight "
+                f"rows to be divisible by groups={groups}, got {b.shape}"
+            )
+        out_dim = flat_out_dim // groups
+        b = b.reshape(groups, out_dim, in_dim)
+    elif b.dim() == 3:
+        b_groups, out_dim, in_dim = b.shape
+        if b_groups != groups:
+            raise ValueError(
+                "MUSA DeepSeek-V4 FP8 einsum fallback group mismatch: "
+                f"a/groups={groups}, b/groups={b_groups}"
+            )
+    else:
+        raise ValueError(
+            "MUSA DeepSeek-V4 FP8 einsum fallback expects a 2D or 3D "
+            f"weight tensor, got shape={tuple(b.shape)}"
+        )
+    out_blocks = out_dim // group_size
+    in_blocks = in_dim // group_size
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if e8m0_dtype is not None and b_scale.dtype == e8m0_dtype:
+        exp_bits = b_scale.view(torch.uint8).to(torch.int32)
+        scales = (exp_bits << 23).view(torch.float32)
+    else:
+        scales = b_scale.to(torch.float32)
+    if scales.dim() == 2:
+        if scales.numel() != groups * out_blocks * in_blocks:
+            raise ValueError(
+                "MUSA DeepSeek-V4 FP8 einsum fallback scale element mismatch: "
+                f"scale_shape={tuple(b_scale.shape)}, expected elements="
+                f"{groups * out_blocks * in_blocks}"
+            )
+        scales = scales.reshape(groups, out_blocks, in_blocks)
+    elif scales.shape == (groups, in_blocks, out_blocks):
+        scales = scales.transpose(-1, -2)
+    assert scales.shape == (groups, out_blocks, in_blocks)
+    b_blocks = b.to(torch.float32).reshape(
+        groups, out_blocks, group_size, in_blocks, group_size
+    )
+    return (b_blocks * scales[:, :, None, :, None]).reshape(groups, out_dim, in_dim)
+
+
+def _musa_deepseek_v4_fp8_einsum_fallback(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+) -> None:
+    if equation != "bhr,hdr->bhd":
+        raise NotImplementedError(
+            f"MUSA DeepSeek-V4 FP8 einsum fallback does not support {equation!r}"
+        )
+    a_deq = _musa_deepseek_v4_dequant_activation(a, a_scale)
+    b_deq = _musa_deepseek_v4_dequant_weight(b, b_scale, a.shape[1])
+    out.copy_(torch.einsum(equation, a_deq, b_deq).to(out.dtype))
+""",
+    ),
+    (
+        """    if (
+        _musa_deepseek_v4_is_current_stream_capturing()
+        and k_cache.dim() >= 3
+        and os.getenv("VLLM_MUSA_DEEPSEEK_V4_NATIVE_SPARSE_KV_STORE", "1") != "0"
+    ):
+""",
+        """    if _musa_deepseek_v4_use_native_sparse_kv_store(k_cache):
+""",
+    ),
+    (
+        """def deepseek_v4_fp8_einsum(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+    recipe: list[int],
+) -> None:
+    fp8_einsum(equation, (a, a_scale), (b, b_scale), out, recipe=tuple(recipe))
+""",
+        """def deepseek_v4_fp8_einsum(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+    recipe: list[int],
+) -> None:
+    if (
+        current_platform.is_musa()
+        and os.getenv("VLLM_MUSA_ENABLE_TORCH_FP8_EINSUM_FALLBACK", "0") == "1"
+    ):
+        try:
+            from vllm_musa.deepseek_v4_jit.fp8_einsum import (
+                try_musa_deepseek_v4_fp8_einsum_gemv,
+            )
+
+            handled, reason = try_musa_deepseek_v4_fp8_einsum_gemv(
+                a, a_scale, b, b_scale, out, equation
+            )
+        except Exception as exc:
+            handled = False
+            reason = f"{type(exc).__name__}: {exc}"
+        if handled:
+            logger.warning_once(
+                "Using MUSA native DeepSeek-V4 FP8 GEMV provider for "
+                "deepseek_v4_fp8_einsum."
+            )
+            return
+        logger.warning_once(
+            "MUSA native DeepSeek-V4 FP8 GEMV provider did not handle this "
+            "call; using torch fallback. Reason: %s",
+            reason,
+        )
+        logger.warning_once(
+            "Using opt-in MUSA torch DeepSeek-V4 FP8 einsum fallback. "
+            "This dequantizes FP8 operands and runs torch.einsum; it is "
+            "a correctness fallback, not a production DeepGEMM replacement."
+        )
+        _musa_deepseek_v4_fp8_einsum_fallback(
+            a, a_scale, b, b_scale, out, equation
+        )
+        return
+    fp8_einsum(equation, (a, a_scale), (b, b_scale), out, recipe=tuple(recipe))
+""",
+    ),
+    (
+        """def deepseek_v4_fp8_einsum(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+    recipe: list[int],
+) -> None:
+    if (
+        current_platform.is_musa()
+        and os.getenv("VLLM_MUSA_ENABLE_TORCH_FP8_EINSUM_FALLBACK", "0") == "1"
+    ):
+        logger.warning_once(
+            "Using opt-in MUSA torch DeepSeek-V4 FP8 einsum fallback. "
+            "This dequantizes FP8 operands and runs torch.einsum; it is "
+            "a correctness fallback, not a production DeepGEMM replacement."
+        )
+        _musa_deepseek_v4_fp8_einsum_fallback(
+            a, a_scale, b, b_scale, out, equation
+        )
+        return
+    fp8_einsum(equation, (a, a_scale), (b, b_scale), out, recipe=tuple(recipe))
+""",
+        """def deepseek_v4_fp8_einsum(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+    recipe: list[int],
+) -> None:
+    if (
+        current_platform.is_musa()
+        and os.getenv("VLLM_MUSA_ENABLE_TORCH_FP8_EINSUM_FALLBACK", "0") == "1"
+    ):
+        try:
+            from vllm_musa.deepseek_v4_jit.fp8_einsum import (
+                try_musa_deepseek_v4_fp8_einsum_gemv,
+            )
+
+            handled, reason = try_musa_deepseek_v4_fp8_einsum_gemv(
+                a, a_scale, b, b_scale, out, equation
+            )
+        except Exception as exc:
+            handled = False
+            reason = f"{type(exc).__name__}: {exc}"
+        if handled:
+            logger.warning_once(
+                "Using MUSA native DeepSeek-V4 FP8 GEMV provider for "
+                "deepseek_v4_fp8_einsum."
+            )
+            return
+        logger.warning_once(
+            "MUSA native DeepSeek-V4 FP8 GEMV provider did not handle this "
+            "call; using torch fallback. Reason: %s",
+            reason,
+        )
+        logger.warning_once(
+            "Using opt-in MUSA torch DeepSeek-V4 FP8 einsum fallback. "
+            "This dequantizes FP8 operands and runs torch.einsum; it is "
+            "a correctness fallback, not a production DeepGEMM replacement."
+        )
+        _musa_deepseek_v4_fp8_einsum_fallback(
+            a, a_scale, b, b_scale, out, equation
+        )
+        return
+    fp8_einsum(equation, (a, a_scale), (b, b_scale), out, recipe=tuple(recipe))
+""",
+    ),
+    (
+        """        torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
+            q,
+            kv,
+            swa_kv_cache_2d,
+            swa_metadata.slot_mapping,
+            positions.to(torch.int64),
+            self.rotary_emb.cos_sin_cache,
+            self.eps,
+            swa_metadata.block_size,
+        )
+""",
+        """        fused_insert = getattr(
+            getattr(torch.ops, "_C", None),
+            "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert",
+            None,
+        )
+        if fused_insert is None:
+            _musa_fused_deepseek_v4_qnorm_rope_kv_insert_fallback(
+                q,
+                kv,
+                swa_kv_cache,
+                swa_metadata.slot_mapping,
+                positions.to(torch.int64),
+                self.rotary_emb.cos_sin_cache,
+                self.eps,
+                swa_metadata.block_size,
+            )
+            return
+        fused_insert(
+            q,
+            kv,
+            swa_kv_cache_2d,
+            swa_metadata.slot_mapping,
+            positions.to(torch.int64),
+            self.rotary_emb.cos_sin_cache,
+            self.eps,
+            swa_metadata.block_size,
+        )
+""",
+    ),
+    (
+        """        fused_insert = getattr(
+            getattr(torch.ops, "_C", None),
+            "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert",
+            None,
+        )
+        if fused_insert is None:
+            _musa_fused_deepseek_v4_qnorm_rope_kv_insert_fallback(
+                q,
+                kv,
+                swa_kv_cache,
+                swa_metadata.slot_mapping,
+                positions.to(torch.int64),
+                self.rotary_emb.cos_sin_cache,
+                self.eps,
+                swa_metadata.block_size,
+            )
+            return
+        fused_insert(
+            q,
+            kv,
+            swa_kv_cache_2d,
+            swa_metadata.slot_mapping,
+            positions.to(torch.int64),
+            self.rotary_emb.cos_sin_cache,
+            self.eps,
+            swa_metadata.block_size,
+        )
+""",
+        """        fused_insert = getattr(
+            getattr(torch.ops, "_C", None),
+            "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert",
+            None,
+        )
+        if fused_insert is None:
+            _musa_fused_deepseek_v4_qnorm_rope_kv_insert_fallback(
+                q,
+                kv,
+                swa_kv_cache,
+                swa_metadata.slot_mapping,
+                positions.to(torch.int64),
+                self.rotary_emb.cos_sin_cache,
+                self.eps,
+                swa_metadata.block_size,
+            )
+            return
+        fused_insert(
+            q,
+            kv,
+            swa_kv_cache_2d,
+            swa_metadata.slot_mapping,
+            positions.to(torch.int64),
+            self.rotary_emb.cos_sin_cache,
+            self.eps,
+            swa_metadata.block_size,
+        )
+""",
+    ),
+    (
+        """        _musa_custom_ops.deepseek_v4_qnorm_rope_kv_insert(
+            q,
+            kv,
+            k_cache,
+            slot_mapping,
+            positions,
+            cos_sin_cache,
+            eps,
+            block_size,
+        )
+""",
+        """        native_slot_mapping = slot_mapping
+        if slot_mapping.shape[0] > q.shape[0]:
+            # Graph+MTP warmup may carry padded cache slots while q/kv only
+            # contain active rows. Match the torch fallback's cache-store
+            # contract by bounding stores to the active q/kv row count.
+            native_slot_mapping = slot_mapping[: q.shape[0]].contiguous()
+
+        _musa_custom_ops.deepseek_v4_qnorm_rope_kv_insert(
+            q,
+            kv,
+            k_cache,
+            native_slot_mapping,
+            positions,
+            cos_sin_cache,
+            eps,
+            block_size,
+        )
+""",
+    ),
+    (
+        """        swa_indices = swa_metadata.decode_swa_indices
+        swa_lens = swa_metadata.decode_swa_lens
+
+        # We treat queries in the same seq as different queries
+        # and later we only attend by generated indices.
+        # q arrives pre-padded to self.padded_heads by the outer wrapper.
+        q = q.unsqueeze(1)
+""",
+        """        active_decode_tokens = q.shape[0]
+        if topk_indices is not None:
+            topk_indices = topk_indices[:active_decode_tokens]
+        if topk_lens is not None:
+            topk_lens = topk_lens[:active_decode_tokens]
+
+        swa_indices = swa_metadata.decode_swa_indices
+        swa_lens = swa_metadata.decode_swa_lens
+        if swa_indices is not None:
+            swa_indices = swa_indices[:active_decode_tokens]
+        if swa_lens is not None:
+            swa_lens = swa_lens[:active_decode_tokens]
+
+        # We treat queries in the same seq as different queries
+        # and later we only attend by generated indices.
+        # q arrives pre-padded to self.padded_heads by the outer wrapper.
+        q = q.unsqueeze(1)
+""",
+    ),
+    (
+        """        self.aux_stream = mla_modules.aux_stream
+        self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
+""",
+        """        self.aux_stream = mla_modules.aux_stream
+        if _musa_deepseek_v4_disable_aux_overlap():
+            self.aux_stream = None
+            logger.warning_once(
+                "Disabling DeepSeek-V4 aux-stream attention overlap on MUSA "
+                "because VLLM_MUSA_DEEPSEEK_V4_DISABLE_AUX_OVERLAP=1."
+            )
+        self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__model_executor__layers__mhc.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__layers__mhc.patch.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch mHC blocks with MUSA native/JIT helpers.
+"""
+
+_MUSA_MHC_PRE_DISPATCH = """    if current_platform.is_musa():
+        from vllm_musa.deepseek_v4_mhc import mhc_pre_musa
+
+        return mhc_pre_musa(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+"""
+
+_MUSA_MHC_PRE_TORCH_GATE = """    if (
+        current_platform.is_musa()
+        and os.getenv("VLLM_MUSA_ENABLE_TORCH_MHC_PRENORM_FALLBACK", "0") == "1"
+    ):
+        from vllm_musa.deepseek_v4_mhc import mhc_pre_torch_fallback
+
+        return mhc_pre_torch_fallback(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+"""
+
+
+def normalize_source(source: str) -> str:
+    if _MUSA_MHC_PRE_TORCH_GATE not in source:
+        return source
+    if _MUSA_MHC_PRE_DISPATCH in source:
+        return source.replace(_MUSA_MHC_PRE_TORCH_GATE + "\n", "")
+    return source.replace(_MUSA_MHC_PRE_TORCH_GATE, _MUSA_MHC_PRE_DISPATCH)
+
+
+PATCHES = [
+    (
+        """import math
+from functools import cache
+""",
+        """import math
+import os
+from functools import cache
+""",
+    ),
+    (
+        """# tilelang is only available on CUDA platforms
+if TYPE_CHECKING or current_platform.is_cuda_alike():
+    if not has_tilelang():
+        raise ImportError(
+            "tilelang is required for mhc but is not installed. Install it with "
+            "`pip install tilelang`."
+        )
+    import tilelang
+    import tilelang.language as T
+else:
+    tilelang = None  # type: ignore[assignment]
+    T = None  # type: ignore[assignment]
+""",
+        """# tilelang is only available on CUDA platforms
+if TYPE_CHECKING or (current_platform.is_cuda_alike() and not current_platform.is_musa()):
+    if not has_tilelang():
+        raise ImportError(
+            "tilelang is required for mhc but is not installed. Install it with "
+            "`pip install tilelang`."
+        )
+    import tilelang
+    import tilelang.language as T
+else:
+    class _MUSATilelangStub:
+        class PassConfigKey:
+            TL_DISABLE_WARP_SPECIALIZED = "TL_DISABLE_WARP_SPECIALIZED"
+            TL_DISABLE_TMA_LOWER = "TL_DISABLE_TMA_LOWER"
+            TL_PTXAS_REGISTER_USAGE_LEVEL = "TL_PTXAS_REGISTER_USAGE_LEVEL"
+
+        @staticmethod
+        def jit(*args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    tilelang = _MUSATilelangStub()  # type: ignore[assignment]
+    T = None  # type: ignore[assignment]
+""",
+    ),
+    (
+        """    class _MUSATilelangStub:
+        class PassConfigKey:
+""",
+        """    class _MUSATilelangStub:
+        JITKernel = object
+
+        class PassConfigKey:
+""",
+    ),
+    (
+        """    # Validate shapes
+    assert residual.dtype == torch.bfloat16
+""",
+        _MUSA_MHC_PRE_DISPATCH + """
+    # Validate shapes
+    assert residual.dtype == torch.bfloat16
+""",
+    ),
+    (
+        _MUSA_MHC_PRE_TORCH_GATE,
+        _MUSA_MHC_PRE_DISPATCH,
+    ),
+    (
+        """def mhc_post(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    out = torch.empty_like(residual)
+""",
+        """def mhc_post(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    if (
+        current_platform.is_musa()
+        and (
+            os.getenv("VLLM_MUSA_ENABLE_DEEPSEEK_V4_MHC_MUSA_IMPL", "1") == "1"
+            or os.getenv(
+                "VLLM_MUSA_ENABLE_TORCH_MHC_PRENORM_FALLBACK",
+                "0",
+            )
+            == "1"
+        )
+    ):
+        from vllm_musa.deepseek_v4_mhc import mhc_post_musa
+
+        return mhc_post_musa(x, residual, post_layer_mix, comb_res_mix)
+
+    out = torch.empty_like(residual)
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__model_executor__layers__sparse_attn_indexer.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__layers__sparse_attn_indexer.patch.py
@@ -1,0 +1,998 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch sparse-attention indexer with an opt-in MUSA correctness fallback.
+"""
+
+import ast
+
+_PREFILL_NATIVE_HELPER = """
+
+def _musa_try_fill_prefill_topk_from_indexer_cache_native(
+    q_quant: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    chunk,
+    topk_indices: torch.Tensor,
+    topk_tokens: int,
+    head_dim: int,
+) -> bool:
+    if (
+        not _musa_sparse_indexer_native_decode_enabled()
+        or head_dim != 128
+        or topk_tokens > 512
+        or q_quant.dtype != torch.float8_e4m3fn
+        or kv_cache.dtype != torch.uint8
+        or weights.dtype != torch.float32
+        or int(chunk.total_seq_lens) > 4096
+    ):
+        return False
+
+    rows = min(q_quant.shape[0], chunk.cu_seqlen_ks.numel(), topk_indices.shape[0])
+    topk = min(int(topk_tokens), topk_indices.shape[1])
+    if rows <= 0 or topk <= 0:
+        return True
+
+    _musa_custom_ops.deepseek_v4_indexer_topk_prefill(
+        q_quant[:rows],
+        kv_cache,
+        weights[:rows],
+        chunk.block_table,
+        chunk.cu_seq_lens,
+        chunk.token_to_seq,
+        chunk.cu_seqlen_ks[:rows],
+        chunk.cu_seqlen_ke[:rows],
+        topk_indices[:rows, :topk],
+        topk,
+    )
+    return True
+"""
+
+
+def _remove_shadowed_exact_fill_definitions(source: str) -> str:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source
+
+    lines = source.splitlines(keepends=True)
+    exact_defs = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_musa_fill_exact_sparse_indexer_indices"
+        and node.end_lineno is not None
+    ]
+    if len(exact_defs) <= 1:
+        return source
+
+    def function_source(node: ast.FunctionDef) -> str:
+        return "".join(lines[node.lineno - 1 : node.end_lineno])
+
+    native_defs = [
+        node
+        for node in exact_defs
+        if "_musa_try_fill_prefill_topk_from_indexer_cache_native("
+        in function_source(node)
+    ]
+    if not native_defs:
+        return source
+
+    keep = native_defs[-1]
+    remove_ranges = [
+        (node.lineno - 1, node.end_lineno) for node in exact_defs if node is not keep
+    ]
+    for start, end in sorted(remove_ranges, reverse=True):
+        del lines[start:end]
+
+    return "".join(lines)
+
+
+def normalize_source(source: str) -> str:
+    """Remove stale duplicate MUSA helper blocks from previously patched files."""
+    helper_start = "\ndef _musa_sparse_indexer_is_current_stream_capturing() -> bool:\n"
+    main_entry = "\ndef _musa_fill_exact_sparse_indexer_indices(\n"
+    stale_forward = """        elif (
+            current_platform.is_musa()
+            and os.getenv(
+                "VLLM_MUSA_ENABLE_TORCH_SPARSE_ATTN_INDEXER_FALLBACK",
+                "0",
+            )
+            == "1"
+        ):
+            try:
+                return _musa_fill_exact_sparse_indexer_indices(
+                    hidden_states,
+                    self.k_cache.prefix,
+                    self.k_cache.kv_cache,
+                    q_quant,
+                    weights,
+                    self.topk_tokens,
+                    self.head_dim,
+                    self.topk_indices_buffer,
+                    self.use_fp4_cache,
+                )
+            except NotImplementedError:
+                return _musa_fill_recent_sparse_indexer_indices(
+                    hidden_states,
+                    self.k_cache.prefix,
+                    self.topk_tokens,
+                    self.topk_indices_buffer,
+                )
+"""
+    native_forward = """        elif (
+            current_platform.is_musa()
+            and (
+                os.getenv(
+                    "VLLM_MUSA_ENABLE_DEEPSEEK_V4_SPARSE_INDEXER_MUSA_IMPL",
+                    "1",
+                )
+                == "1"
+                or os.getenv(
+                    "VLLM_MUSA_ENABLE_TORCH_SPARSE_ATTN_INDEXER_FALLBACK",
+                    "0",
+                )
+                == "1"
+            )
+        ):
+            try:
+                return _musa_fill_exact_sparse_indexer_indices(
+                    hidden_states,
+                    self.k_cache.prefix,
+                    self.k_cache.kv_cache,
+                    q_quant,
+                    weights,
+                    self.topk_tokens,
+                    self.head_dim,
+                    self.topk_indices_buffer,
+                    self.use_fp4_cache,
+                )
+            except NotImplementedError:
+                return _musa_fill_recent_sparse_indexer_indices(
+                    hidden_states,
+                    self.k_cache.prefix,
+                    self.topk_tokens,
+                    self.topk_indices_buffer,
+                )
+"""
+    source = source.replace(stale_forward, native_forward)
+
+    first_start = source.find(helper_start)
+    if first_start >= 0:
+        search_from = first_start + len(helper_start)
+        while True:
+            duplicate_start = source.find(helper_start, search_from)
+            if duplicate_start < 0:
+                break
+
+            duplicate_end = source.find(main_entry, duplicate_start)
+            if duplicate_end < 0:
+                break
+
+            source = source[:duplicate_start] + source[duplicate_end:]
+            search_from = first_start + len(helper_start)
+
+    for default in ("0", "1"):
+        source = source.replace(
+            f"""def _musa_sparse_indexer_graph_exact_decode_enabled() -> bool:
+    return os.getenv("VLLM_MUSA_SPARSE_INDEXER_GRAPH_EXACT_DECODE", "{default}") == "1"
+""",
+            """def _musa_sparse_indexer_graph_exact_decode_enabled() -> bool:
+    return os.getenv("VLLM_MUSA_SPARSE_INDEXER_GRAPH_EXACT_DECODE", "0") == "1"
+""",
+        )
+
+    if (
+        "_musa_try_fill_prefill_topk_from_indexer_cache_native(" in source
+        and "def _musa_try_fill_prefill_topk_from_indexer_cache_native" not in source
+    ):
+        source = source.replace(
+            "\n\ndef _musa_indexer_cache_block(kv_cache: torch.Tensor, block_id: int)"
+            " -> torch.Tensor:\n",
+            _PREFILL_NATIVE_HELPER
+            + "\n\ndef _musa_indexer_cache_block(kv_cache: torch.Tensor, block_id: int)"
+            " -> torch.Tensor:\n",
+        )
+
+    source = _remove_shadowed_exact_fill_definitions(source)
+
+    return source
+
+
+PATCHES = [
+    (
+        """import torch
+
+import vllm.envs as envs
+""",
+        """import os
+
+import torch
+
+import vllm.envs as envs
+from vllm_musa import _custom_ops as _musa_custom_ops
+""",
+    ),
+    (
+        """def _musa_sparse_indexer_is_current_stream_capturing() -> bool:
+    cuda_module = getattr(torch, "cuda", None)
+    if cuda_module is None:
+        return False
+    is_capturing = getattr(cuda_module, "is_current_stream_capturing", None)
+    if is_capturing is None:
+        return False
+    try:
+        return bool(is_capturing())
+    except Exception:
+        return False
+""",
+        """def _musa_sparse_indexer_is_current_stream_capturing() -> bool:
+    for module_name in ("musa", "cuda"):
+        module = getattr(torch, module_name, None)
+        if module is None:
+            continue
+        is_capturing = getattr(module, "is_current_stream_capturing", None)
+        if is_capturing is None:
+            continue
+        try:
+            return bool(is_capturing())
+        except Exception:
+            continue
+    return False
+""",
+    ),
+    (
+        """logger = init_logger(__name__)
+""",
+        """logger = init_logger(__name__)
+
+
+def _musa_sparse_indexer_is_current_stream_capturing() -> bool:
+    for module_name in ("musa", "cuda"):
+        module = getattr(torch, module_name, None)
+        if module is None:
+            continue
+        is_capturing = getattr(module, "is_current_stream_capturing", None)
+        if is_capturing is None:
+            continue
+        try:
+            return bool(is_capturing())
+        except Exception:
+            continue
+    return False
+
+
+def _musa_fill_recent_rows_capture(
+    topk_indices_buffer: torch.Tensor,
+    row_start: int,
+    lengths: torch.Tensor,
+    cap: int,
+) -> None:
+    flat_lengths = lengths.reshape(-1).to(torch.long)
+    rows = min(
+        flat_lengths.numel(),
+        topk_indices_buffer.shape[0] - row_start,
+    )
+    if rows <= 0 or cap <= 0:
+        return
+    row_lengths = flat_lengths[:rows].clamp(min=0)
+    counts = row_lengths.clamp(max=cap)
+    starts = (row_lengths - counts).clamp(min=0)
+    offsets = torch.arange(cap, device=topk_indices_buffer.device, dtype=torch.long)
+    values = starts.unsqueeze(-1) + offsets.unsqueeze(0)
+    valid = offsets.unsqueeze(0) < counts.unsqueeze(-1)
+    rows_view = topk_indices_buffer[row_start : row_start + rows, :cap]
+    rows_view.copy_(
+        torch.where(
+            valid,
+            values.to(topk_indices_buffer.dtype),
+            rows_view,
+        )
+    )
+
+
+def _musa_fill_recent_sparse_indexer_indices_capture(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: LayerNameType,
+    topk_tokens: int,
+    topk_indices_buffer: torch.Tensor,
+) -> torch.Tensor:
+    topk = min(topk_tokens, topk_indices_buffer.shape[-1])
+    topk_indices_buffer[: hidden_states.shape[0], :topk] = -1
+    if topk <= 0:
+        return topk_indices_buffer
+
+    cap = int(os.getenv("VLLM_MUSA_SPARSE_INDEXER_FALLBACK_TOPK", "16"))
+    cap = max(0, min(cap, topk))
+    if cap == 0:
+        return topk_indices_buffer
+
+    attn_metadata = get_forward_context().attn_metadata
+    if not isinstance(attn_metadata, dict):
+        return topk_indices_buffer
+
+    metadata = attn_metadata.get(_resolve_layer_name(k_cache_prefix))
+    if not isinstance(metadata, DeepseekV32IndexerMetadata):
+        return topk_indices_buffer
+
+    if metadata.num_decodes > 0 and metadata.decode is not None:
+        _musa_fill_recent_rows_capture(
+            topk_indices_buffer,
+            0,
+            metadata.decode.seq_lens,
+            cap,
+        )
+
+    if metadata.num_prefills > 0 and metadata.prefill is not None:
+        for chunk in metadata.prefill.chunks:
+            _musa_fill_recent_rows_capture(
+                topk_indices_buffer,
+                int(chunk.token_start),
+                chunk.cu_seqlen_ke - chunk.cu_seqlen_ks,
+                cap,
+            )
+
+    return topk_indices_buffer
+
+
+def _musa_fill_recent_sparse_indexer_indices(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: LayerNameType,
+    topk_tokens: int,
+    topk_indices_buffer: torch.Tensor,
+) -> torch.Tensor:
+    if _musa_sparse_indexer_is_current_stream_capturing():
+        return _musa_fill_recent_sparse_indexer_indices_capture(
+            hidden_states,
+            k_cache_prefix,
+            topk_tokens,
+            topk_indices_buffer,
+        )
+
+    # Diagnostic fallback: preserve sparse-attention control flow by selecting a
+    # small recent compressed-token window when the learned indexer kernels are
+    # unavailable on MUSA.
+    topk = min(topk_tokens, topk_indices_buffer.shape[-1])
+    topk_indices_buffer[: hidden_states.shape[0], :topk] = -1
+    if topk <= 0:
+        return topk_indices_buffer
+
+    cap = int(os.getenv("VLLM_MUSA_SPARSE_INDEXER_FALLBACK_TOPK", "16"))
+    cap = max(0, min(cap, topk))
+    if cap == 0:
+        return topk_indices_buffer
+
+    attn_metadata = get_forward_context().attn_metadata
+    if not isinstance(attn_metadata, dict):
+        return topk_indices_buffer
+
+    metadata = attn_metadata.get(_resolve_layer_name(k_cache_prefix))
+    if not isinstance(metadata, DeepseekV32IndexerMetadata):
+        return topk_indices_buffer
+
+    def fill_rows(row_start: int, lengths: torch.Tensor) -> None:
+        flat_lengths = lengths.reshape(-1).to(torch.long)
+        rows = min(
+            flat_lengths.numel(),
+            hidden_states.shape[0] - row_start,
+            topk_indices_buffer.shape[0] - row_start,
+        )
+        for row_offset in range(rows):
+            length = int(flat_lengths[row_offset].item())
+            count = min(cap, max(length, 0))
+            if count <= 0:
+                continue
+            start = length - count
+            row = row_start + row_offset
+            topk_indices_buffer[row, :count] = torch.arange(
+                start,
+                length,
+                device=topk_indices_buffer.device,
+                dtype=topk_indices_buffer.dtype,
+            )
+
+    if metadata.num_decodes > 0 and metadata.decode is not None:
+        fill_rows(0, metadata.decode.seq_lens)
+
+    if metadata.num_prefills > 0 and metadata.prefill is not None:
+        for chunk in metadata.prefill.chunks:
+            fill_rows(
+                int(chunk.token_start),
+                chunk.cu_seqlen_ke - chunk.cu_seqlen_ks,
+            )
+
+    return topk_indices_buffer
+
+
+def _musa_sparse_indexer_graph_exact_decode_enabled() -> bool:
+    # The exact graph decode path is still diagnostic: it removes the recent
+    # window approximation, but regresses DeepSeek-V4-Flash-Base graph+MTP TPS
+    # at long context until the exact provider is fully optimized.
+    return os.getenv("VLLM_MUSA_SPARSE_INDEXER_GRAPH_EXACT_DECODE", "0") == "1"
+
+
+def _musa_sparse_indexer_native_decode_enabled() -> bool:
+    return os.getenv("VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_NATIVE", "1") == "1"
+
+
+def _musa_decode_block_table_for_token_rows(
+    block_table: torch.Tensor,
+    rows: int,
+) -> torch.Tensor | None:
+    block_rows = block_table.shape[0]
+    if rows <= 0:
+        return block_table[:0]
+    if block_rows == rows:
+        return block_table[:rows]
+    if block_rows <= 0 or rows % block_rows != 0:
+        return None
+    return block_table.repeat_interleave(rows // block_rows, dim=0)
+
+
+def _musa_try_fill_decode_topk_from_indexer_cache_native(
+    q_quant: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    decode_metadata,
+    topk_indices_buffer: torch.Tensor,
+    topk_tokens: int,
+    head_dim: int,
+) -> bool:
+    if (
+        not _musa_sparse_indexer_native_decode_enabled()
+        or head_dim != 128
+        or topk_tokens > 512
+        or q_quant.dtype != torch.float8_e4m3fn
+        or weights.dtype != torch.float32
+        or decode_metadata.block_table.shape[1] * kv_cache.shape[1] > 4096
+    ):
+        return False
+
+    seq_lens = decode_metadata.seq_lens.reshape(-1)
+    rows = min(q_quant.shape[0], seq_lens.numel(), topk_indices_buffer.shape[0])
+    topk = min(int(topk_tokens), topk_indices_buffer.shape[1])
+    if rows <= 0 or topk <= 0:
+        return True
+
+    block_table = _musa_decode_block_table_for_token_rows(
+        decode_metadata.block_table,
+        rows,
+    )
+    if block_table is None:
+        return False
+
+    _musa_custom_ops.deepseek_v4_indexer_topk_decode(
+        q_quant[:rows],
+        kv_cache,
+        weights[:rows],
+        seq_lens[:rows],
+        block_table,
+        topk_indices_buffer[:rows, :topk],
+        topk,
+    )
+    return True
+
+
+def _musa_try_fill_prefill_topk_from_indexer_cache_native(
+    q_quant: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    chunk,
+    topk_indices: torch.Tensor,
+    topk_tokens: int,
+    head_dim: int,
+) -> bool:
+    if (
+        not _musa_sparse_indexer_native_decode_enabled()
+        or head_dim != 128
+        or topk_tokens > 512
+        or q_quant.dtype != torch.float8_e4m3fn
+        or kv_cache.dtype != torch.uint8
+        or weights.dtype != torch.float32
+        or int(chunk.total_seq_lens) > 4096
+    ):
+        return False
+
+    rows = min(q_quant.shape[0], chunk.cu_seqlen_ks.numel(), topk_indices.shape[0])
+    topk = min(int(topk_tokens), topk_indices.shape[1])
+    if rows <= 0 or topk <= 0:
+        return True
+
+    _musa_custom_ops.deepseek_v4_indexer_topk_prefill(
+        q_quant[:rows],
+        kv_cache,
+        weights[:rows],
+        chunk.block_table,
+        chunk.cu_seq_lens,
+        chunk.token_to_seq,
+        chunk.cu_seqlen_ks[:rows],
+        chunk.cu_seqlen_ke[:rows],
+        topk_indices[:rows, :topk],
+        topk,
+    )
+    return True
+
+
+def _musa_indexer_cache_block(kv_cache: torch.Tensor, block_id: int) -> torch.Tensor:
+    return kv_cache[block_id].view(torch.uint8).flatten()
+
+
+def _musa_indexer_cache_rows(kv_cache: torch.Tensor) -> torch.Tensor:
+    return kv_cache.as_strided(
+        (kv_cache.shape[0], kv_cache.stride(0)),
+        (kv_cache.stride(0), 1),
+    )
+
+
+def _musa_dequant_indexer_fp8_cache_row(
+    kv_cache: torch.Tensor,
+    block_id: int,
+    pos_in_block: int,
+    head_dim: int,
+) -> torch.Tensor:
+    block_size = kv_cache.shape[1]
+    scale_dim = 4
+    cache_block = _musa_indexer_cache_block(kv_cache, block_id)
+    token_base = pos_in_block * head_dim
+    scale_base = block_size * head_dim + pos_in_block * scale_dim
+    values = (
+        cache_block[token_base : token_base + head_dim]
+        .contiguous()
+        .view(torch.float8_e4m3fn)
+        .to(torch.float32)
+    )
+    scale = (
+        cache_block[scale_base : scale_base + scale_dim]
+        .contiguous()
+        .view(torch.float32)
+    )
+    return values * scale
+
+
+def _musa_dequant_indexer_fp8_cache_rows(
+    kv_cache: torch.Tensor,
+    block_ids: torch.Tensor,
+    pos_in_block: torch.Tensor,
+    head_dim: int,
+) -> torch.Tensor:
+    if block_ids.numel() == 0:
+        return torch.empty((0, head_dim), dtype=torch.float32, device=kv_cache.device)
+    block_size = kv_cache.shape[1]
+    block_ids = block_ids.to(torch.long)
+    pos_in_block = pos_in_block.to(torch.long)
+    valid = (
+        (block_ids >= 0)
+        & (block_ids < kv_cache.shape[0])
+        & (pos_in_block >= 0)
+        & (pos_in_block < block_size)
+    )
+    safe_blocks = block_ids.clamp(0, kv_cache.shape[0] - 1)
+    safe_pos = pos_in_block.clamp(0, block_size - 1)
+    selected_blocks = _musa_indexer_cache_rows(kv_cache).index_select(0, safe_blocks)
+    value_offsets = safe_pos.unsqueeze(-1) * head_dim + torch.arange(
+        head_dim, device=kv_cache.device, dtype=torch.long
+    )
+    values = (
+        torch.gather(selected_blocks, 1, value_offsets)
+        .contiguous()
+        .view(torch.float8_e4m3fn)
+        .to(torch.float32)
+    )
+    scale_offsets = (
+        block_size * head_dim
+        + safe_pos.unsqueeze(-1) * 4
+        + torch.arange(4, device=kv_cache.device, dtype=torch.long)
+    )
+    scales = (
+        torch.gather(selected_blocks, 1, scale_offsets)
+        .contiguous()
+        .view(torch.float32)
+        .reshape(-1, 1)
+    )
+    dequant = values * scales
+    return torch.where(valid.unsqueeze(-1), dequant, torch.zeros_like(dequant))
+
+
+def _musa_gather_indexer_fp8_cache(
+    kv_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seq_lens: torch.Tensor,
+    head_dim: int,
+) -> torch.Tensor:
+    total_seq_lens = int(cu_seq_lens[-1].item())
+    if total_seq_lens <= 0:
+        return torch.empty((0, head_dim), dtype=torch.float32, device=kv_cache.device)
+    block_size = kv_cache.shape[1]
+    pieces = []
+    for req_idx in range(block_table.shape[0]):
+        start = int(cu_seq_lens[req_idx].item())
+        end = int(cu_seq_lens[req_idx + 1].item())
+        length = end - start
+        if length <= 0:
+            continue
+        local_pos = torch.arange(length, device=kv_cache.device, dtype=torch.long)
+        physical_blocks = block_table[
+            req_idx,
+            torch.div(local_pos, block_size, rounding_mode="floor").clamp(
+                0, block_table.shape[1] - 1
+            ),
+        ]
+        pieces.append(
+            _musa_dequant_indexer_fp8_cache_rows(
+                kv_cache,
+                physical_blocks,
+                local_pos.remainder(block_size),
+                head_dim,
+            )
+        )
+    if not pieces:
+        return torch.empty((0, head_dim), dtype=torch.float32, device=kv_cache.device)
+    return torch.cat(pieces, dim=0)
+
+
+def _musa_sparse_indexer_logits(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+) -> torch.Tensor:
+    # q is FP8-dequantized without an explicit q scale; the FP8 q scale is
+    # already folded into weights by fused_indexer_q_rope_quant.
+    per_head = torch.einsum("h d, n d -> h n", q.to(torch.float32), k)
+    per_head = per_head.clamp_min(0.0)
+    return (per_head * weights.to(torch.float32).unsqueeze(-1)).sum(dim=0)
+
+
+def _musa_fill_topk_rows_from_indexer_logits(
+    q_deq: torch.Tensor,
+    k_deq: torch.Tensor,
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_tokens: int,
+) -> None:
+    rows = min(q_deq.shape[0], topk_indices.shape[0], cu_seqlen_ks.numel())
+    for row in range(rows):
+        start = int(cu_seqlen_ks[row].item())
+        end = int(cu_seqlen_ke[row].item())
+        row_len = max(0, end - start)
+        if row_len == 0:
+            continue
+        k_i = min(int(topk_tokens), row_len, topk_indices.shape[1])
+        logits = _musa_sparse_indexer_logits(
+            q_deq[row],
+            k_deq[start:end],
+            weights[row],
+        )
+        topk_indices[row, :k_i] = torch.topk(logits, k_i, dim=-1).indices.to(
+            topk_indices.dtype
+        )
+
+
+def _musa_fill_decode_topk_from_indexer_cache(
+    q_deq: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    decode_metadata,
+    topk_indices_buffer: torch.Tensor,
+    topk_tokens: int,
+    head_dim: int,
+) -> None:
+    seq_lens = decode_metadata.seq_lens.reshape(-1)
+    rows = min(q_deq.shape[0], seq_lens.numel(), topk_indices_buffer.shape[0])
+    block_size = kv_cache.shape[1]
+    for row in range(rows):
+        seq_len = int(seq_lens[row].item())
+        if seq_len <= 0:
+            continue
+        block_row = min(row, decode_metadata.block_table.shape[0] - 1)
+        local_pos = torch.arange(seq_len, device=kv_cache.device, dtype=torch.long)
+        physical_blocks = decode_metadata.block_table[
+            block_row,
+            torch.div(local_pos, block_size, rounding_mode="floor").clamp(
+                0, decode_metadata.block_table.shape[1] - 1
+            ),
+        ]
+        gathered = _musa_dequant_indexer_fp8_cache_rows(
+                kv_cache,
+                physical_blocks,
+                local_pos.remainder(block_size),
+                head_dim,
+        )
+        k_i = min(int(topk_tokens), seq_len, topk_indices_buffer.shape[1])
+        logits = _musa_sparse_indexer_logits(q_deq[row], gathered, weights[row])
+        topk_indices_buffer[row, :k_i] = torch.topk(logits, k_i, dim=-1).indices.to(
+            topk_indices_buffer.dtype
+        )
+
+
+def _musa_fill_decode_topk_from_indexer_cache_capture(
+    q_deq: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    decode_metadata,
+    topk_indices_buffer: torch.Tensor,
+    topk_tokens: int,
+    head_dim: int,
+) -> None:
+    seq_lens = decode_metadata.seq_lens.reshape(-1).to(torch.long)
+    rows = min(q_deq.shape[0], seq_lens.numel(), topk_indices_buffer.shape[0])
+    topk = min(int(topk_tokens), topk_indices_buffer.shape[1])
+    if rows <= 0 or topk <= 0:
+        return
+
+    block_table = _musa_decode_block_table_for_token_rows(
+        decode_metadata.block_table,
+        rows,
+    )
+    if block_table is None:
+        return
+    block_size = kv_cache.shape[1]
+    max_positions = block_table.shape[1] * block_size
+    topk = min(topk, max_positions)
+    topk_indices_buffer[:rows, :topk] = -1
+    if max_positions <= 0:
+        return
+
+    local_pos = torch.arange(max_positions, device=kv_cache.device, dtype=torch.long)
+    block_cols = torch.div(local_pos, block_size, rounding_mode="floor").clamp(
+        0, block_table.shape[1] - 1
+    )
+    physical_blocks = block_table[:, block_cols]
+    pos_in_block = local_pos.remainder(block_size).expand(rows, -1)
+
+    gathered = _musa_dequant_indexer_fp8_cache_rows(
+        kv_cache,
+        physical_blocks.reshape(-1),
+        pos_in_block.reshape(-1),
+        head_dim,
+    ).view(rows, max_positions, head_dim)
+
+    q_rows = q_deq[:rows].to(torch.float32)
+    weight_rows = weights[:rows].to(torch.float32)
+    per_head = torch.einsum("r h d, r n d -> r h n", q_rows, gathered)
+    per_head = per_head.clamp_min(0.0)
+    logits = (per_head * weight_rows.unsqueeze(-1)).sum(dim=1)
+
+    valid = local_pos.unsqueeze(0) < seq_lens[:rows].unsqueeze(-1)
+    logits = torch.where(
+        valid,
+        logits,
+        torch.full((), float("-inf"), dtype=logits.dtype, device=logits.device),
+    )
+    indices = torch.topk(logits, topk, dim=-1).indices.to(topk_indices_buffer.dtype)
+    valid_counts = seq_lens[:rows].clamp(min=0, max=topk).unsqueeze(-1)
+    rank_offsets = torch.arange(topk, device=kv_cache.device, dtype=torch.long)
+    indices = torch.where(
+        rank_offsets.unsqueeze(0) < valid_counts,
+        indices,
+        torch.full_like(indices, -1),
+    )
+    topk_indices_buffer[:rows, :topk] = indices
+
+
+def _musa_fill_exact_sparse_indexer_indices_capture(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: LayerNameType,
+    kv_cache: torch.Tensor,
+    q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    topk_tokens: int,
+    head_dim: int,
+    topk_indices_buffer: torch.Tensor,
+    use_fp4_cache: bool,
+) -> torch.Tensor:
+    # Avoid logger calls in fallback forward paths; these functions may be
+    # reached while TorchDynamo/CUDA Graph capture is active.
+    if use_fp4_cache or isinstance(q_quant, tuple):
+        return _musa_fill_recent_sparse_indexer_indices(
+            hidden_states,
+            k_cache_prefix,
+            topk_tokens,
+            topk_indices_buffer,
+        )
+
+    attn_metadata = get_forward_context().attn_metadata
+    if not isinstance(attn_metadata, dict):
+        return topk_indices_buffer
+
+    metadata = attn_metadata.get(_resolve_layer_name(k_cache_prefix))
+    if not isinstance(metadata, DeepseekV32IndexerMetadata):
+        return topk_indices_buffer
+
+    topk_indices_buffer[: hidden_states.shape[0]] = -1
+
+    if metadata.num_decodes > 0 and metadata.decode is not None:
+        if not _musa_try_fill_decode_topk_from_indexer_cache_native(
+            q_quant[: metadata.num_decode_tokens],
+            kv_cache,
+            weights[: metadata.num_decode_tokens],
+            metadata.decode,
+            topk_indices_buffer[: metadata.num_decode_tokens, :topk_tokens],
+            topk_tokens,
+            head_dim,
+        ):
+            q_deq = q_quant.to(torch.float32)
+            weights_fp32 = weights.to(torch.float32)
+            _musa_fill_decode_topk_from_indexer_cache_capture(
+                q_deq[: metadata.num_decode_tokens],
+                kv_cache,
+                weights_fp32[: metadata.num_decode_tokens],
+                metadata.decode,
+                topk_indices_buffer[: metadata.num_decode_tokens, :topk_tokens],
+                topk_tokens,
+                head_dim,
+            )
+
+    if metadata.num_prefills > 0:
+        _musa_fill_recent_sparse_indexer_indices(
+            hidden_states,
+            k_cache_prefix,
+            topk_tokens,
+            topk_indices_buffer,
+        )
+
+    return topk_indices_buffer
+
+
+def _musa_fill_exact_sparse_indexer_indices(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: LayerNameType,
+    kv_cache: torch.Tensor,
+    q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    topk_tokens: int,
+    head_dim: int,
+    topk_indices_buffer: torch.Tensor,
+    use_fp4_cache: bool,
+) -> torch.Tensor:
+    if _musa_sparse_indexer_is_current_stream_capturing():
+        if _musa_sparse_indexer_graph_exact_decode_enabled():
+            return _musa_fill_exact_sparse_indexer_indices_capture(
+                hidden_states,
+                k_cache_prefix,
+                kv_cache,
+                q_quant,
+                weights,
+                topk_tokens,
+                head_dim,
+                topk_indices_buffer,
+                use_fp4_cache,
+            )
+        return _musa_fill_recent_sparse_indexer_indices(
+            hidden_states,
+            k_cache_prefix,
+            topk_tokens,
+            topk_indices_buffer,
+        )
+
+    if use_fp4_cache or isinstance(q_quant, tuple):
+        raise NotImplementedError(
+            "MUSA exact sparse-attention indexer fallback currently supports "
+            "the FP8 indexer-cache path only."
+        )
+
+    attn_metadata = get_forward_context().attn_metadata
+    if not isinstance(attn_metadata, dict):
+        return topk_indices_buffer
+
+    metadata = attn_metadata.get(_resolve_layer_name(k_cache_prefix))
+    if not isinstance(metadata, DeepseekV32IndexerMetadata):
+        return topk_indices_buffer
+
+    topk_indices_buffer[: hidden_states.shape[0]] = -1
+    q_deq = None
+    weights_fp32 = None
+
+    if metadata.num_prefills > 0 and metadata.prefill is not None:
+        for chunk in metadata.prefill.chunks:
+            token_start = int(chunk.token_start)
+            token_end = int(chunk.token_end)
+            if _musa_try_fill_prefill_topk_from_indexer_cache_native(
+                q_quant[token_start:token_end],
+                kv_cache,
+                weights[token_start:token_end],
+                chunk,
+                topk_indices_buffer[token_start:token_end, :topk_tokens],
+                topk_tokens,
+                head_dim,
+            ):
+                continue
+            if q_deq is None:
+                q_deq = q_quant.to(torch.float32)
+            if weights_fp32 is None:
+                weights_fp32 = weights.to(torch.float32)
+            k_deq = _musa_gather_indexer_fp8_cache(
+                kv_cache,
+                chunk.block_table,
+                chunk.cu_seq_lens,
+                head_dim,
+            )
+            _musa_fill_topk_rows_from_indexer_logits(
+                q_deq[token_start:token_end],
+                k_deq,
+                weights_fp32[token_start:token_end],
+                chunk.cu_seqlen_ks,
+                chunk.cu_seqlen_ke,
+                topk_indices_buffer[token_start:token_end, :topk_tokens],
+                topk_tokens,
+            )
+
+    if metadata.num_decodes > 0 and metadata.decode is not None:
+        if not _musa_try_fill_decode_topk_from_indexer_cache_native(
+            q_quant[: metadata.num_decode_tokens],
+            kv_cache,
+            weights[: metadata.num_decode_tokens],
+            metadata.decode,
+            topk_indices_buffer[: metadata.num_decode_tokens, :topk_tokens],
+            topk_tokens,
+            head_dim,
+        ):
+            if q_deq is None:
+                q_deq = q_quant.to(torch.float32)
+            if weights_fp32 is None:
+                weights_fp32 = weights.to(torch.float32)
+            _musa_fill_decode_topk_from_indexer_cache_capture(
+                q_deq[: metadata.num_decode_tokens],
+                kv_cache,
+                weights_fp32[: metadata.num_decode_tokens],
+                metadata.decode,
+                topk_indices_buffer[: metadata.num_decode_tokens, :topk_tokens],
+                topk_tokens,
+                head_dim,
+            )
+
+    return topk_indices_buffer
+""",
+    ),
+    (
+        """        else:
+            raise NotImplementedError(
+                "SparseAttnIndexer native forward is only implemented for "
+                "CUDA, ROCm and XPU platforms."
+            )
+""",
+        """        elif (
+            current_platform.is_musa()
+            and (
+                os.getenv(
+                    "VLLM_MUSA_ENABLE_DEEPSEEK_V4_SPARSE_INDEXER_MUSA_IMPL",
+                    "1",
+                )
+                == "1"
+                or os.getenv(
+                    "VLLM_MUSA_ENABLE_TORCH_SPARSE_ATTN_INDEXER_FALLBACK",
+                    "0",
+                )
+                == "1"
+            )
+        ):
+            try:
+                return _musa_fill_exact_sparse_indexer_indices(
+                    hidden_states,
+                    self.k_cache.prefix,
+                    self.k_cache.kv_cache,
+                    q_quant,
+                    weights,
+                    self.topk_tokens,
+                    self.head_dim,
+                    self.topk_indices_buffer,
+                    self.use_fp4_cache,
+                )
+            except NotImplementedError:
+                return _musa_fill_recent_sparse_indexer_indices(
+                    hidden_states,
+                    self.k_cache.prefix,
+                    self.topk_tokens,
+                    self.topk_indices_buffer,
+                )
+        else:
+            raise NotImplementedError(
+                "SparseAttnIndexer native forward is only implemented for "
+                "CUDA, ROCm and XPU platforms."
+            )
+""",
+    ),
+]
+
+RELOAD_AFTER_PATCH = True

--- a/vllm_musa/patches/vllm__model_executor__models__deepseek_v4.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__models__deepseek_v4.patch.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch DeepSeek-V4 model CUDA-only runtime gates for MUSA.
+"""
+
+PATCHES = [
+    (
+        """import typing
+from collections.abc import Callable, Iterable
+""",
+        """import os
+import typing
+from collections.abc import Callable, Iterable
+""",
+    ),
+    (
+        """from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
+    fused_topk_bias,
+)
+""",
+        """from vllm.model_executor.layers.fused_moe.router import (
+    fused_topk_bias_router as _musa_fused_topk_bias_router,
+)
+from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
+    fused_topk_bias,
+)
+""",
+    ),
+    (
+        """from .utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    extract_layer_index,
+    make_layers,
+    maybe_prefix,
+)
+""",
+        """from .utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    extract_layer_index,
+    make_layers,
+    maybe_prefix,
+)
+
+from vllm_musa.deepseek_v4_fallbacks import (
+    enable_deepseek_v4_sparse_correctness_fallbacks as _musa_enable_deepseek_v4_sparse_correctness_fallbacks,
+)
+from vllm_musa import _custom_ops as _musa_ops
+
+
+def _musa_deepseek_v4_topk_softplus_sqrt_fallback(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    e_score_correction_bias: torch.Tensor | None = None,
+    input_tokens: torch.Tensor | None = None,
+    hash_indices_table: torch.Tensor | None = None,
+    routed_scaling_factor: float = 1.0,
+) -> tuple[torch.Tensor, ...]:
+    scores = F.softplus(gating_output).sqrt()
+    scores_for_choice = scores.view(-1, scores.shape[-1])
+    if e_score_correction_bias is not None:
+        scores_for_choice = scores_for_choice + e_score_correction_bias.unsqueeze(0)
+    if hash_indices_table is not None:
+        if input_tokens is None:
+            raise ValueError(
+                "input_tokens is required when hash_indices_table is provided"
+            )
+        topk_selected = hash_indices_table[input_tokens]
+    else:
+        topk_selected = torch.topk(
+            scores_for_choice,
+            k=topk_indices.shape[1],
+            dim=-1,
+            sorted=_musa_fused_topk_bias_router.envs.VLLM_BATCH_INVARIANT,
+        )[1]
+    selected_weights = scores.gather(1, topk_selected.to(torch.long))
+    if renormalize:
+        selected_weights = selected_weights / selected_weights.sum(
+            dim=-1, keepdim=True
+        )
+    if routed_scaling_factor != 1.0:
+        selected_weights = selected_weights * routed_scaling_factor
+    topk_weights.copy_(selected_weights.to(topk_weights.dtype))
+    topk_indices.copy_(topk_selected.to(topk_indices.dtype))
+    token_expert_indices.copy_(topk_selected.to(token_expert_indices.dtype))
+    return topk_weights, topk_indices
+
+
+def _musa_deepseek_v4_topk_softplus_sqrt_native(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    e_score_correction_bias: torch.Tensor | None = None,
+    input_tokens: torch.Tensor | None = None,
+    hash_indices_table: torch.Tensor | None = None,
+    routed_scaling_factor: float = 1.0,
+) -> tuple[torch.Tensor, ...]:
+    _musa_ops.deepseek_v4_topk_softplus_sqrt(
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize,
+        routed_scaling_factor,
+        e_score_correction_bias,
+        input_tokens,
+        hash_indices_table,
+    )
+    return topk_weights, topk_indices
+
+
+if current_platform.is_musa() or getattr(torch.version, "musa", None) is not None:
+    _musa_enable_deepseek_v4_sparse_correctness_fallbacks()
+
+if current_platform.is_musa() or getattr(torch.version, "musa", None) is not None:
+    if os.getenv("VLLM_MUSA_ENABLE_TORCH_TOPK_SOFTPLUS_SQRT_FALLBACK", "0") == "1":
+        _musa_fused_topk_bias_router.vllm_topk_softplus_sqrt = (
+            _musa_deepseek_v4_topk_softplus_sqrt_fallback
+        )
+    else:
+        _musa_fused_topk_bias_router.vllm_topk_softplus_sqrt = (
+            _musa_deepseek_v4_topk_softplus_sqrt_native
+        )
+
+
+""",
+    ),
+    (
+        """from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+""",
+        """from vllm.model_executor.layers.quantization.fp8 import Fp8Config, Fp8MoEMethod
+""",
+    ),
+    (
+        """    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        return "deepseek_v4_fp8"
+
+    @classmethod
+    def override_quantization_method(
+""",
+        """    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        return "deepseek_v4_fp8"
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        if (
+            current_platform.is_musa()
+            or getattr(torch.version, "musa", None) is not None
+        ):
+            return 31
+        return super().get_min_capability()
+
+    @classmethod
+    def override_quantization_method(
+""",
+    ),
+    (
+        """    def get_quant_method(self, layer, prefix):
+        if isinstance(layer, FusedMoE):
+            if is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.ignored_layers,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                return UnquantizedFusedMoEMethod(layer.moe_config)
+            return Mxfp4MoEMethod(layer.moe_config)
+        return super().get_quant_method(layer, prefix)
+""",
+        """    def get_quant_method(self, layer, prefix):
+        if isinstance(layer, FusedMoE):
+            if is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.ignored_layers,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                return UnquantizedFusedMoEMethod(layer.moe_config)
+            if (
+                current_platform.is_musa()
+                or getattr(torch.version, "musa", None) is not None
+            ):
+                return Fp8MoEMethod(self, layer)
+            return Mxfp4MoEMethod(layer.moe_config)
+        return super().get_quant_method(layer, prefix)
+""",
+    ),
+    (
+        """    def is_mxfp4_quant(self, prefix, layer):
+        return isinstance(layer, FusedMoE)
+""",
+        """    def is_mxfp4_quant(self, prefix, layer):
+        if not isinstance(layer, FusedMoE):
+            return False
+        if (
+            current_platform.is_musa()
+            or getattr(torch.version, "musa", None) is not None
+        ):
+            return False
+        return True
+""",
+    ),
+    (
+        """    def _check_runtime_supported(self) -> None:
+        if not torch.cuda.is_available():
+            raise NotImplementedError("DeepSeek V4 MegaMoE requires CUDA.")
+        device = self.w13_weight.device
+        if device.type != "cuda":
+            raise NotImplementedError(
+                "DeepSeek V4 MegaMoE expert weights must be loaded on CUDA."
+            )
+        if torch.cuda.get_device_capability(device)[0] != 10:
+            raise NotImplementedError("DeepGEMM MegaMoE requires SM100 GPUs.")
+        if self.hidden_size % 128 != 0 or self.intermediate_size % 128 != 0:
+            raise ValueError(
+                "DeepGEMM MegaMoE requires hidden and intermediate sizes "
+                "to be multiples of 128."
+            )
+""",
+        """    def _check_runtime_supported(self) -> None:
+        device = self.w13_weight.device
+        if (
+            current_platform.is_musa()
+            or getattr(torch.version, "musa", None) is not None
+            or device.type == "musa"
+        ):
+            raise NotImplementedError(
+                "DeepSeek V4 MegaMoE is not implemented for MUSA yet. "
+                "A MUSA MegaMoE replacement path is "
+                "required before enabling deep_gemm_mega_moe."
+            )
+        if not torch.cuda.is_available():
+            raise NotImplementedError("DeepSeek V4 MegaMoE requires CUDA.")
+        if device.type != "cuda":
+            raise NotImplementedError(
+                "DeepSeek V4 MegaMoE expert weights must be loaded on CUDA."
+            )
+        if torch.cuda.get_device_capability(device)[0] != 10:
+            raise NotImplementedError("DeepGEMM MegaMoE requires SM100 GPUs.")
+        if self.hidden_size % 128 != 0 or self.intermediate_size % 128 != 0:
+            raise ValueError(
+                "DeepGEMM MegaMoE requires hidden and intermediate sizes "
+                "to be multiples of 128."
+            )
+""",
+    ),
+]
+
+# DeepSeek-V4-Flash-Base FP8 checkpoints use per-expert names like
+# `experts.0.w1.scale` / `experts.0.w1.weight`. Upstream v0.20.0 only maps
+# the `weight.` form to `w13_weight` / `w2_weight`; add scale aliases and
+# resolve them to either MegaMoE `*_weight_scale` or FP8 FusedMoE
+# `*_weight_scale_inv` parameters at load time.
+PATCHES.extend(
+    [
+        (
+            '            "experts.w13_" if shard_id in ("w1", "w3") else "experts.w2_",\n            f"experts.{expert_id}.{weight_name}.",\n            expert_id,\n            shard_id,\n        )\n        for expert_id in range(num_experts)\n        for shard_id, weight_name in [\n            ("w1", "w1"),\n            ("w2", "w2"),\n            ("w3", "w3"),\n        ]\n    ]\n',
+            '            "experts.w13_" if shard_id in ("w1", "w3") else "experts.w2_",\n            f"experts.{expert_id}.{weight_name}.",\n            expert_id,\n            shard_id,\n        )\n        for expert_id in range(num_experts)\n        for shard_id, weight_name in [\n            ("w1", "w1"),\n            ("w2", "w2"),\n            ("w3", "w3"),\n        ]\n    ] + [\n        (\n            "experts.w13_weight_scale"\n            if shard_id in ("w1", "w3")\n            else "experts.w2_weight_scale",\n            f"experts.{expert_id}.{weight_name}.scale",\n            expert_id,\n            shard_id,\n        )\n        for expert_id in range(num_experts)\n        for shard_id, weight_name in [\n            ("w1", "w1"),\n            ("w2", "w2"),\n            ("w3", "w3"),\n        ]\n    ]\n',
+        ),
+        (
+            '                    if (\n                        "weight_scale" in name\n                        and loaded_weight.dtype == torch.float8_e8m0fnu\n                    ):\n                        loaded_weight = loaded_weight.view(torch.uint8)\n',
+            "                    # MUSA: convert E8M0 expert scales after resolving the target param.\n",
+        ),
+        (
+            "                    if loaded_weight.dtype == torch.float8_e8m0fnu:\n                        loaded_weight = loaded_weight.view(torch.uint8)\n",
+            "                    # MUSA: convert E8M0 expert scales after resolving the target param.\n",
+        ),
+        (
+            "                    for mapping in expert_mapping:\n                        param_name, weight_name, expert_id, shard_id = mapping\n                        if weight_name not in name:\n                            continue\n                        name_mapped = name.replace(weight_name, param_name)\n                        param = params_dict[name_mapped]\n                        # We should ask the weight loader to return success or not\n",
+            '                    name_mapped = name\n                    for mapping in expert_mapping:\n                        param_name, weight_name, expert_id, shard_id = mapping\n                        if weight_name not in name:\n                            continue\n                        name_mapped = name.replace(weight_name, param_name)\n                        if name_mapped not in params_dict and name_mapped.endswith(\n                            "_weight_scale"\n                        ):\n                            inv_name_mapped = f"{name_mapped}_inv"\n                            if inv_name_mapped in params_dict:\n                                name_mapped = inv_name_mapped\n                        if name_mapped not in params_dict:\n                            continue\n                        param = params_dict[name_mapped]\n                        loaded_weight_for_param = loaded_weight\n                        if loaded_weight_for_param.dtype == torch.float8_e8m0fnu:\n                            if param.dtype == torch.uint8:\n                                loaded_weight_for_param = loaded_weight_for_param.view(\n                                    torch.uint8\n                                )\n                            else:\n                                loaded_weight_for_param = loaded_weight_for_param.to(\n                                    param.dtype\n                                )\n                        # We should ask the weight loader to return success or not\n',
+        ),
+        (
+            "                        success = weight_loader(\n                            param,\n                            loaded_weight,\n                            name_mapped,\n",
+            "                        success = weight_loader(\n                            param,\n                            loaded_weight_for_param,\n                            name_mapped,\n",
+        ),
+    ]
+)
+
+PATCHES.extend(
+    [
+        (
+            """@torch.compile(backend=current_platform.simple_compile_backend)
+def hc_head(
+    hidden_states: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    x = hidden_states
+    shape, dtype = x.size(), x.dtype
+    x = x.flatten(1).float()
+    rsqrt = torch.rsqrt(x.square().mean(-1, keepdim=True) + rms_norm_eps)
+    mixes = F.linear(x, hc_fn) * rsqrt
+    pre = torch.sigmoid(mixes * hc_scale + hc_base) + hc_eps
+    y = torch.sum(pre.unsqueeze(-1) * x.view(shape), dim=1)
+    return y.to(dtype)
+""",
+            """def hc_head(
+    hidden_states: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    if (
+        current_platform.is_musa()
+        and os.getenv("VLLM_MUSA_DEEPSEEK_V4_HC_HEAD_COMPILE", "0") != "1"
+    ):
+        return _musa_deepseek_v4_hc_head_eager(
+            hidden_states,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            rms_norm_eps,
+            hc_eps,
+        )
+    return _compiled_hc_head(
+        hidden_states,
+        hc_fn,
+        hc_scale,
+        hc_base,
+        rms_norm_eps,
+        hc_eps,
+    )
+
+
+@torch.compile(backend=current_platform.simple_compile_backend)
+def _compiled_hc_head(
+    hidden_states: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    x = hidden_states
+    shape, dtype = x.size(), x.dtype
+    x = x.flatten(1).float()
+    rsqrt = torch.rsqrt(x.square().mean(-1, keepdim=True) + rms_norm_eps)
+    mixes = F.linear(x, hc_fn) * rsqrt
+    pre = torch.sigmoid(mixes * hc_scale + hc_base) + hc_eps
+    y = torch.sum(pre.unsqueeze(-1) * x.view(shape), dim=1)
+    return y.to(dtype)
+
+
+def _musa_deepseek_v4_hc_head_eager(
+    hidden_states: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    x = hidden_states
+    shape, dtype = x.size(), x.dtype
+    x = x.flatten(1).to(torch.float32)
+    rsqrt = torch.rsqrt(x.square().mean(-1, keepdim=True) + rms_norm_eps)
+    mixes = F.linear(x, hc_fn.to(torch.float32)) * rsqrt
+    pre = (
+        torch.sigmoid(mixes * hc_scale.to(torch.float32) + hc_base.to(torch.float32))
+        + hc_eps
+    )
+    y = torch.sum(pre.unsqueeze(-1) * x.view(shape), dim=1)
+    return y.to(dtype)
+""",
+        ),
+    ]
+)

--- a/vllm_musa/patches/vllm__model_executor__models__deepseek_v4_mtp.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__models__deepseek_v4_mtp.patch.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch for vllm.model_executor.models.deepseek_v4_mtp.
+"""
+
+PATCHES = [
+    # DeepSeek-V4-Flash-Base stores routed MTP expert scales as
+    # `experts.N.wX.scale`. Upstream remaps those to `*_weight_scale`, which
+    # exists for MegaMoE, but the active FP8 FusedMoE path owns
+    # `*_weight_scale_inv`. Mirror the main DeepSeek-V4 loader's MUSA-safe
+    # resolution and convert E8M0 bytes only after the destination parameter is
+    # known.
+    (
+        """                    # Reinterpret E8M0 scales as uint8 to preserve raw
+                    # exponent bytes; numeric copy_() would zero them.
+                    # Mirrors the main DeepseekV4 loader.
+                    if (
+                        "weight_scale" in name
+                        and loaded_weight.dtype == torch.float8_e8m0fnu
+                    ):
+                        loaded_weight = loaded_weight.view(torch.uint8)
+                    for mapping in expert_mapping:
+                        param_name, weight_name, expert_id, shard_id = mapping
+                        if weight_name not in name:
+                            continue
+                        name_mapped = name.replace(weight_name, param_name)
+                        param = params_dict[name_mapped]
+                        # We should ask the weight loader to return success or not
+""",
+        """                    name_mapped = name
+                    for mapping in expert_mapping:
+                        param_name, weight_name, expert_id, shard_id = mapping
+                        if weight_name not in name:
+                            continue
+                        name_mapped = name.replace(weight_name, param_name)
+                        if name_mapped not in params_dict and name_mapped.endswith(
+                            "_weight_scale"
+                        ):
+                            inv_name_mapped = f"{name_mapped}_inv"
+                            if inv_name_mapped in params_dict:
+                                name_mapped = inv_name_mapped
+                        if name_mapped not in params_dict:
+                            continue
+                        param = params_dict[name_mapped]
+                        loaded_weight_for_param = loaded_weight
+                        if loaded_weight_for_param.dtype == torch.float8_e8m0fnu:
+                            if param.dtype == torch.uint8:
+                                loaded_weight_for_param = loaded_weight_for_param.view(
+                                    torch.uint8
+                                )
+                            else:
+                                loaded_weight_for_param = loaded_weight_for_param.to(
+                                    param.dtype
+                                )
+                        # We should ask the weight loader to return success or not
+""",
+    ),
+    (
+        """                        success = weight_loader(
+                            param,
+                            loaded_weight,
+                            name_mapped,
+""",
+        """                        success = weight_loader(
+                            param,
+                            loaded_weight_for_param,
+                            name_mapped,
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__v1__attention__backends__mla__sparse_swa.patch.py
+++ b/vllm_musa/patches/vllm__v1__attention__backends__mla__sparse_swa.patch.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch DeepSeek-V4 sparse SWA metadata kernel for MUSA Triton.
+"""
+
+PATCHES = [
+    (
+        """from vllm.v1.attention.ops.flashmla import FlashMLASchedMeta, get_mla_metadata
+""",
+        """from vllm_musa.v1.attention.ops.flashmla import FlashMLASchedMeta, get_mla_metadata
+""",
+    ),
+    (
+        """    is_valid = tl.load(is_valid_token_ptr + token_idx)
+    if not is_valid:
+        tl.store(swa_lens_ptr + token_idx, 0)
+        return
+""",
+        """    is_valid = tl.load(is_valid_token_ptr + token_idx)
+    if is_valid == 0:
+        tl.store(swa_lens_ptr + token_idx, 0)
+        return
+""",
+    ),
+    (
+        """        # NOTE: Ensure all metadata tensors maintain fixed memory addresses
+        # for CUDA graph compatibility.
+        query_lens = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+        x = torch.repeat_interleave(torch.arange(num_reqs), query_lens).pin_memory()
+        token_to_req_indices = self.token_to_req_indices[: x.shape[0]]
+        token_to_req_indices.copy_(x, non_blocking=True)
+
+        is_valid_token = self.is_valid_token[: slot_mapping.shape[0]]
+        is_valid_token.copy_(slot_mapping >= 0)
+""",
+        """        # NOTE: Ensure all metadata tensors maintain fixed memory addresses
+        # for CUDA graph compatibility. Build token-to-request and validity
+        # metadata on device: the upstream CPU repeat_interleave + pin_memory +
+        # H2D copy path serializes MTP drafting on MUSA.
+        num_tokens = slot_mapping.shape[0]
+        token_to_req_indices = self.token_to_req_indices[:num_tokens]
+        is_valid_token = self.is_valid_token[:num_tokens]
+        if num_tokens > 0:
+            _compute_token_to_req_and_valid_kernel[(num_tokens,)](
+                token_to_req_indices,
+                is_valid_token,
+                slot_mapping,
+                query_start_loc,
+                num_reqs,
+                BLOCK_SIZE=triton.next_power_of_2(max(num_reqs, 1)),
+            )
+""",
+    ),
+    (
+        """
+
+@triton.jit
+def _compute_swa_indices_and_lens_kernel(
+""",
+        """
+
+@triton.jit
+def _compute_token_to_req_and_valid_kernel(
+    token_to_req_indices_ptr,
+    is_valid_token_ptr,
+    slot_mapping_ptr,
+    query_start_loc_ptr,
+    num_reqs: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    req_idx = tl.full((), 0, tl.int32)
+    for i in range(0, BLOCK_SIZE):
+        q_start = tl.load(query_start_loc_ptr + i, mask=i < num_reqs, other=0)
+        q_end = tl.load(query_start_loc_ptr + i + 1, mask=i < num_reqs, other=0)
+        in_req = (token_idx >= q_start) & (token_idx < q_end) & (i < num_reqs)
+        req_idx = tl.where(in_req, i, req_idx)
+    tl.store(token_to_req_indices_ptr + token_idx, req_idx)
+
+    slot = tl.load(slot_mapping_ptr + token_idx)
+    tl.store(is_valid_token_ptr + token_idx, slot >= 0)
+
+
+@triton.jit
+def _compute_swa_indices_and_lens_kernel(
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__v1__attention__ops__deepseek_v4_ops__cache_utils.patch.py
+++ b/vllm_musa/patches/vllm__v1__attention__ops__deepseek_v4_ops__cache_utils.patch.py
@@ -1,0 +1,444 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch DeepSeek-V4 cache utility kernels with MUSA-specific gates.
+"""
+
+PATCHES = [
+    (
+        """import torch
+
+from vllm.triton_utils import tl, triton
+""",
+        """import os
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+import vllm_musa._custom_ops as musa_ops
+
+logger = init_logger(__name__)
+
+
+def _raise_musa_deepseek_v4_cache_unsupported(op_name: str) -> None:
+    raise NotImplementedError(
+        f"DeepSeek-V4 {op_name} is not implemented for MUSA yet. "
+        "A MUSA-safe cache quantization, dequantization, top-k metadata, "
+        "or sparse prefill index implementation is required before model "
+        "execution can proceed."
+    )
+
+
+def _is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or tensor.device.type == "musa"
+    )
+
+
+def _musa_deepseek_v4_cache_fallback_enabled() -> bool:
+    return (
+        os.getenv("VLLM_MUSA_ENABLE_TORCH_DEEPSEEK_V4_CACHE_FALLBACK", "0")
+        == "1"
+    )
+
+
+def _musa_deepseek_v4_cache_dequant_triton_enabled() -> bool:
+    return (
+        os.getenv("VLLM_MUSA_DEEPSEEK_V4_CACHE_DEQUANT_TRITON", "0")
+        == "1"
+    )
+
+
+def _musa_warn_cache_fallback_once(op_name: str) -> None:
+    logger.warning_once(
+        "Using opt-in MUSA torch DeepSeek-V4 %s fallback. This emulates "
+        "the Triton cache/top-k utility in torch; it is a correctness "
+        "fallback, not a production backend.",
+        op_name,
+    )
+
+
+def _musa_dequantize_and_gather_k_cache_native(
+    out: torch.Tensor,
+    k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor | None,
+    block_table: torch.Tensor,
+    block_size: int,
+    offset: int,
+) -> None:
+    return musa_ops.deepseek_v4_dequantize_and_gather_k_cache(
+        out, k_cache, seq_lens, gather_lens, block_table, block_size, offset
+    )
+
+
+def _musa_compute_global_topk_indices_and_lens_native(
+    topk_indices: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    is_valid_token: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return musa_ops.deepseek_v4_compute_global_topk_indices_and_lens(
+        topk_indices, token_to_req_indices, block_table, block_size, is_valid_token
+    )
+
+
+def _musa_combine_topk_swa_indices_native(
+    topk_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    topk: int,
+    M: int,
+    N: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return musa_ops.deepseek_v4_combine_topk_swa_indices(
+        topk_indices,
+        query_start_loc,
+        seq_lens,
+        gather_lens,
+        window_size,
+        compress_ratio,
+        topk,
+        M,
+        N,
+    )
+
+
+def _musa_deepseek_v4_block_cache_view(k_cache: torch.Tensor) -> torch.Tensor:
+    if k_cache.dtype != torch.uint8:
+        raise AssertionError(f"DeepSeek-V4 K cache must be uint8, got {k_cache.dtype}")
+    block_stride = k_cache.stride(0)
+    return k_cache.as_strided((k_cache.shape[0], block_stride), (block_stride, 1))
+
+
+def _musa_dequantize_and_gather_k_cache_fallback(
+    out: torch.Tensor,
+    k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor | None,
+    block_table: torch.Tensor,
+    block_size: int,
+    offset: int,
+) -> None:
+    # Keep this helper structurally distinct from the upstream function body so
+    # later string replacements do not patch the fallback into calling itself.
+    TOKEN_FP8_DIM = 448
+    TOKEN_BF16_DIM = 64
+    TOKEN_SCALE_DIM = 8
+    QUANT_BLOCK_SIZE = 64
+    TOKEN_DATA_SIZE = TOKEN_FP8_DIM + TOKEN_BF16_DIM * 2
+    N_QUANT_BLOCKS = 7
+
+    if out.shape[-1] != TOKEN_FP8_DIM + TOKEN_BF16_DIM:
+        raise AssertionError(f"DeepSeek-V4 gather output must end in 512, got {out.shape}")
+
+    cache_blocks = _musa_deepseek_v4_block_cache_view(k_cache)
+    for req_idx in range(seq_lens.shape[0]):
+        seq_len = int(seq_lens[req_idx].item())
+        gather_len = (
+            int(gather_lens[req_idx].item()) if gather_lens is not None else seq_len
+        )
+        start_pos = seq_len - gather_len
+        for i in range(gather_len):
+            pos = start_pos + i
+            block_in_seq = pos // block_size
+            pos_in_block = pos % block_size
+            physical_block_idx = int(block_table[req_idx, block_in_seq].item())
+            block_bytes = cache_blocks[physical_block_idx]
+
+            token_base = pos_in_block * TOKEN_DATA_SIZE
+            scale_base = block_size * TOKEN_DATA_SIZE + pos_in_block * TOKEN_SCALE_DIM
+            output_row = out[req_idx, offset + i]
+
+            for qblock_idx in range(N_QUANT_BLOCKS):
+                qblock_start = qblock_idx * QUANT_BLOCK_SIZE
+                qbytes = block_bytes[
+                    token_base + qblock_start : token_base + qblock_start + QUANT_BLOCK_SIZE
+                ]
+                encoded_scale = block_bytes[scale_base + qblock_idx].to(torch.float32)
+                scale = torch.exp2(encoded_scale - 127.0)
+                dequant = qbytes.view(torch.float8_e4m3fn).to(torch.float32) * scale
+                output_row[qblock_start : qblock_start + QUANT_BLOCK_SIZE].copy_(
+                    dequant.to(out.dtype)
+                )
+
+            bf16_start = token_base + TOKEN_FP8_DIM
+            bf16_bytes = block_bytes[bf16_start : bf16_start + TOKEN_BF16_DIM * 2]
+            output_row[TOKEN_FP8_DIM:].copy_(bf16_bytes.view(torch.bfloat16).to(out.dtype))
+
+
+def _musa_compute_global_topk_indices_and_lens_fallback(
+    topk_indices: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    is_valid_token: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens = topk_indices.shape[0]
+    local_indices = topk_indices[:num_tokens].to(torch.long)
+    valid = local_indices >= 0
+    safe_local_indices = local_indices.clamp(min=0)
+    req_indices = token_to_req_indices[:num_tokens].to(torch.long).clamp(
+        0, block_table.shape[0] - 1
+    )
+    block_indices = torch.div(
+        safe_local_indices, block_size, rounding_mode="floor"
+    ).clamp(0, block_table.shape[1] - 1)
+    block_offsets = safe_local_indices.remainder(block_size)
+    block_numbers = block_table[
+        req_indices.unsqueeze(-1),
+        block_indices,
+    ].to(torch.long)
+    slot_ids = block_numbers * block_size + block_offsets
+    global_topk_indices = torch.where(
+        valid,
+        slot_ids.to(topk_indices.dtype),
+        torch.full_like(topk_indices[:num_tokens], -1),
+    )
+    valid_counts = valid.sum(dim=-1).to(torch.int32)
+    topk_lens = torch.where(
+        is_valid_token[:num_tokens].to(torch.bool),
+        valid_counts,
+        torch.zeros_like(valid_counts),
+    )
+    return global_topk_indices, topk_lens
+
+
+def _musa_combine_topk_swa_indices_fallback(
+    topk_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    topk: int,
+    M: int,
+    N: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens = topk_indices.shape[0]
+    # Keep this helper structurally distinct from the upstream function body so
+    # later string replacements do not patch the fallback into calling itself.
+    num_reqs = seq_lens.shape[0]
+    combined_topk = (
+        (topk + window_size + _SPARSE_PREFILL_TOPK_ALIGNMENT - 1)
+        // _SPARSE_PREFILL_TOPK_ALIGNMENT
+        * _SPARSE_PREFILL_TOPK_ALIGNMENT
+    )
+    combined_indices = torch.full(
+        (num_tokens, combined_topk),
+        fill_value=-1,
+        dtype=torch.int32,
+        device=topk_indices.device,
+    )
+    combined_lens = torch.zeros(
+        num_tokens, dtype=torch.int32, device=topk_indices.device
+    )
+    base = int(query_start_loc[0].item())
+    for batch_idx in range(num_reqs):
+        query_start = int(query_start_loc[batch_idx].item()) - base
+        query_end = int(query_start_loc[batch_idx + 1].item()) - base
+        query_len = query_end - query_start
+        seq_len = int(seq_lens[batch_idx].item())
+        gather_len = int(gather_lens[batch_idx].item())
+        start_pos = seq_len - query_len
+        gather_start = seq_len - gather_len
+        req_offset = int(M) * batch_idx
+        for token_idx in range(query_start, query_end):
+            pos = start_pos + token_idx - query_start
+            topk_len = min((pos + 1) // int(compress_ratio), int(topk))
+            swa_len = min(pos + 1, int(window_size))
+            if topk_len > 0:
+                topk_values = topk_indices[token_idx, :topk_len].to(torch.int32)
+                combined_indices[token_idx, :topk_len] = topk_values + req_offset
+            if swa_len > 0:
+                swa_values = (
+                    torch.arange(swa_len, device=topk_indices.device, dtype=torch.int32)
+                    + req_offset
+                    + int(N)
+                    + pos
+                    - swa_len
+                    + 1
+                    - gather_start
+                )
+                combined_indices[
+                    token_idx,
+                    topk_len : topk_len + swa_len,
+                ] = swa_values
+            combined_lens[token_idx] = topk_len + swa_len
+    return combined_indices, combined_lens
+""",
+    ),
+    (
+        """    assert k.dim() == 2 and k.shape[1] == 512, (
+        f"K must be [num_tokens, 512], got {k.shape}"
+    )
+""",
+        """    if _is_musa_tensor(k):
+        _raise_musa_deepseek_v4_cache_unsupported("quantize_and_insert_k_cache")
+    assert k.dim() == 2 and k.shape[1] == 512, (
+        f"K must be [num_tokens, 512], got {k.shape}"
+    )
+""",
+    ),
+    (
+        """) -> None:
+    TOKEN_FP8_DIM = 448
+    TOKEN_BF16_DIM = 64
+""",
+        """) -> None:
+    if _is_musa_tensor(out):
+        if _musa_deepseek_v4_cache_fallback_enabled():
+            _musa_warn_cache_fallback_once("dequantize_and_gather_k_cache")
+            return _musa_dequantize_and_gather_k_cache_fallback(
+                out, k_cache, seq_lens, gather_lens, block_table, block_size, offset
+            )
+        if _musa_deepseek_v4_cache_dequant_triton_enabled():
+            logger.warning_once(
+                "Using opt-in MUSA Triton DeepSeek-V4 "
+                "dequantize_and_gather_k_cache path."
+            )
+        else:
+            return _musa_dequantize_and_gather_k_cache_native(
+                out, k_cache, seq_lens, gather_lens, block_table, block_size, offset
+            )
+    TOKEN_FP8_DIM = 448
+    TOKEN_BF16_DIM = 64
+""",
+    ),
+    (
+        """    num_tokens = topk_indices.shape[0]
+    global_topk_indices = torch.empty_like(topk_indices)
+""",
+        """    if _is_musa_tensor(topk_indices):
+        if _musa_deepseek_v4_cache_fallback_enabled():
+            _musa_warn_cache_fallback_once("compute_global_topk_indices_and_lens")
+            return _musa_compute_global_topk_indices_and_lens_fallback(
+                topk_indices,
+                token_to_req_indices,
+                block_table,
+                block_size,
+                is_valid_token,
+            )
+        return _musa_compute_global_topk_indices_and_lens_native(
+            topk_indices,
+            token_to_req_indices,
+            block_table,
+            block_size,
+            is_valid_token,
+        )
+    num_tokens = topk_indices.shape[0]
+    global_topk_indices = torch.empty_like(topk_indices)
+""",
+    ),
+    (
+        """    num_tokens = topk_indices.shape[0]
+    num_reqs = seq_lens.shape[0]
+""",
+        """    if _is_musa_tensor(topk_indices):
+        if _musa_deepseek_v4_cache_fallback_enabled():
+            _musa_warn_cache_fallback_once("combine_topk_swa_indices")
+            return _musa_combine_topk_swa_indices_fallback(
+                topk_indices,
+                query_start_loc,
+                seq_lens,
+                gather_lens,
+                window_size,
+                compress_ratio,
+                topk,
+                M,
+                N,
+            )
+        return _musa_combine_topk_swa_indices_native(
+            topk_indices,
+            query_start_loc,
+            seq_lens,
+            gather_lens,
+            window_size,
+            compress_ratio,
+            topk,
+            M,
+            N,
+        )
+    num_tokens = topk_indices.shape[0]
+    num_reqs = seq_lens.shape[0]
+""",
+    ),
+    (
+        """def _musa_compute_global_topk_indices_and_lens_fallback(
+    topk_indices: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    is_valid_token: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens = topk_indices.shape[0]
+    global_topk_indices = torch.full_like(topk_indices, -1)
+    topk_lens = torch.empty(num_tokens, dtype=torch.int32, device=topk_indices.device)
+    for token_idx in range(num_tokens):
+        local_indices = topk_indices[token_idx].to(torch.long)
+        valid = local_indices >= 0
+        if bool(valid.any().item()):
+            req_idx = int(token_to_req_indices[token_idx].item())
+            selected_local = local_indices[valid]
+            block_indices = selected_local // block_size
+            block_offsets = selected_local % block_size
+            block_numbers = block_table[req_idx].index_select(0, block_indices)
+            slot_ids = block_numbers.to(torch.long) * block_size + block_offsets
+            global_topk_indices[token_idx, valid] = slot_ids.to(global_topk_indices.dtype)
+        valid_count = int(valid.sum().item())
+        topk_lens[token_idx] = (
+            valid_count if bool(is_valid_token[token_idx].item()) else 0
+        )
+    return global_topk_indices, topk_lens
+""",
+        """def _musa_compute_global_topk_indices_and_lens_fallback(
+    topk_indices: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    is_valid_token: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens = topk_indices.shape[0]
+    local_indices = topk_indices[:num_tokens].to(torch.long)
+    valid = local_indices >= 0
+    safe_local_indices = local_indices.clamp(min=0)
+    req_indices = token_to_req_indices[:num_tokens].to(torch.long).clamp(
+        0, block_table.shape[0] - 1
+    )
+    block_indices = torch.div(
+        safe_local_indices, block_size, rounding_mode="floor"
+    ).clamp(0, block_table.shape[1] - 1)
+    block_offsets = safe_local_indices.remainder(block_size)
+    block_numbers = block_table[
+        req_indices.unsqueeze(-1),
+        block_indices,
+    ].to(torch.long)
+    slot_ids = block_numbers * block_size + block_offsets
+    global_topk_indices = torch.where(
+        valid,
+        slot_ids.to(topk_indices.dtype),
+        torch.full_like(topk_indices[:num_tokens], -1),
+    )
+    valid_counts = valid.sum(dim=-1).to(torch.int32)
+    topk_lens = torch.where(
+        is_valid_token[:num_tokens].to(torch.bool),
+        valid_counts,
+        torch.zeros_like(valid_counts),
+    )
+    return global_topk_indices, topk_lens
+""",
+    ),
+]
+
+RELOAD_AFTER_PATCH = [
+    "__TARGET_MODULE__",
+    "vllm.v1.attention.ops.deepseek_v4_ops",
+]

--- a/vllm_musa/patches/vllm__v1__attention__ops__deepseek_v4_ops__fused_compress_quant_cache.patch.py
+++ b/vllm_musa/patches/vllm__v1__attention__ops__deepseek_v4_ops__fused_compress_quant_cache.patch.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch DeepSeek-V4 fused compressor Triton kernels for MUSA Triton syntax.
+"""
+
+PATCHES = [
+    (
+        """    score = tl.softmax(score, dim=0)
+""",
+        """    # MUSA Triton does not accept the upstream tl.softmax(dim=0) kwarg.
+    score_max = tl.max(score, axis=0)
+    score_max = tl.where(mask, score_max, 0.0)
+    score_exp = tl.exp(score - score_max)
+    score_exp = tl.where(mask[None, :], score_exp, 0.0)
+    score_denom = tl.sum(score_exp, axis=0)
+    score_denom = tl.where(score_denom > 0.0, score_denom, 1.0)
+    score = score_exp / score_denom
+""",
+    ),
+]
+
+RELOAD_AFTER_PATCH = True

--- a/vllm_musa/patches/vllm__v1__attention__ops__deepseek_v4_ops__fused_indexer_q.patch.py
+++ b/vllm_musa/patches/vllm__v1__attention__ops__deepseek_v4_ops__fused_indexer_q.patch.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch DeepSeek-V4 sparse-indexer Q quantization with a MUSA-specific gate.
+"""
+
+PATCHES = [
+    (
+        """import torch
+
+from vllm.triton_utils import tl, triton
+""",
+        """import os
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+""",
+    ),
+    (
+        """MXFP4_BLOCK_SIZE = 32
+""",
+        """MXFP4_BLOCK_SIZE = 32
+
+logger = init_logger(__name__)
+
+
+def _musa_is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or tensor.device.type == "musa"
+    )
+
+
+def _musa_fused_indexer_q_triton_enabled() -> bool:
+    return os.getenv("VLLM_MUSA_DEEPSEEK_V4_INDEXER_Q_TRITON", "1") == "1"
+
+
+def _musa_apply_indexer_gptj_rope(
+    index_q: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+) -> torch.Tensor:
+    out = index_q.to(torch.float32).clone()
+    head_dim = out.shape[-1]
+    rope_dim = cos_sin_cache.shape[-1]
+    half_rope_dim = rope_dim // 2
+    nope_dim = head_dim - rope_dim
+    cos_sin = cos_sin_cache.index_select(0, positions.to(torch.long)).to(
+        torch.float32
+    )
+    cos, sin = cos_sin.split(half_rope_dim, dim=-1)
+    cos = cos[:, None, :]
+    sin = sin[:, None, :]
+    rope = out[..., nope_dim:]
+    even = rope[..., 0::2]
+    odd = rope[..., 1::2]
+    rotated = torch.empty_like(rope)
+    rotated[..., 0::2] = (even * cos - odd * sin).to(torch.bfloat16).to(
+        torch.float32
+    )
+    rotated[..., 1::2] = (odd * cos + even * sin).to(torch.bfloat16).to(
+        torch.float32
+    )
+    out[..., nope_dim:] = rotated
+    return out
+
+
+def _musa_e2m1_nibble(x: torch.Tensor) -> torch.Tensor:
+    abs_x = torch.minimum(
+        x.abs(), torch.full((), 6.0, dtype=torch.float32, device=x.device)
+    )
+    code = torch.where(
+        abs_x <= 0.25,
+        0,
+        torch.where(
+            abs_x <= 0.75,
+            1,
+            torch.where(
+                abs_x <= 1.25,
+                2,
+                torch.where(
+                    abs_x <= 1.75,
+                    3,
+                    torch.where(
+                        abs_x <= 2.5,
+                        4,
+                        torch.where(abs_x <= 3.5, 5, torch.where(abs_x <= 5.0, 6, 7)),
+                    ),
+                ),
+            ),
+        ),
+    ).to(torch.uint8)
+    sign = ((x < 0) & (code != 0)).to(torch.uint8)
+    return code | (sign << 3)
+
+
+def _musa_quantize_mxfp4_pair(
+    even: torch.Tensor,
+    odd: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    amax = torch.maximum(even.abs().amax(dim=-1), odd.abs().amax(dim=-1))
+    amax = torch.maximum(
+        amax, torch.full_like(amax, 1.0e-4, dtype=torch.float32)
+    )
+    exponent = torch.ceil(torch.log2(amax / 6.0)).clamp(-127.0, 127.0)
+    inv_scale = torch.exp2(-exponent).unsqueeze(-1)
+    lo = _musa_e2m1_nibble(even * inv_scale)
+    hi = _musa_e2m1_nibble(odd * inv_scale)
+    return lo | (hi << 4), (exponent + 127.0).to(torch.uint8)
+
+
+def _musa_fused_indexer_q_rope_quant_fallback(
+    positions: torch.Tensor,
+    index_q: torch.Tensor,
+    index_q_cos_sin_cache: torch.Tensor,
+    index_weights: torch.Tensor,
+    index_weights_softmax_scale: float,
+    index_weights_head_scale: float,
+    use_fp4: bool,
+) -> tuple[
+    torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    torch.Tensor,
+]:
+    if (
+        positions.ndim != 1
+        or index_q.ndim != 3
+        or index_q_cos_sin_cache.ndim != 2
+    ):
+        raise AssertionError("unexpected DeepSeek-V4 indexer Q fallback shape")
+    q_rope = _musa_apply_indexer_gptj_rope(
+        index_q, positions, index_q_cos_sin_cache
+    )
+    weights_out = index_weights.to(torch.float32).clone()
+    weights_out *= index_weights_softmax_scale
+    weights_out *= index_weights_head_scale
+
+    if use_fp4:
+        head_dim = index_q.shape[-1]
+        assert head_dim % MXFP4_BLOCK_SIZE == 0
+        q_blocks = q_rope.reshape(
+            *q_rope.shape[:-1], head_dim // MXFP4_BLOCK_SIZE, MXFP4_BLOCK_SIZE
+        )
+        even = q_blocks[..., 0::2]
+        odd = q_blocks[..., 1::2]
+        packed, ue8m0 = _musa_quantize_mxfp4_pair(even, odd)
+        packed = packed.reshape(*q_rope.shape[:-1], head_dim // 2).contiguous()
+        return (
+            packed,
+            ue8m0.contiguous().view(torch.int32).squeeze(-1),
+        ), weights_out
+
+    amax = q_rope.abs().amax(dim=-1)
+    amax = torch.maximum(
+        amax, torch.full_like(amax, 1.0e-4, dtype=torch.float32)
+    )
+    q_scale = torch.exp2(torch.ceil(torch.log2(amax / 448.0)))
+    q_fp8 = (q_rope / q_scale.unsqueeze(-1)).clamp(-448.0, 448.0).to(
+        torch.float8_e4m3fn
+    )
+    weights_out *= q_scale
+    return q_fp8, weights_out
+""",
+    ),
+    (
+        """    assert positions.ndim == 1
+    assert index_q.ndim == 3
+""",
+        """    if _musa_is_musa_tensor(index_q):
+        if _musa_fused_indexer_q_triton_enabled():
+            logger.warning_once(
+                "Using MUSA Triton DeepSeek-V4 "
+                "fused_indexer_q_rope_quant path."
+            )
+        elif (
+            os.getenv(
+                "VLLM_MUSA_ENABLE_TORCH_FUSED_INDEXER_Q_ROPE_QUANT_FALLBACK",
+                "0",
+            )
+            == "1"
+        ):
+            logger.warning_once(
+                "Using opt-in MUSA torch DeepSeek-V4 indexer Q RoPE/quant "
+                "fallback. This emulates fused_indexer_q_rope_quant in torch; "
+                "it is a correctness fallback, not a production backend."
+            )
+            return _musa_fused_indexer_q_rope_quant_fallback(
+                positions,
+                index_q,
+                index_q_cos_sin_cache,
+                index_weights,
+                index_weights_softmax_scale,
+                index_weights_head_scale,
+                use_fp4,
+            )
+        else:
+            raise NotImplementedError(
+                "DeepSeek-V4 fused_indexer_q_rope_quant is not implemented for "
+                "MUSA yet. A MUSA-safe sparse indexer Q RoPE/FP8-or-MXFP4 "
+                "quantization path is required before model execution can proceed."
+            )
+    assert positions.ndim == 1
+    assert index_q.ndim == 3
+""",
+    ),
+    (
+        """    if _musa_is_musa_tensor(index_q):
+        if (
+            os.getenv(
+                "VLLM_MUSA_ENABLE_TORCH_FUSED_INDEXER_Q_ROPE_QUANT_FALLBACK",
+                "0",
+            )
+            == "1"
+        ):
+            logger.warning_once(
+                "Using opt-in MUSA torch DeepSeek-V4 indexer Q RoPE/quant "
+                "fallback. This emulates fused_indexer_q_rope_quant in torch; "
+                "it is a correctness fallback, not a production backend."
+            )
+            return _musa_fused_indexer_q_rope_quant_fallback(
+                positions,
+                index_q,
+                index_q_cos_sin_cache,
+                index_weights,
+                index_weights_softmax_scale,
+                index_weights_head_scale,
+                use_fp4,
+            )
+        raise NotImplementedError(
+            "DeepSeek-V4 fused_indexer_q_rope_quant is not implemented for "
+            "MUSA yet. A MUSA-safe sparse indexer Q RoPE/FP8-or-MXFP4 "
+            "quantization path is required before model execution can proceed."
+        )
+    assert positions.ndim == 1
+    assert index_q.ndim == 3
+""",
+        """    if _musa_is_musa_tensor(index_q):
+        if _musa_fused_indexer_q_triton_enabled():
+            logger.warning_once(
+                "Using MUSA Triton DeepSeek-V4 "
+                "fused_indexer_q_rope_quant path."
+            )
+        elif (
+            os.getenv(
+                "VLLM_MUSA_ENABLE_TORCH_FUSED_INDEXER_Q_ROPE_QUANT_FALLBACK",
+                "0",
+            )
+            == "1"
+        ):
+            logger.warning_once(
+                "Using opt-in MUSA torch DeepSeek-V4 indexer Q RoPE/quant "
+                "fallback. This emulates fused_indexer_q_rope_quant in torch; "
+                "it is a correctness fallback, not a production backend."
+            )
+            return _musa_fused_indexer_q_rope_quant_fallback(
+                positions,
+                index_q,
+                index_q_cos_sin_cache,
+                index_weights,
+                index_weights_softmax_scale,
+                index_weights_head_scale,
+                use_fp4,
+            )
+        else:
+            raise NotImplementedError(
+                "DeepSeek-V4 fused_indexer_q_rope_quant is not implemented for "
+                "MUSA yet. A MUSA-safe sparse indexer Q RoPE/FP8-or-MXFP4 "
+                "quantization path is required before model execution can proceed."
+            )
+    assert positions.ndim == 1
+    assert index_q.ndim == 3
+""",
+    ),
+]
+
+RELOAD_AFTER_PATCH = [
+    "__TARGET_MODULE__",
+    "vllm.v1.attention.ops.deepseek_v4_ops",
+]

--- a/vllm_musa/patches/vllm__v1__attention__ops__deepseek_v4_ops__fused_inv_rope_fp8_quant.patch.py
+++ b/vllm_musa/patches/vllm__v1__attention__ops__deepseek_v4_ops__fused_inv_rope_fp8_quant.patch.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch DeepSeek-V4 inverse-RoPE FP8 quantization with a MUSA correctness fallback.
+"""
+
+PATCHES = [
+    (
+        """        logger.warning_once(
+            "Using opt-in MUSA Triton DeepSeek-V4 "
+            "fused_inv_rope_fp8_quant path."
+        )
+""",
+        """        # Do not log from the forward path: TorchDynamo treats logger
+        # calls inside compiled DeepSeek-V4 decode as graph breaks.
+        pass
+""",
+    ),
+    (
+        """        # Do not log from the forward path: TorchDynamo treats logger
+        # calls inside compiled DeepSeek-V4 decode as graph breaks.
+""",
+        """        # Do not log from the forward path: TorchDynamo treats logger
+        # calls inside compiled DeepSeek-V4 decode as graph breaks.
+        pass
+""",
+    ),
+    (
+        """        logger.warning_once(
+            "Using opt-in MUSA torch fused_inv_rope_fp8_quant fallback. "
+            "This is a correctness fallback and not a production replacement "
+            "for the native fused inverse-RoPE FP8 quant kernel."
+        )
+""",
+        """        # Avoid logger calls here because this function runs under
+        # TorchDynamo.
+""",
+    ),
+    (
+        """    if current_platform.is_musa() or o.device.type == "musa":
+        raise NotImplementedError(
+            "DeepSeek-V4 fused_inv_rope_fp8_quant is not implemented for "
+            "MUSA yet. A MUSA-safe inverse-RoPE, FP8 quantization, and "
+            "scale-layout path is required before model execution can proceed."
+        )
+""",
+        "",
+    ),
+    (
+        """    if (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or o.device.type == "musa"
+    ):
+        raise NotImplementedError(
+            "DeepSeek-V4 fused_inv_rope_fp8_quant is not implemented for "
+            "MUSA yet. A MUSA-safe inverse-RoPE, FP8 quantization, and "
+            "scale-layout path is required before model execution can proceed."
+        )
+""",
+        "",
+    ),
+    (
+        """import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+""",
+        """import os
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
+""",
+    ),
+    (
+        """import torch
+
+from vllm.triton_utils import tl, triton
+""",
+        """import os
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
+""",
+    ),
+    (
+        """logger = init_logger(__name__)
+""",
+        """logger = init_logger(__name__)
+
+
+def _musa_fused_inv_rope_fp8_quant_triton_enabled() -> bool:
+    return os.getenv("VLLM_MUSA_DEEPSEEK_V4_INV_ROPE_TRITON", "0") == "1"
+""",
+    ),
+    (
+        """    from vllm.utils.deep_gemm import get_tma_aligned_size
+
+    num_tokens, num_heads, head_dim = o.shape
+""",
+        """    _musa_is_inv_rope_fp8_quant_tensor = (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or o.device.type == "musa"
+    )
+    if (
+        _musa_is_inv_rope_fp8_quant_tensor
+        and _musa_fused_inv_rope_fp8_quant_triton_enabled()
+    ):
+        logger.warning_once(
+            "Using opt-in MUSA Triton DeepSeek-V4 "
+            "fused_inv_rope_fp8_quant path."
+        )
+    if (
+        _musa_is_inv_rope_fp8_quant_tensor
+        and not _musa_fused_inv_rope_fp8_quant_triton_enabled()
+    ):
+        if (
+            os.getenv(
+                "VLLM_MUSA_ENABLE_TORCH_FUSED_INV_ROPE_FP8_QUANT_FALLBACK",
+                "0",
+            )
+            != "1"
+        ):
+            from vllm_musa import _custom_ops as _musa_custom_ops
+
+            return _musa_custom_ops.deepseek_v4_fused_inv_rope_fp8_quant(
+                o,
+                positions,
+                cos_sin_cache,
+                n_groups,
+                heads_per_group,
+                nope_dim,
+                rope_dim,
+                quant_group_size,
+                tma_aligned_scales,
+            )
+        from vllm.utils.deep_gemm import get_tma_aligned_size
+
+        num_tokens, num_heads, head_dim = o.shape
+        assert num_heads == n_groups * heads_per_group
+        assert head_dim == nope_dim + rope_dim
+        assert head_dim % quant_group_size == 0
+        assert nope_dim % quant_group_size == (quant_group_size - rope_dim)
+        assert rope_dim % 2 == 0
+        assert cos_sin_cache.shape[-1] == rope_dim
+        assert cos_sin_cache.dtype == torch.float32
+
+        d = heads_per_group * head_dim
+        num_scale_blocks = d // quant_group_size
+        chunks_per_head = head_dim // quant_group_size
+        fp8_dtype = torch.float8_e4m3fn
+        fp8_max = torch.finfo(fp8_dtype).max
+
+        x = o.to(torch.float32)
+        rope_abs_start = (chunks_per_head - 1) * quant_group_size + (
+            nope_dim % quant_group_size
+        )
+        rope = x[..., rope_abs_start : rope_abs_start + rope_dim]
+        cos_sin = cos_sin_cache.index_select(0, positions.to(torch.long)).to(
+            torch.float32
+        )
+        cos, sin = cos_sin.split(rope_dim // 2, dim=-1)
+        cos = cos.unsqueeze(1)
+        sin = sin.unsqueeze(1)
+        even = rope[..., 0::2]
+        odd = rope[..., 1::2]
+        rotated = torch.empty_like(rope)
+        rotated[..., 0::2] = even * cos + odd * sin
+        rotated[..., 1::2] = odd * cos - even * sin
+        x = x.clone()
+        x[..., rope_abs_start : rope_abs_start + rope_dim] = rotated
+
+        x = (
+            x.reshape(num_tokens, n_groups, heads_per_group, head_dim)
+            .permute(1, 0, 2, 3)
+            .reshape(n_groups, num_tokens, d)
+        )
+        blocks = x.reshape(n_groups, num_tokens, num_scale_blocks, quant_group_size)
+        scales = torch.exp2(
+            torch.ceil(
+                torch.log2(
+                    torch.clamp(
+                        blocks.abs().amax(dim=-1) / fp8_max,
+                        min=1e-10,
+                    )
+                )
+            )
+        )
+        fp8_buf = (blocks / scales.unsqueeze(-1)).clamp(
+            -fp8_max, fp8_max
+        ).to(fp8_dtype).reshape(n_groups, num_tokens, d)
+
+        tma_aligned_T = get_tma_aligned_size(num_tokens, 4)
+        if tma_aligned_scales:
+            packed_sf_k = (num_scale_blocks + 3) // 4
+            scale_buf = torch.empty(
+                n_groups * packed_sf_k * tma_aligned_T,
+                dtype=torch.int32,
+                device=o.device,
+            ).as_strided(
+                (n_groups, num_tokens, packed_sf_k),
+                (packed_sf_k * tma_aligned_T, 1, tma_aligned_T),
+            )
+            scale_bytes = (
+                torch.log2(scales)
+                .round()
+                .to(torch.int32)
+                .add_(127)
+                .clamp_(0, 255)
+            )
+            scale_bytes = scale_bytes.reshape(
+                n_groups, num_tokens, heads_per_group, chunks_per_head
+            )
+            shifts = (
+                torch.arange(chunks_per_head, device=o.device, dtype=torch.int32)
+                * 8
+            )
+            packed = torch.sum(scale_bytes << shifts, dim=-1)
+            scale_buf.copy_(packed)
+        else:
+            scale_buf = torch.empty(
+                n_groups * num_scale_blocks * tma_aligned_T,
+                dtype=torch.float32,
+                device=o.device,
+            ).as_strided(
+                (n_groups, num_tokens, num_scale_blocks),
+                (num_scale_blocks * tma_aligned_T, 1, tma_aligned_T),
+            )
+            scale_buf.copy_(scales)
+
+        return fp8_buf.transpose(0, 1), scale_buf.transpose(0, 1)
+    from vllm.utils.deep_gemm import get_tma_aligned_size
+
+    # Shape setup for the native Triton path.
+    num_tokens, num_heads, head_dim = o.shape
+""",
+    ),
+    (
+        """    grid = (tma_aligned_T, n_groups * heads_per_group)
+    _fused_inv_rope_fp8_quant_per_head[grid](
+""",
+        """    if (
+        _musa_is_inv_rope_fp8_quant_tensor
+        and _musa_fused_inv_rope_fp8_quant_triton_enabled()
+    ):
+        common_args.pop("launch_pdl", None)
+
+    grid = (tma_aligned_T, n_groups * heads_per_group)
+    _fused_inv_rope_fp8_quant_per_head[grid](
+""",
+    ),
+]
+
+
+def normalize_source(source: str) -> str:
+    """Upgrade stale patched sources from the old Torch-only MUSA fallback."""
+    stale_raise = """            raise NotImplementedError(
+                "DeepSeek-V4 fused_inv_rope_fp8_quant is not implemented for "
+                "MUSA yet. A MUSA-safe inverse-RoPE, FP8 quantization, and "
+                "scale-layout path is required before model execution can proceed."
+            )
+"""
+    native_return = """            from vllm_musa import _custom_ops as _musa_custom_ops
+
+            return _musa_custom_ops.deepseek_v4_fused_inv_rope_fp8_quant(
+                o,
+                positions,
+                cos_sin_cache,
+                n_groups,
+                heads_per_group,
+                nope_dim,
+                rope_dim,
+                quant_group_size,
+                tma_aligned_scales,
+            )
+"""
+    return source.replace(stale_raise, native_return)
+
+
+RELOAD_AFTER_PATCH = [
+    "__TARGET_MODULE__",
+    "vllm.v1.attention.ops.deepseek_v4_ops",
+]

--- a/vllm_musa/patches/vllm__v1__attention__ops__deepseek_v4_ops__fused_qk_rmsnorm.patch.py
+++ b/vllm_musa/patches/vllm__v1__attention__ops__deepseek_v4_ops__fused_qk_rmsnorm.patch.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch DeepSeek-V4 fused Q/K RMSNorm with a native MUSA implementation.
+"""
+
+_HELPERS = """import os
+
+from vllm.platforms import current_platform
+# MUSA fallback helpers below use current_platform.
+from vllm.triton_utils import tl, triton
+
+
+def _is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or tensor.device.type == "musa"
+    )
+
+
+def _musa_rmsnorm_fallback(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    x_float = x.to(torch.float32)
+    variance = x_float.pow(2).mean(dim=-1, keepdim=True)
+    out = x_float * torch.rsqrt(variance + eps)
+    out = out * weight.to(torch.float32)
+    return out.to(x.dtype)
+
+
+def _musa_qkv_rmsnorm_fallback_enabled() -> bool:
+    return os.getenv("VLLM_MUSA_DEEPSEEK_V4_QKV_RMSNORM_FALLBACK", "0") == "1"
+
+
+def _musa_fused_q_kv_rmsnorm(
+    qr: torch.Tensor,
+    kv: torch.Tensor,
+    q_weight: torch.Tensor,
+    kv_weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from vllm_musa import _custom_ops as _musa_custom_ops
+
+    return _musa_custom_ops.deepseek_v4_fused_q_kv_rmsnorm(
+        qr,
+        kv,
+        q_weight,
+        kv_weight,
+        eps,
+    )
+"""
+
+_FALLBACK_RETURN = """    if _is_musa_tensor(qr) or _is_musa_tensor(kv):
+        if not _musa_qkv_rmsnorm_fallback_enabled():
+            return _musa_fused_q_kv_rmsnorm(qr, kv, q_weight, kv_weight, eps)
+        return (
+            _musa_rmsnorm_fallback(qr, q_weight, eps),
+            _musa_rmsnorm_fallback(kv, kv_weight, eps),
+        )
+"""
+
+_OLD_FALLBACK_RETURN = """    if _is_musa_tensor(qr) or _is_musa_tensor(kv):
+        return (
+            _musa_rmsnorm_fallback(qr, q_weight, eps),
+            _musa_rmsnorm_fallback(kv, kv_weight, eps),
+        )
+"""
+
+_OLD_HELPERS = """from vllm.platforms import current_platform
+# MUSA fallback helpers below use current_platform.
+from vllm.triton_utils import tl, triton
+
+
+def _is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or tensor.device.type == "musa"
+    )
+
+
+def _musa_rmsnorm_fallback(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    x_float = x.to(torch.float32)
+    variance = x_float.pow(2).mean(dim=-1, keepdim=True)
+    out = x_float * torch.rsqrt(variance + eps)
+    out = out * weight.to(torch.float32)
+    return out.to(x.dtype)
+"""
+
+PATCHES = [
+    (
+        _OLD_HELPERS,
+        _HELPERS,
+    ),
+    (
+        _OLD_FALLBACK_RETURN,
+        _FALLBACK_RETURN,
+    ),
+    (
+        """import torch
+
+from vllm.triton_utils import tl, triton
+""",
+        f"""import torch
+
+{_HELPERS}""",
+    ),
+    (
+        """from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+""",
+        _HELPERS,
+    ),
+    (
+        """    if current_platform.is_musa() or qr.device.type == "musa":
+        raise NotImplementedError(
+            "DeepSeek-V4 fused_q_kv_rmsnorm is not implemented for MUSA yet. "
+            "A MUSA-safe Q/K RMSNorm implementation is required before model "
+            "execution can proceed."
+        )
+""",
+        _FALLBACK_RETURN,
+    ),
+    (
+        """    if (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or qr.device.type == "musa"
+    ):
+        raise NotImplementedError(
+            "DeepSeek-V4 fused_q_kv_rmsnorm is not implemented for MUSA yet. "
+            "A MUSA-safe Q/K RMSNorm implementation is required before model "
+            "execution can proceed."
+        )
+""",
+        _FALLBACK_RETURN,
+    ),
+    (
+        """    assert qr.ndim == 2 and kv.ndim == 2
+    assert qr.shape[0] == kv.shape[0], (
+""",
+        f"""{_FALLBACK_RETURN}    assert qr.ndim == 2 and kv.ndim == 2, "qr and kv must be 2D"
+    assert qr.shape[0] == kv.shape[0], (
+""",
+    ),
+]
+
+RELOAD_AFTER_PATCH = [
+    "__TARGET_MODULE__",
+    "vllm.v1.attention.ops.deepseek_v4_ops",
+]

--- a/vllm_musa/patches/vllm__v1__sample__rejection_sampler.patch.py
+++ b/vllm_musa/patches/vllm__v1__sample__rejection_sampler.patch.py
@@ -37,6 +37,111 @@ scope at the `rejection_sample()` insertion point.
 """
 
 PATCHES = [
+    (
+        """def rejection_sample(
+""",
+        """def _musa_spec_decode_random_fallback_enabled() -> bool:
+    value = __import__("os").environ.get(
+        "VLLM_MUSA_SPEC_DECODE_RANDOM_FALLBACK",
+        "1",
+    )
+    if value.lower() in ("0", "false", "no", "off"):
+        return False
+    try:
+        from vllm.platforms import current_platform
+
+        return current_platform.is_musa()
+    except Exception:
+        return False
+
+
+def _musa_sample_first_target_token(
+    sampler: Sampler,
+    target_logits: torch.Tensor,
+    metadata: SpecDecodeMetadata,
+    sampling_metadata: SamplingMetadata,
+) -> torch.Tensor | None:
+    # MUSA random rejection sampling is not correctness-stable yet. Preserve
+    # the distribution by sampling only the first target-token logits and
+    # returning placeholders for all speculative positions, effectively
+    # disabling speculative acceptance for non-greedy requests.
+    if any(num_tokens <= 0 for num_tokens in metadata.num_draft_tokens):
+        return None
+
+    starts: list[int] = []
+    offset = 0
+    for num_tokens in metadata.num_draft_tokens:
+        starts.append(offset)
+        offset += num_tokens
+
+    start_indices = torch.tensor(
+        starts,
+        dtype=torch.long,
+        device=target_logits.device,
+    )
+    first_target_logits = target_logits.index_select(0, start_indices)
+    sampled, _ = sampler.sample(first_target_logits, sampling_metadata)
+
+    output_token_ids = torch.full(
+        (len(metadata.num_draft_tokens), metadata.max_spec_len + 1),
+        PLACEHOLDER_TOKEN_ID,
+        dtype=torch.int32,
+        device=target_logits.device,
+    )
+    output_token_ids[:, 0] = sampled.to(torch.int32)
+    return output_token_ids
+
+
+def rejection_sample(
+""",
+    ),
+    (
+        """        target_logits = self.apply_logits_processors(
+            target_logits, sampling_metadata, metadata
+        )
+        # [num_tokens, vocab_size]
+        # NOTE(woosuk): `target_logits` can be updated in place inside the
+        # `apply_sampling_constraints` function.
+        target_logits = apply_sampling_constraints(
+            target_logits,
+            metadata.cu_num_draft_tokens,
+            sampling_metadata,
+        )
+
+        output_token_ids = rejection_sample(
+""",
+        """        target_logits = self.apply_logits_processors(
+            target_logits, sampling_metadata, metadata
+        )
+        if (
+            not sampling_metadata.all_greedy
+            and sampling_metadata.max_num_logprobs is None
+            and _musa_spec_decode_random_fallback_enabled()
+        ):
+            output_token_ids = _musa_sample_first_target_token(
+                self.sampler,
+                target_logits,
+                metadata,
+                sampling_metadata,
+            )
+            if output_token_ids is not None:
+                return SamplerOutput(
+                    sampled_token_ids=output_token_ids,
+                    logprobs_tensors=None,
+                )
+
+        # [num_tokens, vocab_size]
+        # NOTE(woosuk): `target_logits` can be updated in place inside the
+        # `apply_sampling_constraints` function.
+        target_logits = apply_sampling_constraints(
+            target_logits,
+            metadata.cu_num_draft_tokens,
+            sampling_metadata,
+        )
+
+        output_token_ids = rejection_sample(
+""",
+    ),
     # 1 + dummy: call site -- is_greedy as int32 + synthetic dummy tensor.
     (
         """    if sampling_metadata.all_greedy:

--- a/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
@@ -2,33 +2,24 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """MUSA spec-decode kernel monkey-patch shim.
 
-Loaded by ``vllm_musa.patches`` as ``vllm.v1.spec_decode.eagle`` — the
-filename's underscore-encoded module path is the patch system's lookup
-key.
+Loaded by ``vllm_musa.patches`` as ``vllm.v1.spec_decode.eagle``; the
+filename's underscore-encoded module path is the patch system's lookup key.
 
-This file used to install ``EagleFullLoopRunner`` — a 912-line MUSA-only
-custom runner that captured the full N-step Eagle3 draft loop as ONE
-giant CUDAGraph. On yeahdongcn70 (mcc 5.1.0) the giant-chain capture
-corrupted the draft model's MCCL barrier state at replay (accept rate
-collapsed to 3.5% with positions 1-4 at 0%, GPU 4+6 firmware reboots
-when override removed). See ticket MUSA-0203 for the full bisect.
-
-The runner was deleted in favor of the upstream pattern from
-https://github.com/vllm-project/vllm/pull/34880 — wrap the draft model
-with the standard ``CUDAGraphWrapper`` + per-step ``CudagraphDispatcher``
-keyed by ``BatchDescriptor`` (one captured graph per step, dispatched
-fresh per call, structurally identical to the target's PIECEWISE
-captures that already work on MUSA).
+This file used to install ``EagleFullLoopRunner``, a MUSA-only custom runner
+that captured the full N-step Eagle3 draft loop as one CUDAGraph. That runner
+was deleted in favor of the upstream pattern from vllm-project/vllm#34880:
+wrap the draft model with the standard ``CUDAGraphWrapper`` plus per-step
+``CudagraphDispatcher``.
 
 This file is now the minimal shim that ensures the MUSA-Triton-adapted
-``eagle_prepare_next_token_padded_kernel`` (in ``vllm_musa/v1/spec_decode/utils.py``)
-is imported BEFORE upstream's ``vllm.v1.spec_decode.llm_base_proposer``
-binds its own copy of the (broken-on-MUSA) kernel. Without this prime
-the proposer's Triton compile fails with ``mismatched type for
-valid_count``.
+``eagle_prepare_next_token_padded_kernel`` from
+``vllm_musa.v1.spec_decode.utils`` is imported before upstream
+``vllm.v1.spec_decode.llm_base_proposer`` binds its own copy of the kernel.
+Without this prime the proposer's Triton compile fails with
+``mismatched type for valid_count``.
 """
 
-PATCHES: list = []  # No file mutation; the monkey-patch install is the side effect.
+PATCHES: list = []
 
 # CRITICAL ORDER: prime the MUSA-Triton-adapted kernel before upstream binds it.
 import vllm_musa.v1.spec_decode.utils  # noqa: F401

--- a/vllm_musa/patches/vllm__v1__spec_decode__llm_base_proposer.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__llm_base_proposer.patch.py
@@ -34,6 +34,36 @@ When upstream PR #34880 merges (or v0.20.0-dev rebases onto it), this
 patch's anchors will stop matching and the file should be deleted.
 """
 
+
+def normalize_source(source: str) -> str:
+    """Upgrade already-persisted MUSA draft FULL-wrapper patched sources."""
+    return source.replace(
+        """        # Gated by VLLM_MUSA_DRAFT_FULL_WRAP (default ON since the
+        # query_start_loc in-place hunk fixed the captured-replay stale
+        # data_ptr issue). Set to "0" to disable for debugging.
+        import os as _os
+        cudagraph_mode = self.compilation_config.cudagraph_mode
+        if (
+            _os.environ.get("VLLM_MUSA_DRAFT_FULL_WRAP", "1") == "1"
+            and cudagraph_mode.has_full_cudagraphs()
+""",
+        """        # Gated by VLLM_MUSA_DRAFT_FULL_WRAP. Default OFF on MUSA after the
+        # v0.20.0-dev rebase because the wrapped DeepSeek-V4 MTP draft model
+        # can fail graph memory profiling; set to "1" to re-enable for
+        # diagnostics after the draft FULL graph path is fixed.
+        import os as _os
+        cudagraph_mode = self.compilation_config.cudagraph_mode
+        draft_full_wrap_default = "0" if current_platform.is_musa() else "1"
+        if (
+            _os.environ.get(
+                "VLLM_MUSA_DRAFT_FULL_WRAP", draft_full_wrap_default
+            )
+            == "1"
+            and cudagraph_mode.has_full_cudagraphs()
+""",
+    )
+
+
 # ---- Hunk 1: import CUDAGraphWrapper + BatchDescriptor ----
 _OLD_IMPORTS = """from vllm.distributed.parallel_state import get_pp_group
 from vllm.forward_context import set_forward_context"""
@@ -43,7 +73,9 @@ from vllm.distributed.parallel_state import get_pp_group
 from vllm.forward_context import BatchDescriptor, set_forward_context"""
 
 # ---- Hunk 2: dispatcher init — for_draft_model=True ----
-_OLD_DISPATCHER_INIT = """        self.cudagraph_dispatcher = CudagraphDispatcher(self.vllm_config)"""
+_OLD_DISPATCHER_INIT = (
+    """        self.cudagraph_dispatcher = CudagraphDispatcher(self.vllm_config)"""
+)
 
 _NEW_DISPATCHER_INIT = """        # MUSA-0203 / PR #34880: dedicated dispatcher for the draft model so
         # FULL-mode capture keys are registered with uniform_decode_query_len=1
@@ -102,13 +134,18 @@ _NEW_LOAD_MODEL = """self.model = self._get_model()
         # CUDAGraphWrapper when target uses FULL captures. CUDAGraphWrapper
         # is a no-op when the runtime mode at call time doesn't match FULL,
         # so this is safe when target is PIECEWISE-only.
-        # Gated by VLLM_MUSA_DRAFT_FULL_WRAP (default ON since the
-        # query_start_loc in-place hunk fixed the captured-replay stale
-        # data_ptr issue). Set to "0" to disable for debugging.
+        # Gated by VLLM_MUSA_DRAFT_FULL_WRAP. Default OFF on MUSA after the
+        # v0.20.0-dev rebase because the wrapped DeepSeek-V4 MTP draft model
+        # can fail graph memory profiling; set to "1" to re-enable for
+        # diagnostics after the draft FULL graph path is fixed.
         import os as _os
         cudagraph_mode = self.compilation_config.cudagraph_mode
+        draft_full_wrap_default = "0" if current_platform.is_musa() else "1"
         if (
-            _os.environ.get("VLLM_MUSA_DRAFT_FULL_WRAP", "1") == "1"
+            _os.environ.get(
+                "VLLM_MUSA_DRAFT_FULL_WRAP", draft_full_wrap_default
+            )
+            == "1"
             and cudagraph_mode.has_full_cudagraphs()
             and not self.vllm_config.parallel_config.use_ubatching
             and not self.speculative_config.disable_padded_drafter_batch
@@ -144,7 +181,9 @@ _NEW_DETERMINE = """    def _determine_batch_execution_and_padding(
 
 # Need to also patch the return statement of _determine_batch_execution_and_padding
 # to 4-tuple. Find the unique anchor.
-_OLD_DETERMINE_RETURN = """        return cudagraph_mode, num_tokens_padded, num_tokens_across_dp"""
+_OLD_DETERMINE_RETURN = (
+    """        return cudagraph_mode, num_tokens_padded, num_tokens_across_dp"""
+)
 
 _NEW_DETERMINE_RETURN = """        return cudagraph_mode, batch_desc, num_tokens_padded, num_tokens_across_dp"""
 

--- a/vllm_musa/patches/vllm__v1__worker__gpu_model_runner.patch.py
+++ b/vllm_musa/patches/vllm__v1__worker__gpu_model_runner.patch.py
@@ -1,35 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""MUSA-0203: backport of vllm-project/vllm#34880 — gpu_model_runner.py.
+"""MUSA DeepSeek/MTP source patches for gpu_model_runner.py.
 
-Wires the caller-side path that makes the draft model's CUDAGraphWrapper(FULL)
-actually capture entries during boot (instead of failing at request time with
-``validate_cudagraph_capturing_enabled``).
+The base patch is MUSA-0203, a backport of vllm-project/vllm#34880 that makes
+the draft model's CUDAGraphWrapper(FULL) capture entries during boot.
 
-Three changes:
-  1. Add ``supports_sd_full_graph`` flag (True for Eagle + padded drafter).
-  2. ``_dummy_run`` captures ``spec_decode_cm`` from ``_build_attention_metadata``
-     and passes it to ``drafter.dummy_run`` as ``common_attn_metadata``.
-  3. ``_dummy_run`` extends the ``use_cudagraphs`` predicate so FULL captures
-     are enabled when ``supports_sd_full_graph``.
+MUSA-3046 is kept as an additional source patch tuple so it composes with the
+upstream MUSA-0203 backport: skip the drafter for non-greedy MUSA requests.
 
-Skipped from PR #34880 (lower-priority, not strictly required to make the
-draft FULL capture path engage on MUSA's BS=1 SOTA workload):
-  - ``ExecuteModelState.batch_desc`` stash + ``propose_draft_token_ids``
-    target_model_batch_desc threading. Our llm_base_proposer.patch.py
-    derives ``uniform_decode`` locally from common_attn_metadata.max_query_len
-    instead of taking it as an external arg.
-  - ``input_batch.num_reqs_padded`` setter at execute_model.
-  - ``_capture_cudagraphs`` clear_graphs cleanup.
-  - ``_build_attn_group_metadata`` supports_sd_full_graph short-circuit
-    (only matters for unpadded drafter batch, which we don't use).
-
-History: this filename previously held the MUSA-0109 ``VLLM_MUSA_DRAFT_COPY_DEFAULT_STREAM``
-default-stream workaround that targeted the now-deleted EagleFullLoopRunner
-(MUSA-0203 cleanup). That patch is no longer reachable.
+History: this filename previously held the MUSA-0109
+``VLLM_MUSA_DRAFT_COPY_DEFAULT_STREAM`` default-stream workaround that targeted
+the now-deleted EagleFullLoopRunner. That monkey patch is no longer reachable.
 """
 
-# ---- Hunk 1: __init__ — initialize supports_sd_full_graph = False ----
+# ---- MUSA-0203 / PR #34880: initialize supports_sd_full_graph = False ----
 _OLD_INIT_FLAG = """        self.use_aux_hidden_state_outputs = False
         # Set up speculative decoding."""
 
@@ -39,7 +23,7 @@ _NEW_INIT_FLAG = """        self.use_aux_hidden_state_outputs = False
         self.supports_sd_full_graph = False
         # Set up speculative decoding."""
 
-# ---- Hunk 2: __init__ — set the flag for Eagle proposers ----
+# ---- MUSA-0203 / PR #34880: set the flag for Eagle proposers ----
 _OLD_EAGLE_INIT = """            elif self.speculative_config.use_eagle():
                 self.drafter = EagleProposer(self.vllm_config, self.device, self)
                 if self.speculative_config.method == "eagle3":
@@ -59,23 +43,20 @@ _NEW_EAGLE_INIT = """            elif self.speculative_config.use_eagle():
                     not self.speculative_config.disable_padded_drafter_batch
                 )"""
 
-# ---- Hunk 3a: _dummy_run — declare spec_decode_cm None at function top ----
-# The assignment to spec_decode_cm happens inside an `if force_attention or
-# cudagraph_runtime_mode == CUDAGraphMode.FULL:` block. When that branch
-# doesn't fire (PIECEWISE without force_attention) the variable was never
-# assigned, but the drafter.dummy_run call always references it →
-# UnboundLocalError. Match PR #34880's declaration at the top of _dummy_run.
+# ---- MUSA-0203 / PR #34880: declare spec_decode_cm None ----
 _OLD_ATTN_DECL = """        attn_metadata: PerLayerAttnMetadata | None = None"""
 
 _NEW_ATTN_DECL = """        attn_metadata: PerLayerAttnMetadata | None = None
         spec_decode_cm: 'CommonAttentionMetadata | None' = None"""
 
-# ---- Hunk 3b: _dummy_run — capture spec_decode_cm from _build_attention_metadata ----
-_OLD_BUILD_ATTN = """                attn_metadata, _ = self._build_attention_metadata("""
+# ---- MUSA-0203 / PR #34880: capture spec_decode_cm ----
+_OLD_BUILD_ATTN = (
+    """                attn_metadata, _ = self._build_attention_metadata("""
+)
 
 _NEW_BUILD_ATTN = """                attn_metadata, spec_decode_cm = self._build_attention_metadata("""
 
-# ---- Hunk 4: _dummy_run — extend use_cudagraphs predicate ----
+# ---- MUSA-0203 / PR #34880: extend use_cudagraphs predicate ----
 _OLD_USE_CG = """                # Eagle currently only supports PIECEWISE cudagraphs.
                 # Therefore only use cudagraphs if the main model uses PIECEWISE
                 # NOTE(lucas): this is a hack, need to clean up.
@@ -107,7 +88,7 @@ _NEW_USE_CG = """                # MUSA-0203 / PR #34880: Eagle now supports FUL
                     )
                 ) and not self.speculative_config.enforce_eager"""
 
-# ---- Hunk 5: _dummy_run — pass common_attn_metadata to drafter.dummy_run ----
+# ---- MUSA-0203 / PR #34880: pass common_attn_metadata to drafter ----
 _OLD_DRAFTER_CALL = """                self.drafter.dummy_run(
                     num_tokens,
                     use_cudagraphs=use_cudagraphs,
@@ -143,6 +124,35 @@ _NEW_DFLASH_INIT = """            elif self.speculative_config.use_dflash():
                 if _dflash_os.environ.get("VLLM_MUSA_DFLASH_FULL_WRAP", "1") != "0":
                     self.supports_sd_full_graph = True"""
 
+# ---- MUSA-3046: avoid unstable random speculative MUSA drafter path ----
+_OLD_MUSA_RANDOM_DRAFTER_FITS = """            # Decide whether to run the drafter or zero out draft tokens.
+            input_fits_in_drafter = spec_decode_common_attn_metadata is not None and (
+                spec_decode_common_attn_metadata.max_seq_len + self.num_spec_tokens
+                <= self.effective_drafter_max_model_len
+            )
+"""
+
+_NEW_MUSA_RANDOM_DRAFTER_FITS = """            # Decide whether to run the drafter or zero out draft tokens.
+            input_fits_in_drafter = spec_decode_common_attn_metadata is not None and (
+                spec_decode_common_attn_metadata.max_seq_len + self.num_spec_tokens
+                <= self.effective_drafter_max_model_len
+            )
+            if (
+                current_platform.is_musa()
+                and not self.input_batch.sampling_metadata.all_greedy
+                and __import__("os").environ.get(
+                    "VLLM_MUSA_SPEC_DECODE_RANDOM_FALLBACK",
+                    "1",
+                ).lower()
+                not in ("0", "false", "no", "off")
+            ):
+                # The MUSA random rejection-sampling kernel is not
+                # correctness-stable yet. Do not run the drafter for
+                # non-greedy requests; the target model already sampled one
+                # correct token for this step.
+                input_fits_in_drafter = False
+"""
+
 PATCHES = [
     (_OLD_INIT_FLAG, _NEW_INIT_FLAG),
     (_OLD_EAGLE_INIT, _NEW_EAGLE_INIT),
@@ -151,4 +161,5 @@ PATCHES = [
     (_OLD_BUILD_ATTN, _NEW_BUILD_ATTN),
     (_OLD_USE_CG, _NEW_USE_CG),
     (_OLD_DRAFTER_CALL, _NEW_DRAFTER_CALL),
+    (_OLD_MUSA_RANDOM_DRAFTER_FITS, _NEW_MUSA_RANDOM_DRAFTER_FITS),
 ]

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -34,6 +34,34 @@ logger = init_logger(__name__)
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 _QWEN3_MOE_FP8_MAX_CUDAGRAPH_CAPTURE_SIZE = 64
+_DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV = "VLLM_MUSA_GEMV_MOE_BLOCK"
+_DEEPSEEK_V4_DEFAULT_GEMV_MOE_BLOCK = "32x8"
+_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_ENV = (
+    "VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE"
+)
+_DEEPSEEK_V4_TP8_PROFILE_ENV = "VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE"
+_DEEPSEEK_V4_TP8_BALANCED_LONG_PREFILL_PROFILE = "balanced_long_prefill"
+_DEEPSEEK_V4_TP8_AGGRESSIVE_LONG_PREFILL_PROFILE = "aggressive_long_prefill"
+_DEEPSEEK_V4_TP8_BALANCED_LONG_PREFILL_DEFAULTS = {
+    _DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV: "16x8",
+    "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X": "256",
+    _DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_ENV: "256",
+    "VLLM_MUSA_DEEPSEEK_V4_TILELANG_COMPILE_PROFILE": "dsa_full",
+    "VLLM_MUSA_DEEPSEEK_V4_TILELANG_DISABLE_HOST_ASSERTS": "1",
+    "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_TILELANG_MAX_TOKENS": "2048",
+}
+_DEEPSEEK_V4_TP8_AGGRESSIVE_LONG_PREFILL_DEFAULTS = {
+    **_DEEPSEEK_V4_TP8_BALANCED_LONG_PREFILL_DEFAULTS,
+    "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL": "deepgemm_big_fuse",
+}
+_DEEPSEEK_V4_TP8_PROFILE_DEFAULTS = {
+    _DEEPSEEK_V4_TP8_BALANCED_LONG_PREFILL_PROFILE: (
+        _DEEPSEEK_V4_TP8_BALANCED_LONG_PREFILL_DEFAULTS
+    ),
+    _DEEPSEEK_V4_TP8_AGGRESSIVE_LONG_PREFILL_PROFILE: (
+        _DEEPSEEK_V4_TP8_AGGRESSIVE_LONG_PREFILL_DEFAULTS
+    ),
+}
 
 
 def _is_qwen3_moe_fp8_model(model_config: Any | None) -> bool:
@@ -55,6 +83,84 @@ def _is_qwen3_moe_fp8_model(model_config: Any | None) -> bool:
         return quantization_config.get("quant_method") == "fp8"
 
     return False
+
+
+def _is_deepseek_v4_model(model_config: Any | None) -> bool:
+    if model_config is None:
+        return False
+
+    hf_config = getattr(model_config, "hf_config", None)
+    model_type = getattr(hf_config, "model_type", None)
+    if model_type == "deepseek_v4":
+        return True
+
+    architectures = getattr(model_config, "architectures", None)
+    if architectures is None and hf_config is not None:
+        architectures = getattr(hf_config, "architectures", None)
+    return any("DeepseekV4" in str(arch) for arch in architectures or ())
+
+
+def _deepseek_v4_flashmla_sparse_block_size(model_config: Any | None) -> int:
+    value = os.getenv(_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_ENV)
+    if value is None or not _is_deepseek_v4_model(model_config):
+        return 64
+
+    value = value.strip()
+    if value in ("64", "256"):
+        return int(value)
+    raise ValueError(
+        f"{_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_ENV} must be 64 or 256, " f"got {value!r}"
+    )
+
+
+def _apply_deepseek_v4_tp8_profile(
+    model_config: Any | None,
+    tensor_parallel_size: int | None,
+) -> None:
+    profile = os.getenv(_DEEPSEEK_V4_TP8_PROFILE_ENV)
+    if profile is None:
+        return
+
+    profile = profile.strip()
+    if not profile or not _is_deepseek_v4_model(model_config):
+        return
+    profile_defaults = _DEEPSEEK_V4_TP8_PROFILE_DEFAULTS.get(profile)
+    if profile_defaults is None:
+        valid_profiles = ", ".join(
+            repr(name) for name in sorted(_DEEPSEEK_V4_TP8_PROFILE_DEFAULTS)
+        )
+        raise ValueError(
+            f"{_DEEPSEEK_V4_TP8_PROFILE_ENV} must be one of "
+            f"{valid_profiles}, "
+            f"got {profile!r}"
+        )
+    if tensor_parallel_size != 8:
+        logger.info(
+            "Ignoring %s=%s because tensor_parallel_size=%s; the profile is "
+            "validated only for DeepSeek-V4 TP8.",
+            _DEEPSEEK_V4_TP8_PROFILE_ENV,
+            profile,
+            tensor_parallel_size,
+        )
+        return
+
+    applied = []
+    preserved = []
+    for env_name, default_value in profile_defaults.items():
+        if env_name in os.environ:
+            preserved.append(env_name)
+            continue
+        os.environ[env_name] = default_value
+        applied.append(f"{env_name}={default_value}")
+
+    logger.info(
+        "Applied DeepSeek-V4 TP8 profile %s=%s; set defaults: %s; preserved "
+        "explicit envs: %s.",
+        _DEEPSEEK_V4_TP8_PROFILE_ENV,
+        profile,
+        ", ".join(applied) if applied else "none",
+        ", ".join(preserved) if preserved else "none",
+    )
 
 
 @cache
@@ -303,6 +409,7 @@ class MUSAPlatformBase(Platform):
             else getattr(spec_config, "method", None) == "dflash"
         ):
             from .patches import apply_patches
+
             apply_patches(force=True)
             # MUSA-0403: the dflash draft-loop FULL CUDAGraph capture is
             # default-on (opt out with VLLM_MUSA_DFLASH_FULL_WRAP=0). It makes
@@ -315,11 +422,13 @@ class MUSAPlatformBase(Platform):
             # configured sizes (default: the single BS=1 block). Multi-block
             # (BS>1) draft capture is tracked separately (MUSA-0406).
             import os as _df_os
+
             if _df_os.environ.get("VLLM_MUSA_DFLASH_FULL_WRAP", "1") != "0":
                 _comp = getattr(vllm_config, "compilation_config", None)
                 _nspec = getattr(spec_config, "num_speculative_tokens", None)
                 if _comp is not None and _nspec:
                     from vllm.config import CUDAGraphMode as _CGM
+
                     _block = 1 + int(_nspec)
                     # Capture exactly the single BS=1 verify block — the proven,
                     # fast size (no padding). vLLM's default capture sizes are
@@ -329,8 +438,14 @@ class MUSAPlatformBase(Platform):
                     # padded to 72 and running ~35 tok/s vs 48 at the exact
                     # block). MUSA-0406 extends this to BS=1,2,4,8 = block-aligned
                     # [9,18,36,72]; a BS=N decode uses the size-N*block graph exactly.
-                    _maxseq = getattr(getattr(vllm_config, "scheduler_config", None),
-                                      "max_num_seqs", 8) or 8
+                    _maxseq = (
+                        getattr(
+                            getattr(vllm_config, "scheduler_config", None),
+                            "max_num_seqs",
+                            8,
+                        )
+                        or 8
+                    )
                     _comp.cudagraph_capture_sizes = [
                         _block * k for k in (1, 2, 4, 8) if k <= max(1, _maxseq)
                     ]
@@ -345,6 +460,28 @@ class MUSAPlatformBase(Platform):
 
         parallel_config = vllm_config.parallel_config
         model_config = vllm_config.model_config
+
+        if _is_deepseek_v4_model(model_config):
+            _apply_deepseek_v4_tp8_profile(
+                model_config,
+                getattr(parallel_config, "tensor_parallel_size", None),
+            )
+            if os.environ.get("VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV") is None:
+                os.environ["VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV"] = "1"
+                logger.info(
+                    "Enabling DeepSeek-V4 MUSA fused-MoE GEMV dispatcher "
+                    "(set VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV=0 to disable)."
+                )
+            if _DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV not in os.environ:
+                os.environ[_DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV] = (
+                    _DEEPSEEK_V4_DEFAULT_GEMV_MOE_BLOCK
+                )
+                logger.info(
+                    "Defaulting DeepSeek-V4 MUSA GEMV/MoE block selector to "
+                    "%s=%s (set it explicitly to override).",
+                    _DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV,
+                    _DEEPSEEK_V4_DEFAULT_GEMV_MOE_BLOCK,
+                )
 
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm_musa.worker.MTGPUWorker"
@@ -394,10 +531,14 @@ class MUSAPlatformBase(Platform):
                 if not use_flashmla_sparse:
                     use_flashmla_sparse = True
 
-                if use_flashmla_sparse and cache_config.block_size != 64:
-                    cache_config.block_size = 64
+                sparse_block_size = _deepseek_v4_flashmla_sparse_block_size(
+                    model_config
+                )
+                if use_flashmla_sparse and cache_config.block_size != sparse_block_size:
+                    cache_config.block_size = sparse_block_size
                     logger.info(
-                        "Forcing kv cache block size to 64 for FlashMLASparse backend."
+                        "Forcing kv cache block size to %d for FlashMLASparse backend.",
+                        sparse_block_size,
                     )
 
         scheduler_config = vllm_config.scheduler_config

--- a/vllm_musa/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm_musa/v1/attention/backends/mla/flashmla_sparse.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA FlashMLA sparse backend shims.
+
+The implementation stays on upstream vLLM's sparse MLA code path and narrows
+only the platform capability and MATE availability checks.
+"""
+
+import torch
+from vllm.config.cache import CacheDType
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backend import MultipleOf
+from vllm.v1.attention.backends.mla.flashmla_sparse import (
+    DeepseekV4FlashMLASparseBackend,
+    FlashMLASparseBackend,
+)
+
+from vllm_musa.v1.attention.ops.flashmla import is_flashmla_sparse_supported
+
+
+class MUSAFlashMLASparseBackend(FlashMLASparseBackend):
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        return capability.major == 3
+
+    @classmethod
+    def supports_combination(
+        cls,
+        head_size: int,
+        dtype: torch.dtype,
+        kv_cache_dtype: CacheDType | None,
+        block_size: int | None,
+        use_mla: bool,
+        has_sink: bool,
+        use_sparse: bool,
+        device_capability: DeviceCapability,
+    ) -> str | None:
+        return is_flashmla_sparse_supported()[1]
+
+
+class MUSADeepseekV4FlashMLASparseBackend(DeepseekV4FlashMLASparseBackend):
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [256]
+
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        return capability.major == 3
+
+    @classmethod
+    def supports_combination(
+        cls,
+        head_size: int,
+        dtype: torch.dtype,
+        kv_cache_dtype: CacheDType | None,
+        block_size: int | None,
+        use_mla: bool,
+        has_sink: bool,
+        use_sparse: bool,
+        device_capability: DeviceCapability,
+    ) -> str | None:
+        return is_flashmla_sparse_supported()[1]

--- a/vllm_musa/v1/attention/ops/flashmla.py
+++ b/vllm_musa/v1/attention/ops/flashmla.py
@@ -7,66 +7,163 @@ from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
-# ==================== MUSA ADAPTATION ====================
+_FLASHMLA_IMPORT_ERROR: Exception | None = None
 try:
-    from mate.flashmla import flash_mla_with_kvcache, get_mla_metadata
-except ImportError as e:
-    raise ImportError(
-        "MUSA platform requires MATE to be installed. Please install mate first."
-    ) from e
+    import flash_mla as _flash_mla
+except Exception as exc:
+    _FLASHMLA_IMPORT_ERROR = exc
+    _flash_mla = None
+else:
+    _REQUIRED_FLASHMLA_ATTRS = (
+        "FlashMLASchedMeta",
+        "flash_mla_sparse_fwd",
+        "flash_mla_with_kvcache",
+        "get_mla_metadata",
+    )
+    for _attr in _REQUIRED_FLASHMLA_ATTRS:
+        if not hasattr(_flash_mla, _attr):
+            _FLASHMLA_IMPORT_ERROR = AttributeError(
+                f"flash_mla is missing required attribute {_attr!r}"
+            )
+            _flash_mla = None
+            break
 
 
-# vllm.v1.Attention.ops.flashmla will be registered and used earlier than this patch, but it will not affect
+class _UnavailableFlashMLASchedMeta:
+    def __init__(
+        self,
+        tile_scheduler_metadata: torch.Tensor | None = None,
+        num_splits: torch.Tensor | None = None,
+    ) -> None:
+        self.tile_scheduler_metadata = tile_scheduler_metadata
+        self.num_splits = num_splits
+
+
+FlashMLASchedMeta = (
+    _flash_mla.FlashMLASchedMeta
+    if _flash_mla is not None
+    else _UnavailableFlashMLASchedMeta
+)
+
+
+def _flashmla_unavailable_reason() -> str:
+    if _FLASHMLA_IMPORT_ERROR is None:
+        return "flash_mla is not available."
+    return (
+        "flash_mla is not available: "
+        f"{type(_FLASHMLA_IMPORT_ERROR).__name__}: {_FLASHMLA_IMPORT_ERROR}"
+    )
+
+
+def _raise_flashmla_unavailable(*_args, **_kwargs):
+    raise RuntimeError(_flashmla_unavailable_reason())
+
+
+def _require_flashmla():
+    if _flash_mla is None:
+        _raise_flashmla_unavailable()
+    return _flash_mla
+
+
 def _is_flashmla_available() -> tuple[bool, str | None]:
+    if _flash_mla is None:
+        return False, _flashmla_unavailable_reason()
     return True, None
 
 
 def is_flashmla_dense_supported() -> tuple[bool, str | None]:
-    """
-    Return: is_supported_flag, unsupported_reason (optional).
-    """
-    is_available, maybe_reason = _is_flashmla_available()
+    is_available, reason = _is_flashmla_available()
     if not is_available:
-        return False, maybe_reason
-    # Only MUSA devices support FlashMLA Dense
+        return False, reason
     if not current_platform.is_musa():
         return False, "FlashMLA Dense is only supported on MUSA devices."
     return True, None
 
 
 def is_flashmla_sparse_supported() -> tuple[bool, str | None]:
-    """
-    Return: is_supported_flag, unsupported_reason (optional).
-    """
-    is_available, maybe_reason = _is_flashmla_available()
+    is_available, reason = _is_flashmla_available()
     if not is_available:
-        return False, maybe_reason
-    # MUSA devices use compute capability 3
+        return False, reason
     device_capability = current_platform.get_device_capability()
     if device_capability is None or device_capability[0] != 3:
-        return (
-            False,
-            "FlashMLA Sparse is only supported on MUSA devices.",
-        )
+        return False, "FlashMLA Sparse is only supported on MUSA devices."
     return True, None
 
 
-def _raise_flashmla_unavailable(*_args, **_kwargs):
-    _, reason = _is_flashmla_available()
-    raise RuntimeError(reason or "FlashMLA is not available")
+def get_mla_metadata(*args, **kwargs):
+    flash_mla = _require_flashmla()
+    return flash_mla.get_mla_metadata(*args, **kwargs)
 
 
-if _is_flashmla_available()[0]:
-    from mate.flashmla import flash_mla_with_kvcache, get_mla_metadata
-else:
-    flash_mla_with_kvcache = _raise_flashmla_unavailable  # type: ignore[assignment]
-    get_mla_metadata = _raise_flashmla_unavailable  # type: ignore[assignment]
+def flash_mla_sparse_fwd(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    d_v: int = 512,
+    attn_sink: torch.Tensor | None = None,
+    topk_length: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    flash_mla = _require_flashmla()
+
+    result, max_logits, lse = flash_mla.flash_mla_sparse_fwd(
+        q=q,
+        kv=kv,
+        indices=indices,
+        sm_scale=sm_scale,
+        d_v=d_v,
+        attn_sink=attn_sink,
+        topk_length=topk_length,
+    )
+    if out is not None:
+        out.copy_(result)
+        result = out
+    return result, max_logits, lse
 
 
-class FlashMLASchedMeta:
-    def __init__(self, tile_scheduler_metadata: torch.Tensor, num_splits: torch.Tensor):
-        self.tile_scheduler_metadata = tile_scheduler_metadata
-        self.num_splits = num_splits
+def flash_mla_with_kvcache(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    block_table: torch.Tensor | None,
+    cache_seqlens: torch.Tensor | None,
+    head_dim_v: int,
+    tile_scheduler_metadata: FlashMLASchedMeta,
+    num_splits: torch.Tensor | None = None,
+    softmax_scale: float | None = None,
+    causal: bool = False,
+    is_fp8_kvcache: bool = False,
+    indices: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+    extra_k_cache: torch.Tensor | None = None,
+    extra_indices_in_kvcache: torch.Tensor | None = None,
+    topk_length: torch.Tensor | None = None,
+    extra_topk_length: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    flash_mla = _require_flashmla()
+    result, softmax_lse = flash_mla.flash_mla_with_kvcache(
+        q=q,
+        k_cache=k_cache,
+        block_table=block_table,
+        cache_seqlens=cache_seqlens,
+        head_dim_v=head_dim_v,
+        tile_scheduler_metadata=tile_scheduler_metadata,
+        num_splits=num_splits,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        is_fp8_kvcache=is_fp8_kvcache,
+        indices=indices,
+        attn_sink=attn_sink,
+        extra_k_cache=extra_k_cache,
+        extra_indices_in_kvcache=extra_indices_in_kvcache,
+        topk_length=topk_length,
+        extra_topk_length=extra_topk_length,
+    )
+    if out is not None:
+        out.copy_(result)
+        result = out
+    return result, softmax_lse
 
 
 def get_mla_metadata_dense_fp8(
@@ -74,12 +171,13 @@ def get_mla_metadata_dense_fp8(
     num_q_tokens_per_head_k: int,
     num_heads_k: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if not _is_flashmla_available()[0]:
+    if _flash_mla is None:
         _raise_flashmla_unavailable()
-    return torch.ops._flashmla_extension_C.get_mla_decoding_metadata_dense_fp8(
+    return get_mla_metadata(
         cache_seqlens,
         num_q_tokens_per_head_k,
         num_heads_k,
+        is_fp8_kvcache=True,
     )
 
 
@@ -96,21 +194,22 @@ def flash_mla_with_kvcache_fp8(
     descale_q: torch.Tensor | None = None,
     descale_k: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if not _is_flashmla_available()[0]:
-        _raise_flashmla_unavailable()
-    if softmax_scale is None:
-        softmax_scale = q.shape[-1] ** (-0.5)
-    out, softmax_lse = torch.ops._flashmla_extension_C.fwd_kvcache_mla_fp8(
-        q,
-        k_cache,
-        head_dim_v,
-        cache_seqlens,
-        block_table,
-        softmax_scale,
-        causal,
-        tile_scheduler_metadata,
-        num_splits,
-        descale_q,
-        descale_k,
+    if descale_q is not None or descale_k is not None:
+        raise NotImplementedError(
+            "MUSA FlashMLA FP8 dense path does not support explicit descale tensors."
+        )
+    return flash_mla_with_kvcache(
+        q=q,
+        k_cache=k_cache,
+        block_table=block_table,
+        cache_seqlens=cache_seqlens,
+        head_dim_v=head_dim_v,
+        tile_scheduler_metadata=FlashMLASchedMeta(
+            tile_scheduler_metadata=tile_scheduler_metadata,
+            num_splits=num_splits,
+        ),
+        num_splits=num_splits,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        is_fp8_kvcache=True,
     )
-    return out, softmax_lse


### PR DESCRIPTION
## Motivation

Enable DeepSeek-V4-Flash-Base on vllm-musa and bring the TP8 single-node serving path to a usable performance level on MUSA.

This model requires more than basic model registration: it depends on DeepSeek-V4 sparse MLA, FP8 KV cache, MTP, CUDA Graph decode, custom all-reduce compatibility, MHC pre/post processing, sparse indexer handling, FP8 MoE execution, and several native/JIT MUSA kernel paths. The goal is to replace expensive fallback paths with MUSA-native implementations while preserving token correctness.

## Modifications

- Added DeepSeek-V4-Flash-Base support through vllm-musa patch modules without directly modifying upstream vLLM sources.
- Added and integrated DeepSeek-V4 specific MUSA kernels for cache store/utilities, sparse FlashMLA decode, fused Q/KV RMSNorm, sparse indexer top-k, inverse RoPE FP8 quantization, MHC pre-processing, and router top-k/softplus/sqrt.
- Added TileLang/JIT support for DeepSeek-V4 MHC, FP8 einsum/GEMV, qnorm-rope KV insert, compile profile selection, and runtime specialization.
- Integrated TP8 serving support with CUDA Graph decode, MTP/speculative decoding, custom all-reduce compatibility, FP8 KV cache, and FlashMLA sparse attention.
- Added balanced/aggressive TP8 profile controls and opt-in long-prefill tuning paths.
- Removed or gated costly Torch/Triton fallback paths where native MUSA paths are available.
- Added focused tests for DeepSeek-V4 patches, MHC, TileLang helpers, FP8 paths, and qnorm/RMSNorm integration.

## Test

Validated on `vllm-joey-3000` with:

- Model: `/home/dist/DeepSeek-V4-Flash-Base`
- Hardware: 8 x MTT S5000
- Clean vLLM baseline: `v0.20.0`
- vllm-musa commit: `fd7e49722d5a`
- Runtime: `torch 2.9.0`, `torch_musa 2.9.0`, `torchada 0.1.56`, `mate 0.2.1+mu436`

Correctness:

- Server startup passed.
- Chat correctness passed: HTTP 200 and response contains `Beijing`.
- Benchmark token correctness passed: every row completed `1`, failed `0`, `total_output_tokens=1024`.

Final clean-baseline benchmark:

| Shape | Output TPS |
|---|---:|
| 4096 input / 1024 output, run 1 | 42.954216 tok/s |
| 4096 input / 1024 output, run 2 | 43.563139 tok/s |

Best same-session optimization A/B row reached `44.246776 tok/s` for 4096 input / 1024 output.
