### PR TITLE
Adapt DeepSeek-V4-Flash-Base for vLLM v0.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 dependencies = [
     "torch",
     "torch_musa",
-    "torchada>=0.1.52",
-    "mate>=0.2.0",
+    "torchada>=0.1.57",
+    "mate>=0.2.1",
     "flash_attn_3>=0.1.4",
     "mthreads-ml-py>=2.2.11",
     "numpy<2.0",

--- a/tests/test_deepseek_v4_mhc.py
+++ b/tests/test_deepseek_v4_mhc.py
@@ -2,13 +2,59 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Source-level checks for DeepSeek-V4 MHC MUSA dispatch."""
 
+import ast
 from pathlib import Path
+from typing import Optional
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _read(path: str) -> str:
     return (REPO_ROOT / path).read_text()
+
+
+def _function_node(tree: ast.AST, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name!r} not found")
+
+
+def _call_name(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _call_name(node.value)
+        if base:
+            return f"{base}.{node.attr}"
+        return node.attr
+    return None
+
+
+def _calls(node: ast.AST, name: str) -> bool:
+    return any(
+        isinstance(child, ast.Call) and _call_name(child.func) == name
+        for child in ast.walk(node)
+    )
+
+
+def _loads_name(node: ast.AST, name: str) -> bool:
+    return any(
+        isinstance(child, ast.Name)
+        and child.id == name
+        and isinstance(child.ctx, ast.Load)
+        for child in ast.walk(node)
+    )
+
+
+def _stores_subscript(node: ast.AST, name: str) -> bool:
+    return any(
+        isinstance(child, ast.Subscript)
+        and isinstance(child.value, ast.Name)
+        and child.value.id == name
+        and isinstance(child.ctx, ast.Store)
+        for child in ast.walk(node)
+    )
 
 
 def test_mhc_pre_defaults_to_auto_provider():
@@ -83,12 +129,30 @@ def test_mhc_pre_deepgemm_big_fuse_is_default_off():
 
 def test_mhc_fused_post_pre_composes_musa_post_pre_and_norm():
     source = _read("vllm_musa/deepseek_v4_mhc.py")
+    kernels = _read("vllm_musa/deepseek_v4_jit/tilelang_kernels.py")
+    source_tree = ast.parse(source)
+    kernels_tree = ast.parse(kernels)
+    apply_norm = _function_node(source_tree, "_apply_optional_rms_norm")
+    weighted_norm = _function_node(source_tree, "_try_mhc_weighted_rms_norm_musa")
+    kernel_factory = _function_node(kernels_tree, "mhc_weighted_rmsnorm_kernel")
+    inner_kernel = _function_node(kernel_factory, "_kernel")
 
     assert "def mhc_fused_post_pre_musa(" in source
     assert "residual_cur = mhc_post_musa(" in source
     assert "post_mix_cur, comb_mix_cur, layer_input_cur = mhc_pre_musa(" in source
     assert "def _apply_optional_rms_norm(" in source
-    assert "norm_weight.to(torch.float32)" in source
+    assert "def _try_mhc_weighted_rms_norm_musa(" in source
+    assert "VLLM_MUSA_DEEPSEEK_V4_MHC_WEIGHTED_RMSNORM_IMPL" in source
+    assert "def mhc_weighted_rmsnorm_kernel(" in kernels
+    assert _calls(apply_norm, "_try_mhc_weighted_rms_norm_musa")
+    assert _loads_name(apply_norm, "norm_weight")
+    assert _calls(weighted_norm, "mhc_weighted_rmsnorm_kernel")
+    assert _calls(kernel_factory, "T.rsqrt")
+    kernel_args = [arg.arg for arg in inner_kernel.args.args]
+    assert len(kernel_args) == 4
+    _, weight_arg, out_arg, _ = kernel_args
+    assert _loads_name(inner_kernel, weight_arg)
+    assert _stores_subscript(inner_kernel, out_arg)
 
 
 def test_mhc_auto_paths_fall_back_when_tilelang_is_unavailable():

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -111,6 +111,23 @@ class TestDeepSeekV4V022Patches:
 
         assert "vllm.models.deepseek_v4.attention" in modules
 
+    def test_save_partial_states_patch_is_discoverable(self):
+        from vllm_musa.patches import _get_patch_files
+
+        modules = {module_name for module_name, _ in _get_patch_files()}
+
+        assert "vllm.models.deepseek_v4.common.ops.save_partial_states" in modules
+
+    def test_fused_compress_quant_cache_patch_is_discoverable(self):
+        from vllm_musa.patches import _get_patch_files
+
+        modules = {module_name for module_name, _ in _get_patch_files()}
+
+        assert (
+            "vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache"
+            in modules
+        )
+
     def test_nvidia_model_patch_is_discoverable(self):
         from vllm_musa.patches import _get_patch_files
 
@@ -135,6 +152,55 @@ class TestDeepSeekV4V022Patches:
                 break
         else:
             raise AssertionError("DeepSeek-V4 v0.22 attention patch was not found")
+
+    def test_save_partial_states_patch_strips_launch_pdl_on_musa(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        for module_name, patch_path in _get_patch_files():
+            if module_name == "vllm.models.deepseek_v4.common.ops.save_partial_states":
+                patches = _load_patch_config(patch_path)
+                old_source = "\n".join(old for old, _ in patches)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "**(pdl_kwargs or {})" in old_source
+                assert "_musa_deepseek_v4_save_partial_pdl_kwargs" in new_source
+                assert "current_platform.is_musa()" in new_source
+                assert 'getattr(torch.version, "musa", None)' in new_source
+                assert 'getattr(tensor.device, "type", None) == "musa"' in new_source
+                assert 'active_pdl_kwargs.pop("launch_pdl", None)' in new_source
+                break
+        else:
+            raise AssertionError(
+                "DeepSeek-V4 v0.22 save_partial_states patch was not found"
+            )
+
+    def test_fused_compress_quant_cache_patch_strips_launch_pdl_on_musa(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        for module_name, patch_path in _get_patch_files():
+            if (
+                module_name
+                == "vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache"
+            ):
+                patches = _load_patch_config(patch_path)
+                old_source = "\n".join(old for old, _ in patches)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "**pdl_kwargs" in old_source
+                assert "_musa_deepseek_v4_compress_cache_pdl_kwargs" in new_source
+                assert "current_platform.is_musa()" in new_source
+                assert 'getattr(torch.version, "musa", None)' in new_source
+                assert 'getattr(tensor.device, "type", None) == "musa"' in new_source
+                assert 'active_pdl_kwargs.pop("launch_pdl", None)' in new_source
+                assert "tl.softmax(score, dim=0)" in old_source
+                assert "MUSA Triton does not accept" in new_source
+                assert "score_max = tl.max(score, axis=0)" in new_source
+                assert "score = score_exp / score_denom" in new_source
+                break
+        else:
+            raise AssertionError(
+                "DeepSeek-V4 v0.22 fused_compress_quant_cache patch was not found"
+            )
 
     def test_nvidia_model_patch_runs_final_hc_post_on_musa(self):
         from vllm_musa.patches import _get_patch_files, _load_patch_config
@@ -387,10 +453,37 @@ class TestDeepSeekV4AttentionPatch:
                 )
                 assert "flash_mla_sparse_fwd" in new_source
                 assert "flash_mla_with_kvcache" in new_source
+                assert "active_decode_tokens = q.shape[0]" in new_source
+                assert "topk_indices[:active_decode_tokens]" in new_source
+                assert "topk_lens[:active_decode_tokens]" in new_source
+                assert "swa_indices[:active_decode_tokens]" in new_source
+                assert "swa_lens[:active_decode_tokens]" in new_source
                 break
         else:
             raise AssertionError(
                 "v0.22 deepseek_v4 nvidia flashmla patch file was not found"
+            )
+
+    def test_v022_deepseek_v4_mtp_runs_hc_post_on_musa(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.models.deepseek_v4.nvidia.mtp":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert (
+                    "if current_platform.is_cuda() or current_platform.is_musa():"
+                    in new_source
+                )
+                assert "hidden_states = self.mtp_block.hc_post(" in new_source
+                assert "hidden_states.dim() == 2" not in new_source
+                break
+        else:
+            raise AssertionError(
+                "v0.22 deepseek_v4 nvidia mtp patch file was not found"
             )
 
     def test_qnorm_rope_native_path_trims_padded_slot_mapping(self):

--- a/vllm_musa/deepseek_v4_jit/tilelang_kernels.py
+++ b/vllm_musa/deepseek_v4_jit/tilelang_kernels.py
@@ -610,6 +610,71 @@ def mhc_pre_big_fuse_decode_split_kernel(
     return _mhc_pre_big_fuse_decode_split_kernel()
 
 
+@lru_cache(maxsize=None)
+def mhc_weighted_rmsnorm_kernel(
+    hidden_size: int,
+    threads: int = 128,
+):
+    num_rows = T.dynamic("num_rows")
+    warps_per_cta = threads // 32
+    assert hidden_size > 0
+    assert hidden_size % threads == 0
+    assert threads in (64, 128, 256)
+
+    @tilelang.jit(target="musa", pass_configs=_tilelang_musa_pass_configs(tilelang))
+    def _mhc_weighted_rmsnorm_kernel():
+        @T.prim_func
+        def _kernel(
+            x: T.Tensor((num_rows, hidden_size), T.bfloat16),
+            weight: T.Tensor((hidden_size,), T.bfloat16),
+            out: T.Tensor((num_rows, hidden_size), T.bfloat16),
+            eps: T.float32,
+        ):
+            with T.Kernel(num_rows, threads=threads) as row_id:
+                tx = T.get_thread_binding()
+                lane = tx % 32
+                warp = tx // 32
+                partial_sumsq = T.alloc_local((1,), T.float32)
+                warp_sumsq = T.alloc_shared((warps_per_cta,), T.float32)
+
+                partial_sumsq[0] = 0.0
+                for col_base in T.serial(0, hidden_size, threads):
+                    col = col_base + tx
+                    value = T.cast(x[row_id, col], T.float32)
+                    partial_sumsq[0] += value * value
+
+                partial_sumsq[0] = _warp_reduce_sum(partial_sumsq[0])
+                if lane == 0:
+                    warp_sumsq[warp] = partial_sumsq[0]
+                T.sync_threads()
+
+                partial_sumsq[0] = T.if_then_else(
+                    tx < warps_per_cta,
+                    warp_sumsq[tx],
+                    0.0,
+                )
+                if warp == 0:
+                    partial_sumsq[0] = _warp_reduce_sum(partial_sumsq[0])
+                    if lane == 0:
+                        warp_sumsq[0] = T.rsqrt(
+                            partial_sumsq[0] / float(hidden_size) + eps
+                        )
+                T.sync_threads()
+
+                for col_base in T.serial(0, hidden_size, threads):
+                    col = col_base + tx
+                    value = T.cast(x[row_id, col], T.float32)
+                    weight_value = T.cast(weight[col], T.float32)
+                    out[row_id, col] = T.cast(
+                        value * warp_sumsq[0] * weight_value,
+                        T.bfloat16,
+                    )
+
+        return _kernel
+
+    return _mhc_weighted_rmsnorm_kernel()
+
+
 @tilelang.jit(target="musa", pass_configs=_tilelang_musa_pass_configs(tilelang))
 def qnorm_rope_kernel():
     num_tokens = T.dynamic("num_tokens")

--- a/vllm_musa/deepseek_v4_mhc.py
+++ b/vllm_musa/deepseek_v4_mhc.py
@@ -15,6 +15,7 @@ _MHC_PRE_BIG_FUSE_HIDDEN_BLOCK_ENV = (
 )
 _MHC_PRE_BIG_FUSE_PASS_CONFIG_ENV = "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_BIG_FUSE_PASS_CONFIG"
 _MHC_PRE_DECODE_PRENORM_IMPL_ENV = "VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_DECODE_PRENORM_IMPL"
+_MHC_WEIGHTED_RMSNORM_IMPL_ENV = "VLLM_MUSA_DEEPSEEK_V4_MHC_WEIGHTED_RMSNORM_IMPL"
 
 
 def mhc_pre_musa(
@@ -105,11 +106,91 @@ def _apply_optional_rms_norm(
 ) -> torch.Tensor:
     if norm_weight is None:
         return x
+    musa_result = _try_mhc_weighted_rms_norm_musa(x, norm_weight, norm_eps)
+    if musa_result is not None:
+        return musa_result
     x_float = x.to(torch.float32)
     variance = x_float.pow(2).mean(dim=-1, keepdim=True)
     x_float = x_float * torch.rsqrt(variance + norm_eps)
     x_float = x_float * norm_weight.to(torch.float32)
     return x_float.to(x.dtype)
+
+
+def _mhc_weighted_rms_norm_threads(hidden_size: int) -> int | None:
+    if hidden_size % 128 == 0:
+        return 128
+    if hidden_size % 64 == 0:
+        return 64
+    return None
+
+
+def _try_mhc_weighted_rms_norm_musa(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+) -> torch.Tensor | None:
+    impl = os.getenv(_MHC_WEIGHTED_RMSNORM_IMPL_ENV, "auto").strip().lower()
+    disabled_impls = {"", "0", "false", "off", "torch", "fallback"}
+    tilelang_impls = {"1", "true", "on", "tilelang", "jit", "musa"}
+    if impl in disabled_impls:
+        return None
+    if impl not in {"auto"} | tilelang_impls:
+        raise ValueError(
+            f"{_MHC_WEIGHTED_RMSNORM_IMPL_ENV} must be 'auto', one of "
+            "TileLang aliases ('tilelang', 'jit', 'musa', '1', 'true', "
+            "'on'), or one of torch/off aliases ('torch', 'fallback', "
+            "'off', '0', 'false', ''), "
+            f"got {impl!r}"
+        )
+
+    explicit_tilelang = impl in tilelang_impls
+    hidden_size = x.shape[-1]
+    threads = _mhc_weighted_rms_norm_threads(hidden_size)
+    supported = (
+        x.device.type == "musa"
+        and x.dtype == torch.bfloat16
+        and x.is_contiguous()
+        and x.dim() >= 2
+        and norm_weight.shape == (hidden_size,)
+        and norm_weight.device == x.device
+        and norm_weight.dtype == torch.bfloat16
+        and norm_weight.is_contiguous()
+        and threads is not None
+    )
+    if not supported:
+        if explicit_tilelang:
+            raise NotImplementedError(
+                "DeepSeek-V4 MHC TileLang weighted RMSNorm requires contiguous "
+                "MUSA bf16 x, contiguous bf16 norm_weight on the same device, "
+                "and hidden_size divisible by 64; got "
+                f"x_shape={tuple(x.shape)}, "
+                f"x_dtype={x.dtype}, x_device={x.device}, "
+                f"x_contiguous={x.is_contiguous()}, "
+                f"weight_shape={tuple(norm_weight.shape)}, "
+                f"weight_dtype={norm_weight.dtype}, "
+                f"weight_device={norm_weight.device}, "
+                f"weight_contiguous={norm_weight.is_contiguous()}"
+            )
+        return None
+
+    try:
+        from vllm_musa.deepseek_v4_jit.tilelang_kernels import (
+            mhc_weighted_rmsnorm_kernel,
+        )
+
+        x_2d = x.view(-1, hidden_size)
+        out_2d = torch.empty_like(x_2d)
+        mhc_weighted_rmsnorm_kernel(hidden_size, threads=threads)(
+            x_2d,
+            norm_weight,
+            out_2d,
+            float(norm_eps),
+        )
+        return out_2d.view_as(x)
+    except (ImportError, OSError, NotImplementedError, RuntimeError):
+        if explicit_tilelang:
+            raise
+        return None
 
 
 def mhc_pre_musa_with_norm(

--- a/vllm_musa/kernels/musa_ops.py
+++ b/vllm_musa/kernels/musa_ops.py
@@ -3,9 +3,11 @@
 """MUSA IR-op providers for vllm.ir.ops.*
 
 Currently registers:
-- rms_norm: delegates to torch.ops._C.rms_norm (the upstream
-  layernorm_kernels.cu kernel built via vllm-musa/setup.py
-  VLLM_CSRC_SOURCES; torchada redirects CUDA → MUSA at runtime).
+- rms_norm: delegates to torch.ops._C.rms_norm only when that op has a MUSA
+  dispatch kernel. In vLLM v0.22 the upstream layernorm implementation moved
+  to _C_stable_libtorch; vllm-musa builds that extension as a schema-only
+  compatibility shim, so this provider self-disables until a real MUSA kernel
+  is present.
 
 Engine log from MUSA-0049 baseline confirms:
     ir_op_priority=IrOpPriorityConfig(rms_norm=['native'])
@@ -13,7 +15,8 @@ Engine log from MUSA-0049 baseline confirms:
 i.e. before this provider lands, every decoder layer per token uses
 the pure-PyTorch native rms_norm. With the "musa" provider plus a
 priority override in `vllm_musa.platform`, the dispatcher / Inductor
-lowering picks the MUSA kernel.
+lowering picks the MUSA kernel when `_dispatch_has_kernel_for_dispatch_key`
+confirms one is registered.
 """
 
 import torch
@@ -68,8 +71,8 @@ def rms_norm(
 ) -> Tensor:
     """MUSA provider for vllm.ir.ops.rms_norm.
 
-    Delegates to torch.ops._C.rms_norm (the upstream layernorm_kernels.cu
-    kernel built via vllm-musa setup.py; torchada redirects CUDA->MUSA).
+    Delegates to torch.ops._C.rms_norm only when a MUSA dispatch kernel is
+    registered for the upstream op namespace.
     """
     assert variance_size is None
     assert weight is not None

--- a/vllm_musa/patches/vllm__models__deepseek_v4__attention.patch.py
+++ b/vllm_musa/patches/vllm__models__deepseek_v4__attention.patch.py
@@ -9,19 +9,19 @@ PATCHES = [
         """logger = init_logger(__name__)
 
 
-def _musa_deepseek_v4_mm_out_dtype(
+def _musa_deepseek_v4_linear_out_dtype(
     a: torch.Tensor,
-    b: torch.Tensor,
+    weight: torch.Tensor,
     out_dtype: torch.dtype,
 ) -> torch.Tensor:
     if (
         current_platform.is_musa()
         or getattr(torch.version, "musa", None) is not None
         or a.device.type == "musa"
-        or b.device.type == "musa"
+        or weight.device.type == "musa"
     ):
-        return torch.mm(a.to(out_dtype), b.to(out_dtype))
-    return torch.mm(a, b, out_dtype=out_dtype)
+        return F.linear(a.to(out_dtype), weight.to(out_dtype))
+    return torch.mm(a, weight.T, out_dtype=out_dtype)
 
 
 def _musa_deepseek_v4_is_musa_tensor(tensor: torch.Tensor) -> bool:
@@ -123,9 +123,9 @@ def _musa_deepseek_v4_qnorm_rope_kv_insert(
                     out_dtype=torch.float32,
                 )
 """,
-        """                return _musa_deepseek_v4_mm_out_dtype(
+        """                return _musa_deepseek_v4_linear_out_dtype(
                     hidden_states,
-                    compressor.fused_wkv_wgate.weight.T,
+                    compressor.fused_wkv_wgate.weight,
                     torch.float32,
                 )
 """,
@@ -137,9 +137,9 @@ def _musa_deepseek_v4_qnorm_rope_kv_insert(
                     out_dtype=torch.float32,
                 )
 """,
-        """                return _musa_deepseek_v4_mm_out_dtype(
+        """                return _musa_deepseek_v4_linear_out_dtype(
                     hidden_states,
-                    indexer.compressor.fused_wkv_wgate.weight.T,
+                    indexer.compressor.fused_wkv_wgate.weight,
                     torch.float32,
                 )
 """,

--- a/vllm_musa/patches/vllm__models__deepseek_v4__common__ops__fused_compress_quant_cache.patch.py
+++ b/vllm_musa/patches/vllm__models__deepseek_v4__common__ops__fused_compress_quant_cache.patch.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Patch vLLM v0.22 DeepSeek-V4 fused compress-cache launch for MUSA."""
+
+PATCHES = [
+    (
+        """import torch
+
+from vllm.triton_utils import tl, triton
+
+from .fused_indexer_q import _fp32x2_to_fp4x2
+""",
+        """import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+
+from .fused_indexer_q import _fp32x2_to_fp4x2
+
+
+def _musa_deepseek_v4_compress_cache_pdl_kwargs(
+    tensor: torch.Tensor,
+    pdl_kwargs: dict | None,
+) -> dict:
+    active_pdl_kwargs = dict(pdl_kwargs or {})
+    if (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or getattr(tensor.device, "type", None) == "musa"
+    ):
+        active_pdl_kwargs.pop("launch_pdl", None)
+    return active_pdl_kwargs
+""",
+    ),
+    (
+        """        KV_BLOCK_STRIDE=kv_cache.stride(0),
+        num_warps=num_warps,
+        **pdl_kwargs,
+    )
+""",
+        """        KV_BLOCK_STRIDE=kv_cache.stride(0),
+        num_warps=num_warps,
+        **_musa_deepseek_v4_compress_cache_pdl_kwargs(state_cache, pdl_kwargs),
+    )
+""",
+    ),
+    (
+        """    score = tl.softmax(score, dim=0)
+""",
+        """    # MUSA Triton does not accept the upstream tl.softmax(dim=0) kwarg.
+    score_max = tl.max(score, axis=0)
+    score_max = tl.where(mask, score_max, 0.0)
+    score_exp = tl.exp(score - score_max)
+    score_exp = tl.where(mask[None, :], score_exp, 0.0)
+    score_denom = tl.sum(score_exp, axis=0)
+    score_denom = tl.where(score_denom > 0.0, score_denom, 1.0)
+    score = score_exp / score_denom
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__models__deepseek_v4__common__ops__save_partial_states.patch.py
+++ b/vllm_musa/patches/vllm__models__deepseek_v4__common__ops__save_partial_states.patch.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Patch vLLM v0.22 DeepSeek-V4 partial-state save for MUSA Triton."""
+
+PATCHES = [
+    (
+        """import torch
+
+from vllm.triton_utils import tl, triton
+""",
+        """import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+
+
+def _musa_deepseek_v4_save_partial_pdl_kwargs(
+    tensor: torch.Tensor,
+    pdl_kwargs: dict | None,
+) -> dict:
+    active_pdl_kwargs = dict(pdl_kwargs or {})
+    if (
+        current_platform.is_musa()
+        or getattr(torch.version, "musa", None) is not None
+        or getattr(tensor.device, "type", None) == "musa"
+    ):
+        active_pdl_kwargs.pop("launch_pdl", None)
+    return active_pdl_kwargs
+""",
+    ),
+    (
+        """        COMPRESS_RATIO=compress_ratio,
+        **(pdl_kwargs or {}),
+    )
+""",
+        """        COMPRESS_RATIO=compress_ratio,
+        **_musa_deepseek_v4_save_partial_pdl_kwargs(kv, pdl_kwargs),
+    )
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__models__deepseek_v4__nvidia__flashmla.patch.py
+++ b/vllm_musa/patches/vllm__models__deepseek_v4__nvidia__flashmla.patch.py
@@ -15,4 +15,32 @@ PATCHES = [
 )
 """,
     ),
+    (
+        """        swa_indices = swa_metadata.decode_swa_indices
+        swa_lens = swa_metadata.decode_swa_lens
+
+        # We treat queries in the same seq as different queries
+        # and later we only attend by generated indices.
+        # q arrives pre-padded to layer.padded_heads by the outer wrapper.
+        q = q.unsqueeze(1)
+""",
+        """        active_decode_tokens = q.shape[0]
+        if topk_indices is not None:
+            topk_indices = topk_indices[:active_decode_tokens]
+        if topk_lens is not None:
+            topk_lens = topk_lens[:active_decode_tokens]
+
+        swa_indices = swa_metadata.decode_swa_indices
+        swa_lens = swa_metadata.decode_swa_lens
+        if swa_indices is not None:
+            swa_indices = swa_indices[:active_decode_tokens]
+        if swa_lens is not None:
+            swa_lens = swa_lens[:active_decode_tokens]
+
+        # We treat queries in the same seq as different queries
+        # and later we only attend by generated indices.
+        # q arrives pre-padded to layer.padded_heads by the outer wrapper.
+        q = q.unsqueeze(1)
+""",
+    ),
 ]

--- a/vllm_musa/patches/vllm__models__deepseek_v4__nvidia__model.patch.py
+++ b/vllm_musa/patches/vllm__models__deepseek_v4__nvidia__model.patch.py
@@ -4,6 +4,52 @@
 
 PATCHES = [
     (
+        """import typing
+from collections.abc import Callable, Iterable
+""",
+        """import os
+import typing
+from collections.abc import Callable, Iterable
+""",
+    ),
+    (
+        """from vllm.utils.torch_utils import direct_register_custom_op
+
+
+class DeepseekV4MLP(nn.Module):
+""",
+        """from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def _musa_deepseek_v4_disable_aux_overlap() -> bool:
+    return (
+        current_platform.is_musa()
+        and os.getenv("VLLM_MUSA_DEEPSEEK_V4_DISABLE_AUX_OVERLAP", "0") == "1"
+    )
+
+
+class DeepseekV4MLP(nn.Module):
+""",
+    ),
+    (
+        """        aux_stream_list = (
+            None
+            if current_platform.is_rocm() or current_platform.is_xpu()
+            else [torch.cuda.Stream() for _ in range(3)]
+        )
+""",
+        """        aux_stream_list = (
+            None
+            if (
+                current_platform.is_rocm()
+                or current_platform.is_xpu()
+                or _musa_deepseek_v4_disable_aux_overlap()
+            )
+            else [torch.cuda.Stream() for _ in range(3)]
+        )
+""",
+    ),
+    (
         """        if layer is not None and current_platform.is_cuda():
             hidden_states = layer.hc_post(hidden_states, residual, post_mix, res_mix)
 """,

--- a/vllm_musa/patches/vllm__models__deepseek_v4__nvidia__mtp.patch.py
+++ b/vllm_musa/patches/vllm__models__deepseek_v4__nvidia__mtp.patch.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Patch vLLM v0.22 DeepSeek-V4 MTP hidden-state shape handling for MUSA."""
+
+PATCHES = [
+    (
+        """        if current_platform.is_cuda():
+            hidden_states = self.mtp_block.hc_post(
+                hidden_states, residual, post_mix, res_mix
+            )
+""",
+        """        if current_platform.is_cuda() or current_platform.is_musa():
+            hidden_states = self.mtp_block.hc_post(
+                hidden_states, residual, post_mix, res_mix
+            )
+""",
+    ),
+]
+
+
+def normalize_source(source: str) -> str:
+    """Remove an obsolete logits-side guard from earlier MUSA triage.
+
+    The correct contract is that the MTP forward path returns the flat
+    pre-hc_head residual with width ``hc_mult * hidden_size``. Fixing logits to
+    accept already dense states lets the first draft sample run, but breaks the
+    next draft step's hidden-state buffer.
+    """
+    stale = """        if not (
+            current_platform.is_musa()
+            and hidden_states.dim() == 2
+            and hidden_states.shape[-1] == mtp_layer.config.hidden_size
+        ):
+            # MTP forward returns the pre-hc_head residual (T, hc_mult * D);
+            # apply hc_head here so logits are computed from the dense hidden
+            # state. MUSA request-time propose can also receive an already
+            # dense hidden state from the target path, in which case this
+            # projection has already happened.
+            hidden_states = hidden_states.view(
+                -1, mtp_layer.hc_mult, mtp_layer.config.hidden_size
+            )
+            hidden_states = mtp_layer.hc_head_op(
+                hidden_states,
+                mtp_layer.hc_head_fn,
+                mtp_layer.hc_head_scale,
+                mtp_layer.hc_head_base,
+                mtp_layer.rms_norm_eps,
+                mtp_layer.hc_eps,
+            )
+        logits = self.logits_processor(
+"""
+    original = """        # MTP forward returns the pre-hc_head residual (T, hc_mult * D); apply
+        # hc_head here so logits are computed from the dense hidden state.
+        hidden_states = hidden_states.view(
+            -1, mtp_layer.hc_mult, mtp_layer.config.hidden_size
+        )
+        hidden_states = mtp_layer.hc_head_op(
+            hidden_states,
+            mtp_layer.hc_head_fn,
+            mtp_layer.hc_head_scale,
+            mtp_layer.hc_head_base,
+            mtp_layer.rms_norm_eps,
+            mtp_layer.hc_eps,
+        )
+        logits = self.logits_processor(
+"""
+    return source.replace(stale, original)


