### PR TITLE
Fix MUSA shared-expert MoE correctness and FlashMLA sched metadata

### DIFF
--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -5,6 +5,7 @@ from vllm.model_executor.layers.fused_moe import (
     UnquantizedFusedMoEMethod,
     fused_experts,
 )
+
 try:
     from vllm.model_executor.layers.fused_moe.experts.fused_batched_moe import (
         BatchedTritonExperts,
@@ -13,6 +14,7 @@ except ModuleNotFoundError:
     from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
         BatchedTritonExperts,
     )
+
 from vllm.model_executor.layers.fused_moe.modular_kernel import (
     FusedMoEActivationFormat,
     FusedMoEExpertsModular,
@@ -74,8 +76,14 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         shared_experts: object | None = None,
         shared_experts_input: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        is_inplace = not is_torch_equal_or_newer("2.9")
-        result = fused_experts(
+        # MUSA-3171: vLLM v0.22 passes shared experts through the MoE runner,
+        # but the legacy fused_experts() helper only computes routed experts and
+        # does not accept shared_experts kwargs. Return routed output here; the
+        # runner computes and combines shared experts for non-overlapped MUSA
+        # paths. Keep inplace disabled when shared experts exist so this legacy
+        # op never mutates an input that another path may still consume.
+        is_inplace = (not is_torch_equal_or_newer("2.9")) and shared_experts is None
+        return fused_experts(
             hidden_states=x,
             w1=layer.w13_weight,
             w2=layer.w2_weight,
@@ -87,8 +95,4 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             global_num_experts=layer.global_num_experts,
             expert_map=layer.expert_map,
-            shared_experts=shared_experts,
-            shared_experts_input=shared_experts_input,
         )
-
-        return result

--- a/vllm_musa/model_executor/layers/quantization/fp8.py
+++ b/vllm_musa/model_executor/layers/quantization/fp8.py
@@ -120,8 +120,18 @@ def apply(
     shared_experts_input: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     if layer.ep_size != None and layer.ep_size <= 1:
-        is_inplace = not is_torch_equal_or_newer("2.9")
-        return fused_experts(
+        # MUSA-3173: the legacy fused_experts() path only computes routed
+        # experts. For the no-overlap path used by DeepSeek-V2/V3 on MUSA, the
+        # MoE runner computes shared experts separately and combines them with
+        # this routed output. Only compute shared experts here when the runner
+        # explicitly delegated them to the quant method via MK overlap.
+        run_shared_in_quant_method = (
+            shared_experts is not None and self.mk_can_overlap_shared_experts
+        )
+        if run_shared_in_quant_method:
+            se_input = shared_experts_input if shared_experts_input is not None else x
+        is_inplace = (not is_torch_equal_or_newer("2.9")) and shared_experts is None
+        routed = fused_experts(
             hidden_states=x,
             w1=layer.w13_weight,
             w2=layer.w2_weight,
@@ -134,6 +144,9 @@ def apply(
             expert_map=layer.expert_map,
             quant_config=self.moe_quant_config,
         )
+        if not run_shared_in_quant_method:
+            return routed
+        return routed + shared_experts._layer(se_input)
     else:
         assert not self.is_monolithic
         assert self.moe_kernel is not None

--- a/vllm_musa/v1/attention/backends/mla/flashmla.py
+++ b/vllm_musa/v1/attention/backends/mla/flashmla.py
@@ -159,12 +159,20 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
         # we use the max but all should be the same due to uniform length requirement
         max_query_len = query_lens_cpu.max().item()
         num_q_tokens_per_head_k = max_query_len * self.num_q_heads // 1
-        tile_scheduler_metadata, num_splits = get_mla_metadata(
+        scheduler_metadata, _ = get_mla_metadata(
             seq_lens_device,
             num_q_tokens_per_head_k,
             1,  # MQA for the decode path
             is_fp8_kvcache=self.is_fp8_kvcache,
         )
+
+        # MUSA FlashMLA returns a FlashMLASchedMeta holder. Keep that holder as
+        # the public scheduler metadata and only swap its internal tensors when
+        # full cudagraphs need persistent buffers.
+        tile_scheduler_metadata = scheduler_metadata.tile_scheduler_metadata
+        num_splits = scheduler_metadata.num_splits
+        if tile_scheduler_metadata is None or num_splits is None:
+            raise RuntimeError("FlashMLA decode metadata was not initialized.")
 
         # TODO: we can disambiguate between decode and mixed-prefill decode here
         # so we can only use the persistent buffer if a cudagraph is actually
@@ -181,6 +189,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
             ]
             tile_scheduler_metadata_view.copy_(tile_scheduler_metadata)
             tile_scheduler_metadata = tile_scheduler_metadata_view
+            scheduler_metadata.tile_scheduler_metadata = tile_scheduler_metadata
 
             # Num splits is per-batch, varying size (batch_size,)
             n = num_splits.size(0)
@@ -194,10 +203,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
             self.cg_buf_num_splits[n:].fill_(num_splits[-1])
             num_splits = num_splits_view
 
-        scheduler_metadata = FlashMLASchedMeta(
-            tile_scheduler_metadata=tile_scheduler_metadata,
-            num_splits=num_splits,
-        )
+            scheduler_metadata.num_splits = num_splits
         return FlashMLADecodeMetadata(
             block_table=block_table_tensor,
             seq_lens=seq_lens_device,
@@ -275,10 +281,8 @@ class FlashMLAImpl(MLACommonImpl[FlashMLAMetadata]):
 
         num_decodes = attn_metadata.num_decodes
         q = reshape_query_for_spec_decode(q, num_decodes)
-        tile_scheduler_metadata = (
-            attn_metadata.decode.scheduler_metadata.tile_scheduler_metadata
-        )
-        num_splits = attn_metadata.decode.scheduler_metadata.num_splits
+        scheduler_metadata = attn_metadata.decode.scheduler_metadata
+
         if envs.VLLM_BATCH_INVARIANT:
             device = q.device
             dtype = torch.int32
@@ -306,14 +310,17 @@ class FlashMLAImpl(MLACommonImpl[FlashMLAMetadata]):
             # Non-split path ignores num_splits, but the API requires it:
             # zeros of length B+1
             num_splits = torch.zeros((B + 1,), dtype=dtype, device=device)
+            scheduler_metadata = FlashMLASchedMeta(
+                tile_scheduler_metadata=tile_scheduler_metadata,
+                num_splits=num_splits,
+            )
         o, lse = flash_mla_with_kvcache(
             q=q,
             k_cache=kv_c_and_k_pe_cache.unsqueeze(-2),  # Add head dim of 1
             block_table=attn_metadata.decode.block_table,
             cache_seqlens=attn_metadata.decode.seq_lens,
             head_dim_v=self.kv_lora_rank,
-            tile_scheduler_metadata=tile_scheduler_metadata,
-            num_splits=num_splits,
+            tile_scheduler_metadata=scheduler_metadata,
             softmax_scale=self.scale,
             causal=True,
         )

--- a/vllm_musa/v1/attention/ops/flashmla.py
+++ b/vllm_musa/v1/attention/ops/flashmla.py
@@ -90,6 +90,21 @@ def is_flashmla_sparse_supported() -> tuple[bool, str | None]:
     return True, None
 
 
+def _coerce_flashmla_sched_meta(
+    tile_scheduler_metadata: FlashMLASchedMeta | torch.Tensor,
+    num_splits: torch.Tensor | None,
+) -> FlashMLASchedMeta:
+    if isinstance(tile_scheduler_metadata, FlashMLASchedMeta):
+        if num_splits is not None:
+            tile_scheduler_metadata.num_splits = num_splits
+        return tile_scheduler_metadata
+
+    return FlashMLASchedMeta(
+        tile_scheduler_metadata=tile_scheduler_metadata,
+        num_splits=num_splits,
+    )
+
+
 def get_mla_metadata(*args, **kwargs):
     flash_mla = _require_flashmla()
     return flash_mla.get_mla_metadata(*args, **kwargs)
@@ -128,7 +143,7 @@ def flash_mla_with_kvcache(
     block_table: torch.Tensor | None,
     cache_seqlens: torch.Tensor | None,
     head_dim_v: int,
-    tile_scheduler_metadata: FlashMLASchedMeta,
+    tile_scheduler_metadata: FlashMLASchedMeta | torch.Tensor,
     num_splits: torch.Tensor | None = None,
     softmax_scale: float | None = None,
     causal: bool = False,
@@ -142,14 +157,17 @@ def flash_mla_with_kvcache(
     out: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     flash_mla = _require_flashmla()
+    scheduler_metadata = _coerce_flashmla_sched_meta(
+        tile_scheduler_metadata, num_splits
+    )
     result, softmax_lse = flash_mla.flash_mla_with_kvcache(
         q=q,
         k_cache=k_cache,
         block_table=block_table,
         cache_seqlens=cache_seqlens,
         head_dim_v=head_dim_v,
-        tile_scheduler_metadata=tile_scheduler_metadata,
-        num_splits=num_splits,
+        tile_scheduler_metadata=scheduler_metadata,
+        num_splits=None,
         softmax_scale=softmax_scale,
         causal=causal,
         is_fp8_kvcache=is_fp8_kvcache,
@@ -173,12 +191,18 @@ def get_mla_metadata_dense_fp8(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if _flash_mla is None:
         _raise_flashmla_unavailable()
-    return get_mla_metadata(
+    scheduler_metadata, _ = get_mla_metadata(
         cache_seqlens,
         num_q_tokens_per_head_k,
         num_heads_k,
         is_fp8_kvcache=True,
     )
+    if (
+        scheduler_metadata.tile_scheduler_metadata is None
+        or scheduler_metadata.num_splits is None
+    ):
+        raise RuntimeError("FlashMLA FP8 decode metadata was not initialized.")
+    return scheduler_metadata.tile_scheduler_metadata, scheduler_metadata.num_splits
 
 
 def flash_mla_with_kvcache_fp8(


### PR DESCRIPTION
1. Fix legacy MoE with shared experts
    Removed invalid shared_experts kwargs from fused_experts() calls
    Excluded shared expert handling in fp8.py no-overlap path (delegated to MoERunner)
    Disabled inplace mutation when shared experts exist to avoid input corruption
2. Fix FlashMLA metadata type mismatch
    Preserve FlashMLASchedMeta object instead of treating as tensor
    Added compatibility wrapper for older tensor-based callers