### PR TITLE
Adapt vllm-musa to vLLM v0.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vllm-musa"
-version = "0.1.1"
+version = "0.1.22"
 description = "vLLM platform plugin for Moore Threads (MUSA) GPUs"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/setup.py
+++ b/setup.py
@@ -120,13 +120,16 @@ class _RepoInfo:
 _VLLM_REPO = _RepoInfo(
     name="vllm",
     git_repository="https://github.com/vllm-project/vllm.git",
-    git_tag="v0.20.0",
+    git_tag="v0.22.0",
     git_shallow=False,
 )
 
 _FLASHINFER_REPO = _RepoInfo(
     name="flashinfer",
     git_repository="https://github.com/flashinfer-ai/flashinfer.git",
+    # Keep the prepared MUSA-compatible FlashInfer baseline. Upstream vLLM
+    # v0.22.0 uses v0.6.11.post2, but that tag currently breaks the MUSA
+    # csrc_musa/include_musa build path used by vllm-musa.
     git_tag="bc29697ba20b7e6bdb728ded98f04788e16ee021",
     git_shallow=False,
 )
@@ -143,47 +146,36 @@ INCLUDE_DIRS = [
 # =============================================================================
 
 VLLM_CSRC_SOURCES = [
-    str(_VLLM_REPO.source_dir / "csrc/activation_kernels.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/cache_kernels.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/cuda_utils_kernels.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/cumem_allocator.cpp"),
-    str(_VLLM_REPO.source_dir / "csrc/layernorm_kernels.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/pos_encoding_kernels.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/sampler.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/attention/merge_attn_states.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/cuda_view.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/quantization/w8a8/int8/scaled_quant.cu"),
     str(_VLLM_REPO.source_dir / "csrc/mamba/mamba_ssm/selective_scan_fwd.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/quantization/gptq/q_gemm.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/quantization/gguf/gguf_kernel.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/layernorm_quant_kernels.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/fused_qknorm_rope_kernel.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/quantization/activation_kernels.cu"),
+    str(_VLLM_REPO.source_dir / "csrc/cache_kernels.cu"),
+    str(_VLLM_REPO.source_dir / "csrc/cache_kernels_fused.cu"),
     # MUSA-0203 (2026-05-28): paged_attention_v1/v2 are CUDA-only and unused
     # on MUSA (vllm uses FlashAttention via mate's flash_attn_varlen_func).
-    # Skipping them avoids ~2 min of compile time and ~1 mcc clang frontend
-    # segfault we hit when expanding mcc flags. Their schema declarations
-    # are also stripped from third_party/vllm/csrc/torch_bindings.cpp below
-    # so torch.ops._C lookups at vllm import time don't reference unbound
-    # kernels.
+    # Skipping them avoids compile time and mcc frontend failures. Their impl
+    # registrations are stripped from third_party/vllm/csrc/torch_bindings.cpp
+    # below so torch.ops._C import does not reference unbuilt symbols.
     # str(_VLLM_REPO.source_dir / "csrc/attention/paged_attention_v1.cu"),
     # str(_VLLM_REPO.source_dir / "csrc/attention/paged_attention_v2.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/cache_kernels_fused.cu"),
-    str(
-        _VLLM_REPO.source_dir
-        / "csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu"
-    ),
-    str(_VLLM_REPO.source_dir / "csrc/quantization/w8a8/fp8/common.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/custom_all_reduce.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/quantization/awq/gemm_kernels.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/attention/vertical_slash_index.cu"),
-    str(_VLLM_REPO.source_dir / "csrc/torch_bindings.cpp"),
+    str(_VLLM_REPO.source_dir / "csrc/attention/merge_attn_states.cu"),
+    str(_VLLM_REPO.source_dir / "csrc/sampler.cu"),
     str(_VLLM_REPO.source_dir / "csrc/topk.cu"),
+    str(_VLLM_REPO.source_dir / "csrc/cuda_view.cu"),
     str(
         _VLLM_REPO.source_dir
         / "csrc/quantization/fused_kernels/fused_silu_mul_block_quant.cu"
     ),
+    str(_VLLM_REPO.source_dir / "csrc/quantization/activation_kernels.cu"),
+    str(_VLLM_REPO.source_dir / "csrc/cuda_utils_kernels.cu"),
+    str(_VLLM_REPO.source_dir / "csrc/custom_all_reduce.cu"),
+    str(_VLLM_REPO.source_dir / "csrc/torch_bindings.cpp"),
     str(_VLLM_REPO.source_dir / "csrc/minimax_reduce_rms_kernel.cu"),
+]
+
+VLLM_STABLE_CSRC_SOURCES = [
+    # v0.22 imports this extension for stable-ABI operator schemas. The CUDA
+    # stable kernels require torch/headeronly/core/Dispatch.h, which is not in
+    # the current torch_musa stack, so MUSA builds this as a schema-only shim.
+    str(_VLLM_REPO.source_dir / "csrc/libtorch_stable/torch_bindings.cpp"),
 ]
 
 VLLM_MUSA_CSRC_SOURCES = [
@@ -199,10 +191,9 @@ VLLM_MUSA_CSRC_SOURCES = [
     "csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu",
     "csrc/musa/mhc/deepseek_v4_mhc_pre.mu",
     "csrc/musa/moe/deepseek_v4_topk_softplus_sqrt.mu",
-    # XXX (MUSA): The version used here is vllm 0.18.0, located at csrc/quantization/w8a8/fp8.
-    # While in version 0.20.0, the path has changed to csrc/libtorch_stable/quantization/w8a8/fp8,
-    # and depends on two header file from PyTorch 2.11's torch/headeronly/core/ScalarType.h and
-    # torch/headeronly/util/Exception.h, which is not supported by the current musa.
+    # XXX (MUSA): This local kernel stays non-stable for now because the
+    # upstream v0.22 path moved under csrc/libtorch_stable and depends on
+    # stable ABI headers not yet covered by the current MUSA path.
     "csrc/musa/quantization/per_token_group_quant.cu",
     "csrc/musa/sampler.mu",
     str(_FLASHINFER_REPO.source_dir / "csrc/norm.cu"),
@@ -213,6 +204,7 @@ VLLM_MUSA_CSRC_SOURCES = [
 VLLM_MOE_CSRC_SOURCES = [
     str(_VLLM_REPO.source_dir / "csrc/moe/moe_align_sum_kernels.cu"),
     str(_VLLM_REPO.source_dir / "csrc/moe/topk_softmax_kernels.cu"),
+    str(_VLLM_REPO.source_dir / "csrc/moe/topk_softplus_sqrt_kernels.cu"),
     str(_VLLM_REPO.source_dir / "csrc/moe/torch_bindings.cpp"),
 ]
 
@@ -227,8 +219,6 @@ CSRC_FILE_OVERRIDES = [
     "csrc/custom_all_reduce.cuh",
     "csrc/mamba/mamba_ssm/selective_scan_fwd.cu",
     "csrc/quantization/activation_kernels.cu",
-    "csrc/quantization/gptq/q_gemm.cu",
-    "csrc/quantization/gptq/compat.cuh",
 ]
 
 # Inline text replacements to apply to upstream source files.
@@ -258,6 +248,21 @@ CSRC_TEXT_PATCHES = {
         {
             '  ops.impl("paged_attention_v2", torch::kCUDA, &paged_attention_v2);': "  // MUSA-0203: paged_attention_v2 impl stripped (kernel not built on MUSA)",
         },
+        {
+            '  ops.impl("fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert", torch::kCUDA,\n           &fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert);': "  // MUSA: fused DeepSeek-V4 qnorm/rope/cache impl stripped;\n  // vllm_musa redirects this path to native/JIT MUSA implementations.",
+        },
+    ],
+    str(_VLLM_REPO.source_dir / "csrc/libtorch_stable/torch_bindings.cpp"): [
+        {
+            '#include "ops.h"': '#if !defined(USE_MUSA)\n#include "ops.h"\n#endif'
+        },
+        {
+            "STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {": "#if !defined(USE_MUSA)\nSTABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {"
+        },
+        {
+            "STABLE_TORCH_LIBRARY_IMPL(_C, CompositeExplicitAutograd, ops) {": "#endif\n#if !defined(USE_MUSA)\nSTABLE_TORCH_LIBRARY_IMPL(_C, CompositeExplicitAutograd, ops) {"
+        },
+        {"REGISTER_EXTENSION(_C_stable_libtorch)": "#endif\nREGISTER_EXTENSION(_C_stable_libtorch)"},
     ],
     str(_VLLM_REPO.source_dir / "csrc/quantization/w8a8/fp8/nvidia/quant_utils.cuh"): [
         {
@@ -314,6 +319,14 @@ CSRC_TEXT_PATCHES = {
     ): [
         {
             '#include "../w8a8/fp8/common.cuh"': '#include "quantization/w8a8/fp8/common.cuh"'
+        },
+    ],
+    str(
+        _VLLM_REPO.source_dir
+        / "csrc/libtorch_stable/quantization/fused_kernels/quant_conversions.cuh"
+    ): [
+        {
+            '#include "../../../quantization/w8a8/fp8/common.cuh"': '#include "quantization/w8a8/fp8/common.cuh"'
         },
     ],
     str(
@@ -469,6 +482,15 @@ EXT_MODULES = [
         py_limited_api=False,
     ),
     CUDAExtension(
+        name="vllm._C_stable_libtorch",
+        sources=VLLM_STABLE_CSRC_SOURCES,
+        include_dirs=INCLUDE_DIRS,
+        extra_compile_args=COMPILE_ARGS,
+        libraries=LINK_LIBRARIES,
+        extra_link_args=EXTRA_LINK_ARGS,
+        py_limited_api=False,
+    ),
+    CUDAExtension(
         name="vllm_musa._C",
         sources=VLLM_MUSA_CSRC_SOURCES,
         include_dirs=INCLUDE_DIRS,
@@ -593,6 +615,10 @@ class _CustomBuildExt(BuildExtension):
     def _apply_text_patches():
         """Apply inline text replacements to upstream source files."""
         for file_path, replacement_rules in CSRC_TEXT_PATCHES.items():
+            if not Path(file_path).exists():
+                print(f"Skipping missing text patch target: {file_path}")
+                continue
+
             with open(file_path, "r", encoding="utf-8") as f:
                 content = f.read()
 

--- a/tests/test_deepseek_v4_mhc.py
+++ b/tests/test_deepseek_v4_mhc.py
@@ -48,10 +48,23 @@ def test_mhc_patch_uses_musa_provider_by_default():
 
     assert "from vllm_musa.deepseek_v4_mhc import mhc_pre_musa" in source
     assert "from vllm_musa.deepseek_v4_mhc import mhc_post_musa" in source
+    assert "from vllm_musa.deepseek_v4_mhc import mhc_pre_musa_with_norm" in source
+    assert "from vllm_musa.deepseek_v4_mhc import mhc_fused_post_pre_musa" in source
+    assert "from vllm_musa.deepseek_v4_mhc import hc_head_musa" in source
     assert "VLLM_MUSA_ENABLE_DEEPSEEK_V4_MHC_MUSA_IMPL" in source
     assert (
         'VLLM_MUSA_ENABLE_TORCH_MHC_PRENORM_FALLBACK",\n                "0"' in source
     )
+
+
+def test_fp8_einsum_fallback_validates_group_size_divisibility():
+    source = _read("vllm_musa/deepseek_v4_jit/fp8_einsum.py")
+
+    assert "def _validate_group_size_divisible(" in source
+    assert "must be divisible by" in source
+    assert '_validate_group_size_divisible("activation hidden", hidden)' in source
+    assert '_validate_group_size_divisible("weight output", out_dim)' in source
+    assert '_validate_group_size_divisible("weight input", in_dim)' in source
 
 
 def test_mhc_pre_deepgemm_big_fuse_is_default_off():
@@ -66,6 +79,41 @@ def test_mhc_pre_deepgemm_big_fuse_is_default_off():
     assert "return _mhc_pre_deepgemm_big_fuse_provider(" in source
     assert 'return "native"' in source
     assert 'return "deepgemm_big_fuse"' not in source
+
+
+def test_mhc_fused_post_pre_composes_musa_post_pre_and_norm():
+    source = _read("vllm_musa/deepseek_v4_mhc.py")
+
+    assert "def mhc_fused_post_pre_musa(" in source
+    assert "residual_cur = mhc_post_musa(" in source
+    assert "post_mix_cur, comb_mix_cur, layer_input_cur = mhc_pre_musa(" in source
+    assert "def _apply_optional_rms_norm(" in source
+    assert "norm_weight.to(torch.float32)" in source
+
+
+def test_mhc_auto_paths_fall_back_when_tilelang_is_unavailable():
+    source = _read("vllm_musa/deepseek_v4_mhc.py")
+
+    assert 'VLLM_MUSA_DEEPSEEK_V4_MHC_POST_IMPL", "auto"' in source
+    assert "except (ImportError, OSError, NotImplementedError):" in source
+    assert "return mhc_post_torch_fallback(" in source
+    assert "return _mhc_pre_native_provider(" in source
+    assert "if not auto_impl:" in source
+
+
+def test_hc_head_musa_eager_path_preserves_token_dimensions():
+    source = _read("vllm_musa/deepseek_v4_mhc.py")
+
+    assert "def _reshape_hc_head_input(" in source
+    assert "def hc_head_musa(" in source
+    assert "hidden_states.flatten(1)" not in source
+    assert "token_shape = hidden_states.shape[:-1]" in source
+    assert "token_shape = hidden_states.shape[:-2]" in source
+    assert "grouped = hidden_states.reshape(-1, hc_mult, hidden_size)" in source
+    assert "x = grouped.reshape(grouped.shape[0], -1)" in source
+    assert "x @ hc_fn.to(torch.float32).t()" in source
+    assert "torch.sum(pre.unsqueeze(-1) * grouped, dim=1)" in source
+    assert "return y.reshape(*token_shape, hidden_size).to(dtype)" in source
 
 
 def test_mhc_pre_decode_prenorm_tilelang_selector_is_default_off():

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -75,6 +75,84 @@ class TestPatchFileLoading:
         assert patches == []
 
 
+class TestCustomOpsRuntimePatches:
+    def test_rms_norm_wrapper_is_registered_on_vllm_custom_ops(self, monkeypatch):
+        import vllm
+
+        import vllm_musa
+
+        vllm_ops = ModuleType("vllm._custom_ops")
+        monkeypatch.setitem(sys.modules, "vllm._custom_ops", vllm_ops)
+        monkeypatch.setattr(vllm, "_custom_ops", vllm_ops, raising=False)
+
+        vllm_musa._patch_vllm_custom_ops_dflash_fallbacks()
+
+        assert vllm_ops.rms_norm is vllm_musa._musa_safe_rms_norm
+        assert getattr(vllm_ops.rms_norm, "_musa_safe_rms_norm") is True
+        assert vllm_ops.rotary_embedding is vllm_musa._musa_safe_rotary_embedding
+        assert getattr(vllm_ops.rotary_embedding, "_musa_safe_rotary_embedding") is True
+
+
+class TestDeepSeekV4V022Patches:
+    def test_common_inv_rope_fp8_quant_patch_is_discoverable(self):
+        from vllm_musa.patches import _get_patch_files
+
+        modules = {module_name for module_name, _ in _get_patch_files()}
+
+        assert (
+            "vllm.models.deepseek_v4.common.ops.fused_inv_rope_fp8_quant"
+            in modules
+        )
+
+    def test_attention_fp8_einsum_patch_is_discoverable(self):
+        from vllm_musa.patches import _get_patch_files
+
+        modules = {module_name for module_name, _ in _get_patch_files()}
+
+        assert "vllm.models.deepseek_v4.attention" in modules
+
+    def test_nvidia_model_patch_is_discoverable(self):
+        from vllm_musa.patches import _get_patch_files
+
+        modules = {module_name for module_name, _ in _get_patch_files()}
+
+        assert "vllm.models.deepseek_v4.nvidia.model" in modules
+
+    def test_attention_fp8_einsum_patch_uses_musa_provider(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        for module_name, patch_path in _get_patch_files():
+            if module_name == "vllm.models.deepseek_v4.attention":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "try_musa_deepseek_v4_fp8_einsum" in new_source
+                assert "upstream DeepGEMM fp8_einsum" in new_source
+                assert "not available in the MUSA runtime" in new_source
+                assert "current_platform.is_musa()" in new_source
+                assert "_musa_deepseek_v4_mm_out_dtype" in new_source
+                assert "torch.mm(a.to(out_dtype), b.to(out_dtype))" in new_source
+                break
+        else:
+            raise AssertionError("DeepSeek-V4 v0.22 attention patch was not found")
+
+    def test_nvidia_model_patch_runs_final_hc_post_on_musa(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        for module_name, patch_path in _get_patch_files():
+            if module_name == "vllm.models.deepseek_v4.nvidia.model":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "current_platform.is_cuda() or current_platform.is_musa()" in (
+                    new_source
+                )
+                assert "hidden_states = layer.hc_post(" in new_source
+                break
+        else:
+            raise AssertionError("DeepSeek-V4 v0.22 NVIDIA model patch was not found")
+
+
 class TestTritonPatch:
     """Tests for the Triton unified attention patch."""
 
@@ -269,6 +347,51 @@ class TestLLMBaseProposerPatch:
 
 class TestDeepSeekV4AttentionPatch:
     """Tests for the MUSA DeepSeek-V4 attention patch."""
+
+    def test_v022_attention_redirects_qnorm_rope_insert_to_musa_native(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.models.deepseek_v4.attention":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "def _musa_deepseek_v4_qnorm_rope_kv_insert(" in new_source
+                assert "_musa_custom_ops.deepseek_v4_qnorm_rope_kv_insert(" in (
+                    new_source
+                )
+                assert "if _musa_deepseek_v4_is_musa_tensor(q):" in new_source
+                assert "swa_kv_cache," in new_source
+                assert "F.pad(q, (0, 0, 0, padded_heads - q.shape[1])" in (
+                    new_source
+                )
+                assert "slot_mapping[: q.shape[0]].contiguous()" in new_source
+                break
+        else:
+            raise AssertionError("v0.22 deepseek_v4 attention patch file was not found")
+
+    def test_v022_deepseek_v4_flashmla_uses_musa_ops_wrapper(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.models.deepseek_v4.nvidia.flashmla":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "from vllm_musa.v1.attention.ops.flashmla import (" in (
+                    new_source
+                )
+                assert "flash_mla_sparse_fwd" in new_source
+                assert "flash_mla_with_kvcache" in new_source
+                break
+        else:
+            raise AssertionError(
+                "v0.22 deepseek_v4 nvidia flashmla patch file was not found"
+            )
 
     def test_qnorm_rope_native_path_trims_padded_slot_mapping(self):
         from vllm_musa.patches import _get_patch_files, _load_patch_config

--- a/vllm_musa/__init__.py
+++ b/vllm_musa/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "register_custom_ops",
     "collect_env",
 ]
-__version__ = "0.1.1"
+__version__ = "0.1.22"
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +224,50 @@ def _patch_vllm_functorch_config() -> None:
     compiler_interface._get_vllm_functorch_config = get_existing_functorch_config
 
 
+def _patch_musa_batch_defaults() -> None:
+    """Keep MUSA on the non-H100 scheduler defaults.
+
+    vLLM v0.22 picks the high-memory defaults (16384 tokens / 1024 seqs) for
+    non-A100 GPUs with >=70 GiB memory. S5000 has that memory size, but mate
+    FA3 metadata kernels do not currently support the resulting warmup shape.
+    """
+    try:
+        from vllm.engine.arg_utils import EngineArgs
+        from vllm.usage.usage_lib import UsageContext
+    except Exception as e:
+        logger.debug("Skipping MUSA batch-defaults patch: %s", e)
+        return
+
+    original = EngineArgs.get_batch_defaults
+    if getattr(original, "_musa_batch_defaults_patched", False):
+        return
+
+    original_func = original.__func__
+
+    @classmethod
+    def get_musa_batch_defaults(cls, world_size: int):
+        try:
+            from vllm.platforms import current_platform
+
+            if current_platform.is_musa():
+                return (
+                    {
+                        UsageContext.LLM_CLASS: 8192,
+                        UsageContext.OPENAI_API_SERVER: 2048,
+                    },
+                    {
+                        UsageContext.LLM_CLASS: 256,
+                        UsageContext.OPENAI_API_SERVER: 256,
+                    },
+                )
+        except Exception:
+            pass
+        return original_func(cls, world_size)
+
+    get_musa_batch_defaults._musa_batch_defaults_patched = True
+    EngineArgs.get_batch_defaults = get_musa_batch_defaults
+
+
 def _register_patches() -> None:
     """Apply vLLM source patches for MUSA compatibility."""
     _apply_vllm_patches()
@@ -231,11 +275,129 @@ def _register_patches() -> None:
     _patch_inductor_config_patch()
     _patch_vllm_backend_call_options()
     _patch_vllm_functorch_config()
+    _patch_musa_batch_defaults()
 
 
 def _register_ops() -> None:
     """Register OOT custom ops (activation, layernorm, fused_moe, etc.)."""
     import vllm_musa.model_executor  # noqa: F401
+
+
+def _has_musa_rms_norm_kernel() -> bool:
+    try:
+        import torch
+
+        if not hasattr(torch.ops, "_C") or not hasattr(torch.ops._C, "rms_norm"):
+            return False
+        return torch._C._dispatch_has_kernel_for_dispatch_key(
+            "_C::rms_norm", "MUSA"
+        )
+    except Exception:
+        return False
+
+
+def _has_musa_rotary_embedding_kernel() -> bool:
+    try:
+        import torch
+
+        if (
+            not hasattr(torch.ops, "_C")
+            or not hasattr(torch.ops._C, "rotary_embedding")
+        ):
+            return False
+        return torch._C._dispatch_has_kernel_for_dispatch_key(
+            "_C::rotary_embedding", "MUSA"
+        )
+    except Exception:
+        return False
+
+
+def _musa_safe_rms_norm(
+    out: Any,
+    input: Any,
+    weight: Any,
+    epsilon: float,
+) -> None:
+    import torch
+    import torch.nn as nn
+
+    if (
+        getattr(input.device, "type", None) == "musa"
+        and not _has_musa_rms_norm_kernel()
+    ):
+        normalized_shape = (weight.shape[-1],)
+        out.copy_(nn.functional.rms_norm(input, normalized_shape, weight, epsilon))
+        return
+    torch.ops._C.rms_norm(out, input, weight, epsilon)
+
+
+def _musa_safe_rotary_embedding(
+    positions: Any,
+    query: Any,
+    key: Any,
+    head_size: int,
+    cos_sin_cache: Any,
+    is_neox: bool,
+    rope_dim_offset: int = 0,
+    inverse: bool = False,
+) -> None:
+    import torch
+
+    if (
+        getattr(query.device, "type", None) == "musa"
+        and rope_dim_offset == 0
+        and not inverse
+        and not _has_musa_rotary_embedding_kernel()
+    ):
+        from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
+
+        rotary_dim = cos_sin_cache.shape[-1]
+        query_rot, key_rot = RotaryEmbedding.forward_static(
+            positions,
+            query,
+            key,
+            head_size,
+            rotary_dim,
+            cos_sin_cache,
+            is_neox,
+        )
+        query.copy_(query_rot)
+        if key is not None:
+            key.copy_(key_rot)
+        return
+    if rope_dim_offset == 0 and not inverse:
+        torch.ops._C.rotary_embedding(
+            positions, query, key, head_size, cos_sin_cache, is_neox
+        )
+    else:
+        torch.ops._C.rotary_embedding(
+            positions,
+            query,
+            key,
+            head_size,
+            cos_sin_cache,
+            is_neox,
+            rope_dim_offset,
+            inverse,
+        )
+
+
+def _patch_vllm_custom_ops_dflash_fallbacks() -> None:
+    """Patch direct vllm._custom_ops calls for MUSA-only dflash paths."""
+    try:
+        from vllm import _custom_ops as vllm_custom_ops
+    except Exception:
+        return
+
+    current = getattr(vllm_custom_ops, "rms_norm", None)
+    if not getattr(current, "_musa_safe_rms_norm", False):
+        setattr(_musa_safe_rms_norm, "_musa_safe_rms_norm", True)
+        vllm_custom_ops.rms_norm = _musa_safe_rms_norm
+
+    current = getattr(vllm_custom_ops, "rotary_embedding", None)
+    if not getattr(current, "_musa_safe_rotary_embedding", False):
+        setattr(_musa_safe_rotary_embedding, "_musa_safe_rotary_embedding", True)
+        vllm_custom_ops.rotary_embedding = _musa_safe_rotary_embedding
 
 
 def _register_modules() -> None:
@@ -256,6 +418,7 @@ def register_custom_ops() -> None:
     """
     _register_patches()
     _register_ops()
+    _patch_vllm_custom_ops_dflash_fallbacks()
     _register_modules()
     logger.info("MUSA patches and custom ops registered")
 

--- a/vllm_musa/deepseek_v4_jit/fp8_einsum.py
+++ b/vllm_musa/deepseek_v4_jit/fp8_einsum.py
@@ -150,3 +150,88 @@ def try_musa_deepseek_v4_fp8_einsum_gemv(
         return False, f"{type(exc).__name__}: {exc}"
 
     return True, "musa_fused_gemv"
+
+
+def _torch_fp8_einsum_fallback_enabled() -> bool:
+    return os.getenv("VLLM_MUSA_ENABLE_TORCH_FP8_EINSUM_FALLBACK", "0") == "1"
+
+
+def _validate_group_size_divisible(name: str, size: int) -> None:
+    if size % _GROUP_SIZE != 0:
+        raise ValueError(
+            f"{name} dimension must be divisible by {_GROUP_SIZE}, got {size}"
+        )
+
+
+def _dequant_activation(
+    activation: torch.Tensor,
+    activation_scale: torch.Tensor,
+) -> torch.Tensor:
+    tokens, groups, hidden = activation.shape
+    _validate_group_size_divisible("activation hidden", hidden)
+    scale_blocks = hidden // _GROUP_SIZE
+    activation_blocks = activation.to(torch.float32).reshape(
+        tokens,
+        groups,
+        scale_blocks,
+        _GROUP_SIZE,
+    )
+    return (
+        activation_blocks * activation_scale.to(torch.float32).unsqueeze(-1)
+    ).reshape(tokens, groups, hidden)
+
+
+def _dequant_weight(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    groups: int,
+) -> torch.Tensor:
+    weight, scales, out_dim, in_dim = _normalize_weight(
+        weight,
+        weight_scale,
+        groups,
+    )
+    _validate_group_size_divisible("weight output", out_dim)
+    _validate_group_size_divisible("weight input", in_dim)
+    out_blocks = out_dim // _GROUP_SIZE
+    in_blocks = in_dim // _GROUP_SIZE
+    weight_blocks = weight.to(torch.float32).reshape(
+        groups,
+        out_blocks,
+        _GROUP_SIZE,
+        in_blocks,
+        _GROUP_SIZE,
+    )
+    return (
+        weight_blocks * scales[:, :, None, :, None]
+    ).reshape(groups, out_dim, in_dim)
+
+
+def try_musa_deepseek_v4_fp8_einsum(
+    activation: torch.Tensor,
+    activation_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+) -> tuple[bool, str]:
+    """Try supported MUSA replacements for DeepSeek-V4 FP8 einsum."""
+    handled, reason = try_musa_deepseek_v4_fp8_einsum_gemv(
+        activation,
+        activation_scale,
+        weight,
+        weight_scale,
+        out,
+        equation,
+    )
+    if handled:
+        return True, reason
+    if not _torch_fp8_einsum_fallback_enabled():
+        return False, reason
+    if equation != "bhr,hdr->bhd":
+        return False, f"unsupported equation {equation!r}"
+
+    activation_deq = _dequant_activation(activation, activation_scale)
+    weight_deq = _dequant_weight(weight, weight_scale, activation.shape[1])
+    out.copy_(torch.einsum(equation, activation_deq, weight_deq).to(out.dtype))
+    return True, "torch_dequant_einsum_fallback"

--- a/vllm_musa/deepseek_v4_mhc.py
+++ b/vllm_musa/deepseek_v4_mhc.py
@@ -29,6 +29,7 @@ def mhc_pre_musa(
     sinkhorn_repeat: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     impl = os.getenv("VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_IMPL", "auto").lower()
+    auto_impl = impl == "auto"
     if impl == "auto":
         impl = _select_mhc_pre_auto_impl(residual)
     if impl in {"native", "musa", "mu"}:
@@ -56,17 +57,32 @@ def mhc_pre_musa(
             sinkhorn_repeat,
         )
     if impl in {"tilelang", "jit"}:
-        return _mhc_pre_tilelang_provider(
-            residual,
-            fn,
-            hc_scale,
-            hc_base,
-            rms_eps,
-            hc_pre_eps,
-            hc_sinkhorn_eps,
-            hc_post_mult_value,
-            sinkhorn_repeat,
-        )
+        try:
+            return _mhc_pre_tilelang_provider(
+                residual,
+                fn,
+                hc_scale,
+                hc_base,
+                rms_eps,
+                hc_pre_eps,
+                hc_sinkhorn_eps,
+                hc_post_mult_value,
+                sinkhorn_repeat,
+            )
+        except (ImportError, OSError, NotImplementedError):
+            if not auto_impl:
+                raise
+            return _mhc_pre_native_provider(
+                residual,
+                fn,
+                hc_scale,
+                hc_base,
+                rms_eps,
+                hc_pre_eps,
+                hc_sinkhorn_eps,
+                hc_post_mult_value,
+                sinkhorn_repeat,
+            )
     if impl in {"deepgemm_big_fuse", "deepgemm-big-fuse"}:
         return _mhc_pre_deepgemm_big_fuse_provider(
             residual,
@@ -80,6 +96,148 @@ def mhc_pre_musa(
             sinkhorn_repeat,
         )
     raise ValueError(f"unsupported DeepSeek-V4 MHC pre impl: {impl!r}")
+
+
+def _apply_optional_rms_norm(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor | None,
+    norm_eps: float,
+) -> torch.Tensor:
+    if norm_weight is None:
+        return x
+    x_float = x.to(torch.float32)
+    variance = x_float.pow(2).mean(dim=-1, keepdim=True)
+    x_float = x_float * torch.rsqrt(variance + norm_eps)
+    x_float = x_float * norm_weight.to(torch.float32)
+    return x_float.to(x.dtype)
+
+
+def mhc_pre_musa_with_norm(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    post_mix, comb_mix, layer_input = mhc_pre_musa(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+    )
+    return post_mix, comb_mix, _apply_optional_rms_norm(
+        layer_input,
+        norm_weight,
+        norm_eps,
+    )
+
+
+def mhc_fused_post_pre_musa(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+    tile_n: int = 1,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    del n_splits, tile_n
+    residual_cur = mhc_post_musa(x, residual, post_layer_mix, comb_res_mix)
+    post_mix_cur, comb_mix_cur, layer_input_cur = mhc_pre_musa(
+        residual_cur,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+    )
+    layer_input_cur = _apply_optional_rms_norm(
+        layer_input_cur,
+        norm_weight,
+        norm_eps,
+    )
+    return residual_cur, post_mix_cur, comb_mix_cur, layer_input_cur
+
+
+def _reshape_hc_head_input(
+    hidden_states: torch.Tensor,
+    hc_fn: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Size, int]:
+    hc_mult = hc_fn.shape[0]
+    flat_hidden = hc_fn.shape[1]
+    if hidden_states.shape[-1] == flat_hidden:
+        if flat_hidden % hc_mult != 0:
+            raise ValueError(
+                f"hc_head hidden width {flat_hidden} is not divisible by hc_mult "
+                f"{hc_mult}"
+            )
+        hidden_size = flat_hidden // hc_mult
+        token_shape = hidden_states.shape[:-1]
+        grouped = hidden_states.reshape(-1, hc_mult, hidden_size)
+    elif (
+        hidden_states.dim() >= 2
+        and hidden_states.shape[-2] * hidden_states.shape[-1] == flat_hidden
+    ):
+        token_shape = hidden_states.shape[:-2]
+        hidden_size = hidden_states.shape[-1]
+        grouped = hidden_states.reshape(-1, hidden_states.shape[-2], hidden_size)
+    else:
+        raise ValueError(
+            "hc_head hidden_states must have trailing shape "
+            f"({flat_hidden},) or (*, {flat_hidden}); got "
+            f"{tuple(hidden_states.shape)}"
+        )
+    if grouped.shape[1] != hc_mult:
+        raise ValueError(
+            f"hc_head grouped dimension must match hc_mult {hc_mult}, got "
+            f"{grouped.shape[1]}"
+        )
+    return grouped, token_shape, hidden_size
+
+
+def hc_head_musa(
+    hidden_states: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    dtype = hidden_states.dtype
+    grouped, token_shape, hidden_size = _reshape_hc_head_input(hidden_states, hc_fn)
+    grouped = grouped.to(torch.float32)
+    x = grouped.reshape(grouped.shape[0], -1)
+    rsqrt = torch.rsqrt(x.square().mean(-1, keepdim=True) + rms_norm_eps)
+    mixes = (x @ hc_fn.to(torch.float32).t()) * rsqrt
+    pre = (
+        torch.sigmoid(mixes * hc_scale.to(torch.float32) + hc_base.to(torch.float32))
+        + hc_eps
+    )
+    y = torch.sum(pre.unsqueeze(-1) * grouped, dim=1)
+    return y.reshape(*token_shape, hidden_size).to(dtype)
 
 
 def _select_mhc_pre_auto_impl(residual: torch.Tensor) -> str:
@@ -725,7 +883,16 @@ def mhc_post_musa(
     post_layer_mix: torch.Tensor,
     comb_res_mix: torch.Tensor,
 ) -> torch.Tensor:
-    impl = os.getenv("VLLM_MUSA_DEEPSEEK_V4_MHC_POST_IMPL", "tilelang").lower()
+    impl = os.getenv("VLLM_MUSA_DEEPSEEK_V4_MHC_POST_IMPL", "auto").lower()
+    if impl in {"auto", ""}:
+        try:
+            return _mhc_post_tilelang_provider(
+                x, residual, post_layer_mix, comb_res_mix
+            )
+        except (ImportError, OSError, NotImplementedError):
+            return mhc_post_torch_fallback(
+                x, residual, post_layer_mix, comb_res_mix
+            )
     if impl in {"tilelang", "jit", "native", "musa", "mu"}:
         return _mhc_post_tilelang_provider(x, residual, post_layer_mix, comb_res_mix)
     if impl in {"torch", "fallback"}:

--- a/vllm_musa/kernels/musa_ops.py
+++ b/vllm_musa/kernels/musa_ops.py
@@ -27,7 +27,11 @@ current_platform.import_kernels()
 
 def _has_C_rms_norm() -> bool:
     try:
-        return hasattr(torch.ops._C, "rms_norm")
+        if not hasattr(torch.ops._C, "rms_norm"):
+            return False
+        return torch._C._dispatch_has_kernel_for_dispatch_key(
+            "_C::rms_norm", "MUSA"
+        )
     except Exception:
         return False
 

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.quantization.utils.mxfp6_utils import dequant_mx
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import OCP_MX_Scheme
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Dynamic128Sym,
+    kFp8DynamicTensorSym,
     kFp8DynamicTokenSym,
     kFp8Static128BlockSym,
     kFp8StaticChannelSym,
@@ -102,6 +103,7 @@ def _supports_quant_scheme(
         (kFp8StaticChannelSym, kFp8DynamicTokenSym),
         (kFp8StaticTensorSym, kFp8DynamicTokenSym),
         (kFp8StaticTensorSym, kFp8StaticTensorSym),
+        (kFp8StaticTensorSym, kFp8DynamicTensorSym),
     ]
     return (weight_key, activation_key) in SUPPORTED_W_A
 
@@ -325,8 +327,25 @@ def _musa_fused_experts_impl_dispatch(*args, **kwargs) -> torch.Tensor:
 
 _upstream_fused_moe.fused_experts_impl = _musa_fused_experts_impl_dispatch
 
+
+def _patch_triton_experts_quant_scheme() -> None:
+    """Patch the Triton MoE expert class across vLLM fused-MoE layouts."""
+    try:
+        from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+            TritonExperts,
+        )
+    except ImportError:
+        TritonExperts = getattr(_upstream_fused_moe, "TritonExperts", None)
+
+    if TritonExperts is None:
+        logger.warning(
+            "Skipping MUSA TritonExperts quant-scheme patch: class not found."
+        )
+        return
+
+    TritonExperts._supports_quant_scheme = _supports_quant_scheme
+
+
 # The TritonExperts._supports_quant_scheme patch is independent; it expands
 # MUSA's supported FP8 quant key list and stays in place for upstream dispatch.
-vllm.model_executor.layers.fused_moe.fused_moe.TritonExperts._supports_quant_scheme = (
-    _supports_quant_scheme
-)
+_patch_triton_experts_quant_scheme()

--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -5,7 +5,14 @@ from vllm.model_executor.layers.fused_moe import (
     UnquantizedFusedMoEMethod,
     fused_experts,
 )
-from vllm.model_executor.layers.fused_moe.fused_batched_moe import BatchedTritonExperts
+try:
+    from vllm.model_executor.layers.fused_moe.experts.fused_batched_moe import (
+        BatchedTritonExperts,
+    )
+except ModuleNotFoundError:
+    from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
+        BatchedTritonExperts,
+    )
 from vllm.model_executor.layers.fused_moe.modular_kernel import (
     FusedMoEActivationFormat,
     FusedMoEExpertsModular,
@@ -64,6 +71,7 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         x: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
+        shared_experts: object | None = None,
         shared_experts_input: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         is_inplace = not is_torch_equal_or_newer("2.9")
@@ -79,6 +87,8 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             global_num_experts=layer.global_num_experts,
             expert_map=layer.expert_map,
+            shared_experts=shared_experts,
+            shared_experts_input=shared_experts_input,
         )
 
         return result

--- a/vllm_musa/model_executor/layers/layernorm.py
+++ b/vllm_musa/model_executor/layers/layernorm.py
@@ -3,7 +3,12 @@
 
 import torch
 import torch.nn as nn
-from vllm.model_executor.layers.layernorm import RMSNorm, fused_add_rms_norm
+from vllm.model_executor.layers.layernorm import RMSNorm
+
+try:
+    from vllm.model_executor.layers.layernorm import fused_add_rms_norm
+except ImportError:
+    fused_add_rms_norm = None
 
 from vllm_musa import _custom_ops as musa_ops
 from vllm_musa.utils.environ import envs
@@ -59,9 +64,11 @@ class MusaRMSNorm(RMSNorm):
                     x, residual, self.weight.data, self.variance_epsilon
                 )
                 return x, residual
-            return fused_add_rms_norm(
-                x, residual, self.weight.data, self.variance_epsilon
-            )
+            if fused_add_rms_norm is not None:
+                return fused_add_rms_norm(
+                    x, residual, self.weight.data, self.variance_epsilon
+                )
+            return self.forward_native(x, residual)
         else:
             out = nn.functional.rms_norm(
                 x, (self.hidden_size,), self.weight.data, self.variance_epsilon

--- a/vllm_musa/model_executor/layers/quantization/fp8.py
+++ b/vllm_musa/model_executor/layers/quantization/fp8.py
@@ -116,6 +116,7 @@ def apply(
     x: torch.Tensor,
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
+    shared_experts: object | None = None,
     shared_experts_input: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     if layer.ep_size != None and layer.ep_size <= 1:
@@ -146,6 +147,7 @@ def apply(
             global_num_experts=layer.global_num_experts,
             expert_map=layer.expert_map,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            shared_experts=shared_experts,
             shared_experts_input=shared_experts_input,
         )
 

--- a/vllm_musa/patches/vllm__model_executor__kernels__linear.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__kernels__linear.patch.py
@@ -27,7 +27,10 @@ _MUSA_FP8_FALLBACK = """    platform_kernels = possible_kernels.get(current_plat
                 MUSADeepGemmFp8BlockScaledMMKernel,
             )
 
-            platform_kernels = [MUSADeepGemmFp8BlockScaledMMKernel]
+            platform_kernels = [
+                MUSADeepGemmFp8BlockScaledMMKernel,
+                TritonFp8BlockScaledMMKernel,
+            ]
         elif possible_kernels is _POSSIBLE_FP8_KERNELS:
             from vllm_musa.model_executor.kernels.linear.scaled_mm.torch_scaled_mm import (
                 MUSAChannelWiseTorchFP8ScaledMMLinearKernel,
@@ -49,7 +52,73 @@ _MUSA_FP8_FALLBACK = """    platform_kernels = possible_kernels.get(current_plat
     for kernel in platform_kernels:
 """
 
+_OLD_MUSA_FP8_PLATFORM_KERNELS = """    platform_kernels = possible_kernels.get(current_platform._enum)
+    if platform_kernels is None and current_platform.is_musa():
+        if possible_kernels is _POSSIBLE_FP8_BLOCK_KERNELS:
+            from vllm_musa.model_executor.kernels.linear.scaled_mm.deep_gemm import (
+                MUSADeepGemmFp8BlockScaledMMKernel,
+            )
+
+            platform_kernels = [MUSADeepGemmFp8BlockScaledMMKernel]
+        elif possible_kernels is _POSSIBLE_FP8_KERNELS:
+            from vllm_musa.model_executor.kernels.linear.scaled_mm.torch_scaled_mm import (
+                MUSAChannelWiseTorchFP8ScaledMMLinearKernel,
+                MUSAPerTensorTorchFP8ScaledMMLinearKernel,
+            )
+
+            platform_kernels = [
+                MUSAPerTensorTorchFP8ScaledMMLinearKernel,
+                MUSAChannelWiseTorchFP8ScaledMMLinearKernel,
+            ]
+
+    if platform_kernels is None:
+        raise ValueError(
+            "Failed to find a kernel that can implement the "
+            "ScaledMM linear layer. No kernels are registered for "
+            f"platform {current_platform._enum.name}."
+        )
+"""
+
+_MUSA_FP8_PLATFORM_KERNELS = """    platform_kernels = possible_kernels.get(current_platform._enum)
+    if platform_kernels is None and current_platform.is_musa():
+        if possible_kernels is _POSSIBLE_FP8_BLOCK_KERNELS:
+            from vllm_musa.model_executor.kernels.linear.scaled_mm.deep_gemm import (
+                MUSADeepGemmFp8BlockScaledMMKernel,
+            )
+
+            platform_kernels = [
+                MUSADeepGemmFp8BlockScaledMMKernel,
+                TritonFp8BlockScaledMMKernel,
+            ]
+        elif possible_kernels is _POSSIBLE_FP8_KERNELS:
+            from vllm_musa.model_executor.kernels.linear.scaled_mm.torch_scaled_mm import (
+                MUSAChannelWiseTorchFP8ScaledMMLinearKernel,
+                MUSAPerTensorTorchFP8ScaledMMLinearKernel,
+            )
+
+            platform_kernels = [
+                MUSAPerTensorTorchFP8ScaledMMLinearKernel,
+                MUSAChannelWiseTorchFP8ScaledMMLinearKernel,
+            ]
+
+    if platform_kernels is None:
+        raise ValueError(
+            "Failed to find a kernel that can implement the "
+            "ScaledMM linear layer. No kernels are registered for "
+            f"platform {current_platform._enum.name}."
+        )
+"""
+
 PATCHES = [
+    (
+        """    platform_kernels = possible_kernels[current_platform._enum]
+""",
+        _MUSA_FP8_PLATFORM_KERNELS,
+    ),
+    (
+        _OLD_MUSA_FP8_PLATFORM_KERNELS,
+        _MUSA_FP8_PLATFORM_KERNELS,
+    ),
     (
         """    for kernel in possible_kernels[current_platform._enum]:
 """,

--- a/vllm_musa/patches/vllm__model_executor__layers__fused_moe__activation.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__layers__fused_moe__activation.patch.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA compatibility patch for v0.22 MoE activation helpers."""
+
+PATCHES = [
+    (
+        "        torch.ops._C.silu_and_mul(output, input)\n",
+        """        if input.device.type == "musa":
+            d = input.shape[-1] // 2
+            output.copy_(F.silu(input[..., :d]) * input[..., d:])
+        else:
+            torch.ops._C.silu_and_mul(output, input)
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__model_executor__layers__mhc.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__layers__mhc.patch.py
@@ -123,6 +123,48 @@ else:
         _MUSA_MHC_PRE_DISPATCH,
     ),
     (
+        """        return mhc_kernels.mhc_pre_torch(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+""",
+        """        if residual.device.type == "musa":
+            from vllm_musa.deepseek_v4_mhc import mhc_pre_musa_with_norm
+
+            return mhc_pre_musa_with_norm(
+                residual,
+                fn,
+                hc_scale,
+                hc_base,
+                rms_eps,
+                hc_pre_eps,
+                hc_sinkhorn_eps,
+                hc_post_mult_value,
+                sinkhorn_repeat,
+                norm_weight,
+                norm_eps,
+            )
+        return mhc_kernels.mhc_pre_torch(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+""",
+    ),
+    (
         """def mhc_post(
     x: torch.Tensor,
     residual: torch.Tensor,
@@ -153,6 +195,56 @@ else:
         return mhc_post_musa(x, residual, post_layer_mix, comb_res_mix)
 
     out = torch.empty_like(residual)
+""",
+    ),
+    (
+        """        return mhc_kernels.mhc_post_torch(
+            x,
+            residual,
+            post_layer_mix,
+            comb_res_mix,
+        )
+""",
+        """        if x.device.type == "musa":
+            from vllm_musa.deepseek_v4_mhc import mhc_post_musa
+
+            return mhc_post_musa(x, residual, post_layer_mix, comb_res_mix)
+        return mhc_kernels.mhc_post_torch(
+            x,
+            residual,
+            post_layer_mix,
+            comb_res_mix,
+        )
+""",
+    ),
+    (
+        """    def forward_native(self, *args, **kwargs):
+        raise NotImplementedError("Native implementation of hc_head is not available")
+""",
+        """    def forward_native(self, *args, **kwargs):
+        hidden_states = args[0] if args else kwargs.get("hidden_states")
+        if hidden_states is not None and hidden_states.device.type == "musa":
+            from vllm_musa.deepseek_v4_mhc import hc_head_musa
+
+            return hc_head_musa(*args, **kwargs)
+        raise NotImplementedError("Native implementation of hc_head is not available")
+""",
+    ),
+    (
+        """    def forward_native(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Native implementation of mhc_fused_post_pre is not available"
+        )
+""",
+        """    def forward_native(self, *args, **kwargs):
+        x = args[0] if args else kwargs.get("x")
+        if x is not None and x.device.type == "musa":
+            from vllm_musa.deepseek_v4_mhc import mhc_fused_post_pre_musa
+
+            return mhc_fused_post_pre_musa(*args, **kwargs)
+        raise NotImplementedError(
+            "Native implementation of mhc_fused_post_pre is not available"
+        )
 """,
     ),
 ]

--- a/vllm_musa/patches/vllm__models__deepseek_v4__attention.patch.py
+++ b/vllm_musa/patches/vllm__models__deepseek_v4__attention.patch.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Patch vLLM v0.22 DeepSeek-V4 attention FP8 einsum for MUSA."""
+
+PATCHES = [
+    (
+        """logger = init_logger(__name__)
+""",
+        """logger = init_logger(__name__)
+
+
+def _musa_deepseek_v4_mm_out_dtype(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    if (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or a.device.type == "musa"
+        or b.device.type == "musa"
+    ):
+        return torch.mm(a.to(out_dtype), b.to(out_dtype))
+    return torch.mm(a, b, out_dtype=out_dtype)
+
+
+def _musa_deepseek_v4_is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or getattr(tensor.device, "type", None) == "musa"
+    )
+
+
+def _musa_deepseek_v4_qnorm_rope_kv_insert(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    padded_heads: int,
+    eps: float,
+    block_size: int,
+) -> torch.Tensor:
+    from vllm_musa import _custom_ops as _musa_custom_ops
+
+    active_slot_mapping = slot_mapping
+    if slot_mapping.shape[0] > q.shape[0]:
+        active_slot_mapping = slot_mapping[: q.shape[0]].contiguous()
+
+    _musa_custom_ops.deepseek_v4_qnorm_rope_kv_insert(
+        q,
+        kv,
+        kv_cache,
+        active_slot_mapping,
+        positions.contiguous(),
+        cos_sin_cache,
+        eps,
+        block_size,
+    )
+    if q.shape[1] < padded_heads:
+        return F.pad(q, (0, 0, 0, padded_heads - q.shape[1]), value=0.0)
+    return q
+""",
+    ),
+    (
+        """def deepseek_v4_fp8_einsum(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+    recipe: list[int],
+) -> None:
+    fp8_einsum(equation, (a, a_scale), (b, b_scale), out, recipe=tuple(recipe))
+""",
+        """def deepseek_v4_fp8_einsum(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+    recipe: list[int],
+) -> None:
+    if (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or a.device.type == "musa"
+        or out.device.type == "musa"
+    ):
+        try:
+            from vllm_musa.deepseek_v4_jit.fp8_einsum import (
+                try_musa_deepseek_v4_fp8_einsum,
+            )
+
+            handled, reason = try_musa_deepseek_v4_fp8_einsum(
+                a, a_scale, b, b_scale, out, equation
+            )
+        except Exception as exc:
+            handled = False
+            reason = f"{type(exc).__name__}: {exc}"
+        if handled:
+            logger.warning_once(
+                "Using MUSA DeepSeek-V4 FP8 einsum provider: %s.",
+                reason,
+            )
+            return
+        raise NotImplementedError(
+            "MUSA DeepSeek-V4 FP8 einsum could not use a supported local "
+            f"provider for {equation!r}; upstream DeepGEMM fp8_einsum is "
+            f"not available in the MUSA runtime. Reason: {reason}"
+        )
+    fp8_einsum(equation, (a, a_scale), (b, b_scale), out, recipe=tuple(recipe))
+""",
+    ),
+    (
+        """                return torch.mm(
+                    hidden_states,
+                    compressor.fused_wkv_wgate.weight.T,
+                    out_dtype=torch.float32,
+                )
+""",
+        """                return _musa_deepseek_v4_mm_out_dtype(
+                    hidden_states,
+                    compressor.fused_wkv_wgate.weight.T,
+                    torch.float32,
+                )
+""",
+    ),
+    (
+        """                return torch.mm(
+                    hidden_states,
+                    indexer.compressor.fused_wkv_wgate.weight.T,
+                    out_dtype=torch.float32,
+                )
+""",
+        """                return _musa_deepseek_v4_mm_out_dtype(
+                    hidden_states,
+                    indexer.compressor.fused_wkv_wgate.weight.T,
+                    torch.float32,
+                )
+""",
+    ),
+    (
+        """        return torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
+            q,
+            kv,
+            swa_kv_cache_2d,
+            swa_metadata.slot_mapping,
+            positions.to(torch.int64),
+            self.rotary_emb.cos_sin_cache,
+            self.padded_heads,
+            self.eps,
+            swa_metadata.block_size,
+        )
+""",
+        """        if _musa_deepseek_v4_is_musa_tensor(q):
+            return _musa_deepseek_v4_qnorm_rope_kv_insert(
+                q,
+                kv,
+                swa_kv_cache,
+                swa_metadata.slot_mapping,
+                positions.to(torch.int64),
+                self.rotary_emb.cos_sin_cache,
+                self.padded_heads,
+                self.eps,
+                swa_metadata.block_size,
+            )
+
+        return torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
+            q,
+            kv,
+            swa_kv_cache_2d,
+            swa_metadata.slot_mapping,
+            positions.to(torch.int64),
+            self.rotary_emb.cos_sin_cache,
+            self.padded_heads,
+            self.eps,
+            swa_metadata.block_size,
+        )
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__models__deepseek_v4__common__ops__fused_inv_rope_fp8_quant.patch.py
+++ b/vllm_musa/patches/vllm__models__deepseek_v4__common__ops__fused_inv_rope_fp8_quant.patch.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Patch vLLM v0.22 DeepSeek-V4 inverse-RoPE FP8 quantization for MUSA."""
+
+PATCHES = [
+    (
+        """import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+""",
+        """import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def _musa_deepseek_v4_is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or getattr(tensor.device, "type", None) == "musa"
+    )
+""",
+    ),
+    (
+        """    from vllm.utils.deep_gemm import get_tma_aligned_size
+
+    num_tokens, num_heads, head_dim = o.shape
+""",
+        """    if _musa_deepseek_v4_is_musa_tensor(o):
+        from vllm_musa import _custom_ops as _musa_custom_ops
+
+        return _musa_custom_ops.deepseek_v4_fused_inv_rope_fp8_quant(
+            o,
+            positions,
+            cos_sin_cache,
+            n_groups,
+            heads_per_group,
+            nope_dim,
+            rope_dim,
+            quant_group_size,
+            tma_aligned_scales,
+        )
+
+    from vllm.utils.deep_gemm import get_tma_aligned_size
+
+    num_tokens, num_heads, head_dim = o.shape
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__models__deepseek_v4__nvidia__flashmla.patch.py
+++ b/vllm_musa/patches/vllm__models__deepseek_v4__nvidia__flashmla.patch.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Patch vLLM v0.22 DeepSeek-V4 FlashMLA imports for MUSA."""
+
+PATCHES = [
+    (
+        """from vllm.v1.attention.ops.flashmla import (
+    flash_mla_sparse_fwd,
+    flash_mla_with_kvcache,
+)
+""",
+        """from vllm_musa.v1.attention.ops.flashmla import (
+    flash_mla_sparse_fwd,
+    flash_mla_with_kvcache,
+)
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__models__deepseek_v4__nvidia__model.patch.py
+++ b/vllm_musa/patches/vllm__models__deepseek_v4__nvidia__model.patch.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Patch vLLM v0.22 DeepSeek-V4 NVIDIA model gates for MUSA."""
+
+PATCHES = [
+    (
+        """        if layer is not None and current_platform.is_cuda():
+            hidden_states = layer.hc_post(hidden_states, residual, post_mix, res_mix)
+""",
+        """        if layer is not None and (
+            current_platform.is_cuda() or current_platform.is_musa()
+        ):
+            hidden_states = layer.hc_post(hidden_states, residual, post_mix, res_mix)
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__triton_utils__jit_monitor.patch.py
+++ b/vllm_musa/patches/vllm__triton_utils__jit_monitor.patch.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA Triton compatibility patch for v0.22 JIT monitor."""
+
+PATCHES = [
+    (
+        "    from triton import knobs  # type: ignore[import-untyped]\n",
+        """    try:
+        from triton import knobs  # type: ignore[import-untyped]
+    except ImportError:
+        logger.debug("Triton knobs API is unavailable; skipping JIT monitor setup.")
+        return
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__v1__worker__gpu__block_table.patch.py
+++ b/vllm_musa/patches/vllm__v1__worker__gpu__block_table.patch.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA Triton compatibility patch for v0.22 block table kernels.
+
+MUSA Triton rejects ``tl.pointer_type(elem_dtype)`` when the dtype is threaded
+through a helper argument. The v0.22 block-table kernels only use int32 pointer
+loads, so specialize the helper instead of carrying the dtype parameter.
+"""
+
+
+def normalize_source(source: str) -> str:
+    return source.replace(
+        "def _load_ptr(ptr_to_ptr, elem_dtype: tl.constexpr):",
+        "def _load_ptr(ptr_to_ptr, elem_dtype):",
+    )
+
+
+PATCHES = [
+    (
+        "dst_block_table_ptr = _load_ptr(dst_block_table_ptrs + group_id, tl.int32)",
+        "dst_block_table_ptr = _load_int32_ptr(dst_block_table_ptrs + group_id)",
+    ),
+    (
+        "src_block_table_ptr = _load_ptr(src_block_table_ptrs + group_id, tl.int32)",
+        "src_block_table_ptr = _load_int32_ptr(src_block_table_ptrs + group_id)",
+    ),
+    (
+        "block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)",
+        "block_table_ptr = _load_int32_ptr(block_table_ptrs + group_id)",
+    ),
+    (
+        """@triton.jit
+def _load_ptr(ptr_to_ptr, elem_dtype):
+    ptr = tl.load(ptr_to_ptr)
+    ptr = tl.cast(ptr, tl.pointer_type(elem_dtype))
+    return tl.multiple_of(ptr, 16)
+""",
+        """@triton.jit
+def _load_int32_ptr(ptr_to_ptr):
+    ptr = tl.load(ptr_to_ptr)
+    ptr = ptr.to(tl.pointer_type(tl.int32))
+    return tl.multiple_of(ptr, 16)
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__v1__worker__gpu__sample__penalties.patch.py
+++ b/vllm_musa/patches/vllm__v1__worker__gpu__sample__penalties.patch.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA Triton compatibility patch for v0.22 worker penalties."""
+
+PATCHES = [
+    (
+        "    use_penalty = use_rep_penalty or use_freq_penalty or use_pres_penalty\n",
+        "    use_penalty = (use_rep_penalty or use_freq_penalty) or use_pres_penalty\n",
+    ),
+]

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -215,15 +215,18 @@ def register_attention_backends() -> None:
             "MUSATurboQuantAttentionBackend"
         ),
     )
-    # MUSA-0094: tree drafting via a MUSA-routed TreeAttention backend
-    # (Triton unified_attention is already MUSA-patched; reshape_and_cache_flash
-    # is wired through fa_utils.reshape_and_cache_flash).
-    register_backend(
-        AttentionBackendEnum.TREE_ATTN,
-        class_path=(
-            "vllm_musa.v1.attention.backends.tree_attn.MUSATreeAttentionBackend"
-        ),
-    )
+    tree_attn_backend = getattr(AttentionBackendEnum, "TREE_ATTN", None)
+    if tree_attn_backend is not None:
+        # MUSA-0094: tree drafting via a MUSA-routed TreeAttention backend
+        # (Triton unified_attention is already MUSA-patched; reshape_and_cache_flash
+        # is wired through fa_utils.reshape_and_cache_flash). v0.22 removed this
+        # enum member, so only register it on older upstream snapshots.
+        register_backend(
+            tree_attn_backend,
+            class_path=(
+                "vllm_musa.v1.attention.backends.tree_attn.MUSATreeAttentionBackend"
+            ),
+        )
 
 
 class MUSAPlatformBase(Platform):
@@ -256,6 +259,15 @@ class MUSAPlatformBase(Platform):
         return True
 
     @classmethod
+    def import_kernels(cls) -> None:
+        """Import upstream vLLM kernels, including v0.22 stable ABI ops."""
+        super().import_kernels()
+        try:
+            import vllm._C_stable_libtorch  # noqa: F401
+        except ImportError as e:
+            logger.warning("Failed to import from vllm._C_stable_libtorch: %r", e)
+
+    @classmethod
     def import_ir_kernels(cls) -> None:
         """Import upstream and MUSA-OOT IR-op providers.
 
@@ -284,7 +296,7 @@ class MUSAPlatformBase(Platform):
         """Platform-default priority list for vllm.ir.ops on MUSA.
 
         When compiling with Inductor, prefer the `native` (pure-PyTorch)
-        IR impl; in the eager path, prefer the `musa` kernel provider.
+        IR impl; in the eager path, prefer the `musa` rms_norm provider.
         This mirrors the upstream `cuda.py` pattern
         (`default = ["native"] if using_inductor else ["vllm_c", "native"]`):
         under Inductor the native rms_norm is a handful of
@@ -318,8 +330,11 @@ class MUSAPlatformBase(Platform):
             default = ["native"]
             rms_norm = ["native"]
         else:
-            # Eager path: no Inductor fusion to lose, so take the kernel.
-            default = ["musa", "native"]
+            # Eager path: no Inductor fusion to lose, so take the rms_norm
+            # kernel. Keep the default native because v0.22 adds
+            # fused_add_rms_norm and MUSA has not registered an IR provider
+            # for that op.
+            default = ["native"]
             rms_norm = ["musa", "native"]
         return IrOpPriorityConfig.with_default(default, rms_norm=rms_norm)
 

--- a/vllm_musa/v1/attention/backends/mla/common.py
+++ b/vllm_musa/v1/attention/backends/mla/common.py
@@ -13,9 +13,8 @@ from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import get_current_vllm_config
 from vllm.distributed.parallel_state import get_dcp_group, is_global_first_rank
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention import mla_attention as _mla_attention
 from vllm.model_executor.layers.attention.mla_attention import (
-    CudnnPrefillMetadata,
-    FlashInferPrefillMetadata,
     MLAAttentionImpl,
     MLACommonMetadata,
     MLACommonMetadataBuilder,
@@ -23,9 +22,6 @@ from vllm.model_executor.layers.attention.mla_attention import (
     dynamic_per_batched_tensor_quant,
     has_flashinfer,
     reorg_kvcache,
-    use_cudnn_prefill,
-    use_flashinfer_prefill,
-    use_trtllm_ragged_deepseek_prefill,
 )
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -63,6 +59,94 @@ logger = init_logger(__name__)
 
 M = TypeVar("M", bound=MLACommonMetadata)
 A = TypeVar("A")
+
+CudnnPrefillMetadata = getattr(
+    _mla_attention, "CudnnPrefillMetadata", MLACommonPrefillMetadata
+)
+FlashInferPrefillMetadata = getattr(
+    _mla_attention, "FlashInferPrefillMetadata", MLACommonPrefillMetadata
+)
+
+
+def _disabled_prefill_backend() -> bool:
+    return False
+
+
+use_cudnn_prefill = getattr(
+    _mla_attention, "use_cudnn_prefill", _disabled_prefill_backend
+)
+use_flashinfer_prefill = getattr(
+    _mla_attention, "use_flashinfer_prefill", _disabled_prefill_backend
+)
+use_trtllm_ragged_deepseek_prefill = getattr(
+    _mla_attention, "use_trtllm_ragged_deepseek_prefill", _disabled_prefill_backend
+)
+
+
+class MUSAMLAPrefillBackend:
+    """Compatibility backend for vLLM v0.22 MLA prefill selection.
+
+    MUSA keeps the prefill execution in this module's MLACommonImpl because
+    mate's FlashAttention interface differs from upstream CUDA FA. v0.22 still
+    requires MLAAttention to own a prefill_backend object, so provide a backend
+    that participates in metadata construction while execution remains here.
+    """
+
+    supported_dtypes = [torch.float16, torch.bfloat16]
+    requires_r1_mla_dimensions = False
+
+    def __init__(
+        self,
+        num_heads: int,
+        scale: float,
+        kv_lora_rank: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        vllm_config,
+    ) -> None:
+        self.num_heads = num_heads
+        self.scale = scale
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.vllm_config = vllm_config
+
+    @staticmethod
+    def get_name() -> str:
+        return "FLASH_ATTN"
+
+    @classmethod
+    def supports_compute_capability(cls, device_capability) -> bool:
+        return True
+
+    @classmethod
+    def supports_dtype(cls, dtype: torch.dtype) -> bool:
+        return dtype in cls.supported_dtypes
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return True
+
+    @classmethod
+    def validate_configuration(cls, device_capability, selector_config) -> list[str]:
+        if not cls.supports_dtype(selector_config.dtype):
+            return [f"dtype {selector_config.dtype} not supported"]
+        return []
+
+    def prepare_metadata(self, prefill_metadata: MLACommonPrefillMetadata) -> None:
+        self._prefill_metadata = prefill_metadata
+
+    def run_prefill_new_tokens(self, *args, **kwargs):
+        raise RuntimeError("MUSA MLA prefill is executed by MLACommonImpl")
+
+    def run_prefill_context_chunk(self, *args, **kwargs):
+        raise RuntimeError("MUSA MLA prefill is executed by MLACommonImpl")
+
+
+def _get_musa_mla_prefill_backend(vllm_config):
+    return MUSAMLAPrefillBackend
 
 
 def _v_up_proj(self, x: torch.Tensor, out: torch.Tensor):
@@ -799,6 +883,17 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
 
 
 import vllm.model_executor.layers.attention.mla_attention
+import vllm.v1.attention.backends.mla.prefill
+import vllm.v1.attention.backends.mla.prefill.selector
 
 vllm.model_executor.layers.attention.mla_attention.MLAAttention._v_up_proj = _v_up_proj
 vllm.model_executor.layers.attention.mla_attention.MLACommonImpl = MLACommonImpl
+vllm.model_executor.layers.attention.mla_attention.get_mla_prefill_backend = (
+    _get_musa_mla_prefill_backend
+)
+vllm.v1.attention.backends.mla.prefill.get_mla_prefill_backend = (
+    _get_musa_mla_prefill_backend
+)
+vllm.v1.attention.backends.mla.prefill.selector.get_mla_prefill_backend = (
+    _get_musa_mla_prefill_backend
+)

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -435,7 +435,6 @@ def _apply_worker_sampling_params_defer_filters(
         idx_mapping_np,
         input_ids,
         expanded_local_pos,
-        sampler.num_speculative_tokens,
     )
     sampler.bad_words_state.apply_bad_words(
         logits,


### PR DESCRIPTION
## Motivation
Adapt vllm-musa to vllm v0.22.0

## Modifications
- Upgrade vllm-musa adaptation to vLLM v0.22.0, including setup/build dependency updates and platform compatibility fixes.                                     
  - Add and update MUSA patch coverage for vLLM v0.22 paths, especially DeepSeek-V4, MHC, MLA attention, FP8 quantization, fused MoE, linear kernels, and v1
  worker sampling/block-table paths.
  - Add DeepSeek-V4 MUSA helpers and tests to validate patch discovery and v0.22-specific behavior.
  - Fix MUSA runtime compatibility issues around FP8 MoE shared experts, dflash/custom-op fallbacks, layernorm/kernel wrappers, and DeepSeek-V4 request path
  execution.

## Test

Smoke tests:

Qwen3-8B
Qwen3-8B-FP8
Qwen3-30B-A3B-Instruct-2507
DeepSeek-V2-Lite