### PR DESCRIPTION
## Motivation

Adapt `vllm-musa` to support DeepSeek-V4-Flash-Base on the vLLM v0.22.0 codebase. Upstream vLLM v0.22.0 changed the DeepSeek-V4 request/model layout and runtime integration points, so the existing MUSA DeepSeek-V4 adaptation needed to be updated for the new paths while preserving the validated TP8 performance behavior.

## Modifications

- Update dependencies: maet >= 0.2.0 and torchada>=0.1.57
- Added vLLM v0.22.0 DeepSeek-V4 patch coverage for the updated request path, NVIDIA model modules, FlashMLA integration, MTP path, fused compressor/cache ops, and partial-state save handling.
- Added MUSA-side DeepSeek-V4 MHC helpers, including TileLang-backed weighted RMSNorm support and related tests.
- Restored the DeepSeek-V4 aux-stream disable gate and decode-prenorm selector behavior on the v0.22 runtime path.
- Fixed the MUSA compressor GEMM fallback to avoid the non-contiguous `weight.T` cast path that regressed decode TPOT.
- Extended patch/unit coverage for the new v0.22 DeepSeek-V4 integration points.

## Test

- Reinstalled :
  - `vllm` from `v.022.0`
  - `vllm-musa from commit` 02dc65c97e3a4bfcfae3ed6d287572882fb9b5dd`
- Validated DeepSeek-V4-Flash-Base TP8 serving.

```
export PATH=/root/.virtualenvs/sglang-0.5.6/bin:$PATH
export MUSA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export SAFETENSORS_FAST_GPU=1
export VLLM_DEEP_GEMM_WARMUP=skip
export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
export VLLM_USE_DEEP_GEMM=1
export VLLM_USE_DEEP_GEMM_E8M0=0
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export PYTHONUNBUFFERED=1
export VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE=aggressive_long_prefill
export VLLM_MUSA_DEEPSEEK_V4_DISABLE_AUX_OVERLAP=1
export VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_DECODE_PRENORM_IMPL=tilelang

unset PYTHONPATH
unset TORCHDYNAMO_DISABLE
unset VLLM_ATTENTION_BACKEND

vllm serve /home/dist/DeepSeek-V4-Flash-Base \
  --served-model-name deepseek \
  --gpu-memory-utilization 0.95 \
  --max-model-len 6144 \
  --max-num-seqs 1 \
  --max-num-batched-tokens 8195 \
  --tensor-parallel-size 8 \
  -ac.backend FLASHMLA \
  --port 25606 \
  --host 0.0.0.0 \
  --kv-cache-dtype fp8 \
  --no-enable-prefix-caching \
  --no-async-scheduling \
  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","max_cudagraph_capture_size":3,"cudagraph_capture_sizes":[3],"cudagraph_copy_inputs":true}' \
  --speculative-config '{"method":"mtp","num_speculative_tokens":2}'
```