### PR TITLE
Gate generic MUSA RoPE JIT behind opt-in

### DIFF
--- a/vllm_musa/model_executor/layers/rotary_embedding/base.py
+++ b/vllm_musa/model_executor/layers/rotary_embedding/base.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
 
@@ -6,6 +8,15 @@ from vllm_musa.jit_kernel import rotary_embedding
 
 @RotaryEmbedding.register_oot
 class MusaRotaryEmbedding(RotaryEmbedding):
+    @classmethod
+    def enabled(cls) -> bool:
+        # The MUSA RoPE JIT is an experimental generic RotaryEmbedding
+        # replacement. Keep it opt-in so DeepSeek-V4-specific enablement does
+        # not force Qwen/FlashAttention models through this kernel.
+        if os.getenv("VLLM_MUSA_ENABLE_JIT_ROPE", "0") != "1":
+            return False
+        return super().enabled()
+
     def forward_oot(
         self,
         positions: torch.Tensor,


### PR DESCRIPTION
## Motivation
Fix Qwen startup error. 
DeepSeek-V4-Flash-Base enablement should not affect unrelated model families. A regression was found where Qwen models using the normal FlashAttention path failed during startup because the generic MUSA RoPE JIT was globally registered as an OOT replacement for upstream RotaryEmbedding.

## Modifications
  - Ensure Qwen/FlashAttention models use the normal upstream/native RoPE path unless the experimental JIT RoPE path is explicitly requested.

## Test
Smoke tests:
- Qwen3-8B 
- Qwen3-8B-FP8
- Qwen3-30B-A3B-Instruct-2507
- DeepSeek-V2-Lite

