### PR TITLE
rewrite custom all-reduce

### DIFF
--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+import ctypes
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from vllm.logger import init_logger
+from vllm_musa.jit_kernel.csrc import allreduce as jit_ar
+
+logger = init_logger(__name__)
+
+
+cudaError_t = ctypes.c_int
+
+
+class cudaIpcMemHandle_t(ctypes.Structure):
+    _fields_ = [("internal", ctypes.c_byte * 128)]
+
+
+@dataclass(frozen=True)
+class _Function:
+    name: str
+    restype: Any
+    argtypes: list[Any]
+
+
+class _MusaRTLibrary:
+    _exported_functions = (
+        _Function(
+            "cudaMalloc",
+            cudaError_t,
+            [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t],
+        ),
+        _Function("cudaFree", cudaError_t, [ctypes.c_void_p]),
+        _Function(
+            "cudaMemset", cudaError_t, [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]
+        ),
+        _Function("cudaGetErrorString", ctypes.c_char_p, [cudaError_t]),
+        _Function(
+            "cudaIpcGetMemHandle",
+            cudaError_t,
+            [ctypes.POINTER(cudaIpcMemHandle_t), ctypes.c_void_p],
+        ),
+        _Function(
+            "cudaIpcOpenMemHandle",
+            cudaError_t,
+            [ctypes.POINTER(ctypes.c_void_p), cudaIpcMemHandle_t, ctypes.c_uint],
+        ),
+        _Function("cudaIpcCloseMemHandle", cudaError_t, [ctypes.c_void_p]),
+    )
+    _library_cache: dict[str, Any] = {}
+    _func_cache: dict[str, dict[str, Any]] = {}
+
+    def __init__(self, so_file: str = "libmusart.so") -> None:
+        if so_file not in self._library_cache:
+            self._library_cache[so_file] = ctypes.CDLL(so_file)
+        self.lib = self._library_cache[so_file]
+
+        if so_file not in self._func_cache:
+            funcs: dict[str, Any] = {}
+            for func in self._exported_functions:
+                f = getattr(self.lib, func.name)
+                f.restype = func.restype
+                f.argtypes = func.argtypes
+                funcs[func.name] = f
+            self._func_cache[so_file] = funcs
+        self.funcs = self._func_cache[so_file]
+
+    def check(self, result: cudaError_t) -> None:
+        if result != 0:
+            error = self.funcs["cudaGetErrorString"](result)
+            error_str = error.decode("utf-8") if error else str(result)
+            raise RuntimeError(f"MUSART error: {error_str}")
+
+    def malloc(self, size: int) -> ctypes.c_void_p:
+        ptr = ctypes.c_void_p()
+        self.check(self.funcs["cudaMalloc"](ctypes.byref(ptr), size))
+        return ptr
+
+    def free(self, ptr: ctypes.c_void_p) -> None:
+        self.check(self.funcs["cudaFree"](ptr))
+
+    def memset(self, ptr: ctypes.c_void_p, value: int, count: int) -> None:
+        self.check(self.funcs["cudaMemset"](ptr, value, count))
+
+    def ipc_get_mem_handle(self, ptr: ctypes.c_void_p) -> cudaIpcMemHandle_t:
+        handle = cudaIpcMemHandle_t()
+        self.check(self.funcs["cudaIpcGetMemHandle"](ctypes.byref(handle), ptr))
+        return handle
+
+    def ipc_open_mem_handle(self, handle: cudaIpcMemHandle_t) -> ctypes.c_void_p:
+        cuda_ipc_mem_lazy_enable_peer_access = 1
+        ptr = ctypes.c_void_p()
+        self.check(
+            self.funcs["cudaIpcOpenMemHandle"](
+                ctypes.byref(ptr), handle, cuda_ipc_mem_lazy_enable_peer_access
+            )
+        )
+        return ptr
+
+    def ipc_close_mem_handle(self, ptr: ctypes.c_void_p) -> None:
+        self.check(self.funcs["cudaIpcCloseMemHandle"](ptr))
+
+
+_COMM_REGISTRY: dict[int, Any] = {}
+_NEXT_COMM_ID = 0
+
+
+def _register_comm(comm: Any) -> int:
+    global _NEXT_COMM_ID
+    comm_id = _NEXT_COMM_ID
+    _NEXT_COMM_ID += 1
+    _COMM_REGISTRY[comm_id] = comm
+    return comm_id
+
+
+def _musa_jit_custom_all_reduce(input: torch.Tensor, comm_id: int) -> torch.Tensor:
+    comm = _COMM_REGISTRY.get(int(comm_id))
+    if comm is None:
+        raise RuntimeError(f"MUSA JIT custom all-reduce communicator {comm_id} is gone")
+    return comm._custom_all_reduce_impl(input)
+
+
+def _musa_jit_custom_all_reduce_fake(
+    input: torch.Tensor, comm_id: int
+) -> torch.Tensor:
+    return torch.empty_like(input)
+
+
+direct_register_custom_op(
+    op_name="musa_jit_custom_all_reduce",
+    op_func=_musa_jit_custom_all_reduce,
+    fake_impl=_musa_jit_custom_all_reduce_fake,
+)
+
+
+def _ipc_handle_to_bytes(handle: cudaIpcMemHandle_t) -> bytes:
+    return ctypes.string_at(ctypes.byref(handle), ctypes.sizeof(handle))
+
+
+def _ipc_handle_from_bytes(data: bytes) -> cudaIpcMemHandle_t:
+    expected_size = ctypes.sizeof(cudaIpcMemHandle_t)
+    if len(data) != expected_size:
+        raise RuntimeError(
+            f"Invalid MUSA IPC handle size: got {len(data)}, expected {expected_size}"
+        )
+    return cudaIpcMemHandle_t.from_buffer_copy(data)
+
+
+@dataclass
+class _SharedBuffer:
+    pointers: list[int]
+    opened_ipc_ptrs: list[int]
+
+
+def _make_shared_buffer(
+    size_in_bytes: int, group: ProcessGroup | None = None
+) -> _SharedBuffer:
+    lib = _MusaRTLibrary()
+    pointer = lib.malloc(size_in_bytes)
+    opened_ipc_ptrs: list[int] = []
+    try:
+        lib.memset(pointer, 0, size_in_bytes)
+        handle = _ipc_handle_to_bytes(lib.ipc_get_mem_handle(pointer))
+
+        world_size = dist.get_world_size(group=group)
+        rank = dist.get_rank(group=group)
+        handles = [None] * world_size
+        dist.all_gather_object(handles, handle, group=group)
+
+        pointers: list[int] = []
+        for i, handle_i in enumerate(handles):
+            if i == rank:
+                pointers.append(int(pointer.value))
+            else:
+                assert isinstance(handle_i, bytes)
+                opened = int(
+                    lib.ipc_open_mem_handle(_ipc_handle_from_bytes(handle_i)).value
+                )
+                pointers.append(opened)
+                opened_ipc_ptrs.append(opened)
+        return _SharedBuffer(pointers, opened_ipc_ptrs)
+    except Exception:
+        for ptr in opened_ipc_ptrs:
+            try:
+                lib.ipc_close_mem_handle(ctypes.c_void_p(ptr))
+            except Exception:
+                pass
+        try:
+            lib.free(pointer)
+        except Exception:
+            pass
+        raise
+
+
+def _close_ipc_handles(pointers: list[int]) -> None:
+    lib = _MusaRTLibrary()
+    for ptr in pointers:
+        try:
+            lib.ipc_close_mem_handle(ctypes.c_void_p(ptr))
+        except Exception:
+            logger.debug("Failed to close MUSA IPC handle.", exc_info=True)
+
+
+def _free_own_shared_buffer(
+    pointers: list[int], group: ProcessGroup | None = None, rank: int | None = None
+) -> None:
+    if rank is None:
+        rank = dist.get_rank(group=group)
+    _MusaRTLibrary().free(ctypes.c_void_p(pointers[rank]))
+
+
+class _MusaJitCustomAllreduceImpl:
+    _SUPPORTED_WORLD_SIZES = (2, 4, 6, 8)
+    _MAX_CAR_SIZE = 512 * 1024 * 1024
+
+    def __init__(
+        self,
+        group: ProcessGroup,
+        device: int | str | torch.device,
+        max_size: int = _MAX_CAR_SIZE,
+    ) -> None:
+        self.disabled = True
+        self.group = group
+        self.max_size = max_size
+        self._IS_CAPTURING = False
+        self._comm_id: int | None = None
+        self.meta_ptrs: list[int] = []
+        self.meta_opened_ipc_ptrs: list[int] = []
+        self.buffer_ptrs: list[int] = []
+        self.buffer_opened_ipc_ptrs: list[int] = []
+        self.buffer_rank_data: torch.Tensor | None = None
+
+        if isinstance(device, int):
+            device = torch.device(f"musa:{device}")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        assert isinstance(device, torch.device)
+        self.device = device
+
+        self.rank = dist.get_rank(group=group)
+        self.world_size = dist.get_world_size(group=group)
+        if self.world_size not in self._SUPPORTED_WORLD_SIZES:
+            logger.warning(
+                "MUSA JIT custom allreduce disabled due to unsupported world "
+                "size %d. Supported world sizes: %s.",
+                self.world_size,
+                self._SUPPORTED_WORLD_SIZES,
+            )
+            return
+
+        try:
+            meta_bytes = jit_ar.meta_size(self.world_size)
+            meta_buffer = _make_shared_buffer(
+                meta_bytes + self.max_size, group=group
+            )
+            self.meta_ptrs = meta_buffer.pointers
+            self.meta_opened_ipc_ptrs = meta_buffer.opened_ipc_ptrs
+            buffer = _make_shared_buffer(self.max_size, group=group)
+            self.buffer_ptrs = buffer.pointers
+            self.buffer_opened_ipc_ptrs = buffer.opened_ipc_ptrs
+            jit_ar.ensure_compiled(self.world_size)
+        except Exception:
+            logger.exception("MUSA JIT custom allreduce initialization failed.")
+            if self.meta_opened_ipc_ptrs:
+                try:
+                    _close_ipc_handles(self.meta_opened_ipc_ptrs)
+                except Exception:
+                    pass
+            if self.buffer_opened_ipc_ptrs:
+                try:
+                    _close_ipc_handles(self.buffer_opened_ipc_ptrs)
+                except Exception:
+                    pass
+            if self.meta_ptrs:
+                try:
+                    _free_own_shared_buffer(self.meta_ptrs, group=group, rank=self.rank)
+                except Exception:
+                    pass
+            if self.buffer_ptrs:
+                try:
+                    _free_own_shared_buffer(
+                        self.buffer_ptrs, group=group, rank=self.rank
+                    )
+                except Exception:
+                    pass
+            self.meta_ptrs = []
+            self.meta_opened_ipc_ptrs = []
+            self.buffer_ptrs = []
+            self.buffer_opened_ipc_ptrs = []
+            return
+
+        self.signal_ptrs_cpu = torch.tensor(self.meta_ptrs, dtype=torch.int64)
+        buffer_ptrs = self.buffer_ptrs + [0] * (8 - self.world_size)
+        self.buffer_rank_data = torch.tensor(buffer_ptrs, dtype=torch.int64)
+        self._comm_id = _register_comm(self)
+        self.disabled = False
+        logger.info_once(
+            "Using MUSA JIT custom all-reduce for world_size=%d max_size=%d.",
+            self.world_size,
+            self.max_size,
+        )
+
+    @contextmanager
+    def capture(self):
+        try:
+            self._IS_CAPTURING = True
+            yield
+        finally:
+            self._IS_CAPTURING = False
+
+    def should_custom_ar(self, inp: torch.Tensor) -> bool:
+        if self.disabled:
+            return False
+        if inp.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            return False
+        inp_size = inp.numel() * inp.element_size()
+        if inp_size % 16 != 0 or inp_size > self.max_size:
+            return False
+        return inp.is_contiguous()
+
+    @staticmethod
+    def _is_current_stream_capturing() -> bool:
+        try:
+            return bool(torch.cuda.is_current_stream_capturing())
+        except Exception:
+            return False
+
+    @staticmethod
+    def _is_torch_compiling() -> bool:
+        try:
+            if torch.compiler.is_compiling():
+                return True
+        except Exception:
+            pass
+        try:
+            return bool(torch._dynamo.is_compiling())
+        except Exception:
+            return False
+
+    def _custom_all_reduce_custom_op(self, input: torch.Tensor) -> torch.Tensor:
+        assert self._comm_id is not None
+        return torch.ops.vllm.musa_jit_custom_all_reduce(input, self._comm_id)
+
+    def custom_all_reduce(self, input: torch.Tensor) -> torch.Tensor | None:
+        if not self.should_custom_ar(input):
+            return None
+        if self._IS_CAPTURING:
+            if not self._is_current_stream_capturing():
+                # Match vLLM's CustomAllreduce warmup semantics. During graph
+                # warmup no communication should run; the real graph capture
+                # below records the scratch-buffer copy plus JIT AR kernel.
+                return torch.empty_like(input)
+            return self._custom_all_reduce_custom_op(input)
+        if self._is_torch_compiling():
+            # Keep Dynamo/Inductor from tracing into the Python Tile/JIT module
+            # loader. The registered op provides the compile-time fake impl and
+            # launches the same fixed-staging kernel at runtime.
+            return self._custom_all_reduce_custom_op(input)
+        # Use fixed staging buffers instead of caching peer IPC pointers for
+        # each input. This keeps eager and graph replay on the same
+        # pointer-stable kernel.
+        return self._custom_all_reduce_impl(input)
+
+    def _custom_all_reduce_impl(self, input: torch.Tensor) -> torch.Tensor:
+        assert self.buffer_rank_data is not None
+        out = torch.empty_like(input)
+        shot = jit_ar.preferred_shot(
+            self.world_size, input.numel() * input.element_size()
+        )
+        jit_ar.launch_unregistered(
+            self.buffer_rank_data,
+            self.signal_ptrs_cpu,
+            input,
+            out,
+            self.meta_ptrs[self.rank],
+            self.buffer_ptrs[self.rank],
+            self.max_size,
+            self.rank,
+            self.world_size,
+            shot,
+        )
+        return out
+
+    def close(self) -> None:
+        if self.meta_opened_ipc_ptrs:
+            _close_ipc_handles(self.meta_opened_ipc_ptrs)
+        if self.buffer_opened_ipc_ptrs:
+            _close_ipc_handles(self.buffer_opened_ipc_ptrs)
+        if self.meta_ptrs:
+            try:
+                _free_own_shared_buffer(self.meta_ptrs, rank=self.rank)
+            except Exception:
+                logger.debug(
+                    "Failed to free MUSA custom AR metadata buffer.", exc_info=True
+                )
+        if self.buffer_ptrs:
+            try:
+                _free_own_shared_buffer(self.buffer_ptrs, rank=self.rank)
+            except Exception:
+                logger.debug(
+                    "Failed to free MUSA custom AR staging buffer.", exc_info=True
+                )
+        if self._comm_id is not None:
+            _COMM_REGISTRY.pop(self._comm_id, None)
+            self._comm_id = None
+        self.meta_ptrs = []
+        self.meta_opened_ipc_ptrs = []
+        self.buffer_ptrs = []
+        self.buffer_opened_ipc_ptrs = []
+        self.buffer_rank_data = None
+        self.disabled = True
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class MusaJitCustomAllreduce:
+    """JIT custom all-reduce for MUSA.
+
+    Keep a single all-reduce implementation across eager and CUDA graph paths.
+    Falling back to vLLM's native CustomAllreduce on MUSA can segfault in
+    graph/Dynamo startup paths, so unsupported tensors should route to the next
+    communicator backend instead of a second custom-allreduce implementation.
+    """
+
+    def __init__(
+        self,
+        group: ProcessGroup,
+        device: int | str | torch.device,
+        max_size: int = _MusaJitCustomAllreduceImpl._MAX_CAR_SIZE,
+        symm_mem_enabled: bool = False,
+    ) -> None:
+        self.group = group
+        self.device = device
+        self._jit_comm: _MusaJitCustomAllreduceImpl | None = None
+        del symm_mem_enabled
+
+        try:
+            self._jit_comm = _MusaJitCustomAllreduceImpl(
+                group=group,
+                device=device,
+                max_size=max_size,
+            )
+        except Exception:
+            logger.exception("Failed to initialize MUSA JIT custom all-reduce.")
+
+        if self._jit_available:
+            logger.info_once(
+                "Using MUSA JIT custom all-reduce for eager and CUDA graph paths."
+            )
+
+    @property
+    def _jit_available(self) -> bool:
+        return self._jit_comm is not None and not self._jit_comm.disabled
+
+    @property
+    def disabled(self) -> bool:
+        return not self._jit_available
+
+    @contextmanager
+    def capture(self):
+        if self._jit_available:
+            with self._jit_comm.capture():
+                yield
+        else:
+            yield
+
+    def should_custom_ar(self, inp: torch.Tensor) -> bool:
+        return self._jit_available and self._jit_comm.should_custom_ar(inp)
+
+    def custom_all_reduce(self, input: torch.Tensor) -> torch.Tensor | None:
+        if self._jit_available and self._jit_comm.should_custom_ar(input):
+            return self._jit_comm.custom_all_reduce(input)
+        return None
+
+    def close(self) -> None:
+        if self._jit_comm is not None:
+            self._jit_comm.close()
+            self._jit_comm = None
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/vllm_musa/jit_kernel/csrc/allreduce.py
+++ b/vllm_musa/jit_kernel/csrc/allreduce.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import functools
+import os
+
+import torch
+
+from vllm_musa.jit_kernel.csrc.jit import load_musa_jit
+
+
+def _default_threads_blocks(world_size: int) -> tuple[int, int]:
+    if world_size == 8:
+        return 1024, 60
+    return 512, 36
+
+
+def preferred_shot(world_size: int, nbytes: int) -> int:
+    if world_size == 2 and nbytes >= 16 * 1024 * 1024:
+        return 1
+    return 2
+
+
+def _compile_config(world_size: int) -> tuple[int, int, int, int, int]:
+    default_threads, default_blocks = _default_threads_blocks(world_size)
+    threads = int(os.environ.get("VLLM_MUSA_CUSTOM_AR_THREADS", default_threads))
+    blocks = int(os.environ.get("VLLM_MUSA_CUSTOM_AR_BLOCKS", default_blocks))
+    vector_load = int(os.environ.get("VLLM_MUSA_CUSTOM_AR_VECTOR_LOAD", "0"))
+    atomic_barrier = int(os.environ.get("VLLM_MUSA_CUSTOM_AR_ATOMIC_BARRIER", "1"))
+    max_blocks = int(
+        os.environ.get("VLLM_MUSA_CUSTOM_AR_MAX_BLOCKS", str(max(120, blocks)))
+    )
+    max_blocks = max(max_blocks, blocks)
+    return threads, blocks, vector_load, atomic_barrier, max_blocks
+
+
+@functools.lru_cache(maxsize=16)
+def _custom_ar_module(world_size: int):
+    threads, blocks, vector_load, atomic_barrier, max_blocks = _compile_config(
+        world_size
+    )
+    name = (
+        f"vllm_musa_custom_all_reduce_t{threads}_b{blocks}"
+        f"_v{vector_load}_ab{atomic_barrier}_mb{max_blocks}"
+    )
+    return load_musa_jit(
+        name,
+        ("distributed/custom_all_reduce.mu",),
+        extra_musa_cflags=(
+            "-Wno-error=address-of-temporary",
+            "-fmusa-flush-denormals-to-zero",
+            "-fno-signed-zeros",
+            "-D__MUSA_ARCH_LIST__=310",
+            f"-DSGL_CUSTOM_AR_THREADS={threads}",
+            f"-DSGL_CUSTOM_AR_BLOCKS={blocks}",
+            f"-DSGL_CUSTOM_AR_VECTOR_LOAD={vector_load}",
+            f"-DSGL_CUSTOM_AR_ATOMIC_BARRIER={atomic_barrier}",
+            f"-DSGL_CUSTOM_AR_MAX_BLOCKS={max_blocks}",
+            "-mllvm",
+            "-mtgpu-opt-level=1",
+            "-mllvm",
+            "-mtgpu-load-store-opt=1",
+            "-mllvm",
+            "-mtgpu-fold-global-ldst=1",
+        ),
+    )
+
+
+def ensure_compiled(world_size: int) -> None:
+    _custom_ar_module(int(world_size))
+
+
+def meta_size(world_size: int = 8) -> int:
+    return int(_custom_ar_module(int(world_size)).vllm_musa_custom_ar_meta_size())
+
+
+def launch_unregistered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    self_signal_ptr: int,
+    self_buffer_ptr: int,
+    max_size_bytes: int,
+    rank: int,
+    world_size: int,
+    shot: int,
+) -> None:
+    _custom_ar_module(int(world_size)).vllm_musa_custom_ar_launch_unregistered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        out,
+        int(self_signal_ptr),
+        int(self_buffer_ptr),
+        int(max_size_bytes),
+        int(rank),
+        int(world_size),
+        int(shot),
+    )

--- a/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
+++ b/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
@@ -1,0 +1,437 @@
+#include "../common.h"
+#include "../device_utils.h"
+
+#include <musa_runtime.h>
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+namespace {
+
+#ifndef SGL_CUSTOM_AR_THREADS
+#define SGL_CUSTOM_AR_THREADS 512
+#endif
+
+#ifndef SGL_CUSTOM_AR_BLOCKS
+#define SGL_CUSTOM_AR_BLOCKS 36
+#endif
+
+#ifndef SGL_CUSTOM_AR_VECTOR_LOAD
+#define SGL_CUSTOM_AR_VECTOR_LOAD 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_ATOMIC_BARRIER
+#define SGL_CUSTOM_AR_ATOMIC_BARRIER 1
+#endif
+
+#ifndef SGL_CUSTOM_AR_MAX_BLOCKS
+#define SGL_CUSTOM_AR_MAX_BLOCKS 120
+#endif
+
+constexpr int kMaxBlocks = SGL_CUSTOM_AR_MAX_BLOCKS;
+constexpr int kMaxThreadsPerBlock = 1024;
+constexpr int kDefaultThreads = SGL_CUSTOM_AR_THREADS;
+constexpr int kDefaultBlockLimit = SGL_CUSTOM_AR_BLOCKS;
+constexpr int kMaxRanks = 8;
+using FlagType = uint32_t;
+
+struct alignas(128) Signal {
+  alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+  alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks];
+};
+
+struct __align__(16) RankData {
+  const void* ptrs[kMaxRanks];
+};
+
+struct __align__(16) RankSignals {
+  Signal* signals[kMaxRanks];
+};
+
+template <typename T, int sz>
+struct __align__(alignof(T) * sz) array_t {
+  T data[sz];
+  using type = T;
+  static constexpr int size = sz;
+};
+
+template <typename T>
+struct packed_t {
+  using P = array_t<T, 16 / sizeof(T)>;
+  using A = array_t<float, 16 / sizeof(T)>;
+};
+
+template <typename T>
+__device__ __forceinline__ T downcast_s(float value) {
+  return from_float<T>(value);
+}
+
+template <>
+__device__ __forceinline__ float downcast_s<float>(float value) {
+  return value;
+}
+
+template <typename T>
+__device__ __forceinline__ T& assign_add(T& a, T b) {
+  a = downcast_s<T>(to_float(a) + to_float(b));
+  return a;
+}
+
+template <>
+__device__ __forceinline__ float& assign_add<float>(float& a, float b) {
+  a += b;
+  return a;
+}
+
+template <typename T, int N>
+__device__ __forceinline__ array_t<T, N>& packed_assign_add(array_t<T, N>& a, array_t<T, N> b) {
+#pragma unroll
+  for (int i = 0; i < N; ++i) {
+    assign_add(a.data[i], b.data[i]);
+  }
+  return a;
+}
+
+template <typename T, int N>
+__device__ __forceinline__ array_t<float, N> upcast(array_t<T, N> value) {
+  if constexpr (std::is_same<T, float>::value) {
+    return value;
+  } else {
+    array_t<float, N> out;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      out.data[i] = to_float(value.data[i]);
+    }
+    return out;
+  }
+}
+
+template <typename O>
+__device__ __forceinline__ O downcast(array_t<float, O::size> value) {
+  if constexpr (std::is_same<typename O::type, float>::value) {
+    return value;
+  } else {
+    O out;
+#pragma unroll
+    for (int i = 0; i < O::size; ++i) {
+      out.data[i] = downcast_s<typename O::type>(value.data[i]);
+    }
+    return out;
+  }
+}
+
+__device__ __forceinline__ void signal_store(FlagType* ptr, FlagType value) {
+  volatile_store(static_cast<uint32_t>(value), reinterpret_cast<uint32_t*>(ptr));
+}
+
+__device__ __forceinline__ FlagType signal_load(FlagType* ptr) {
+  flushInv_byp();
+  return static_cast<uint32_t>(volatile_load(reinterpret_cast<uint32_t*>(ptr)));
+}
+
+template <int nranks, bool start, bool fence = false>
+__device__ __forceinline__ void multi_rank_barrier(const RankSignals& sg, Signal* self_sg, int rank) {
+  static_assert(!(start && fence));
+  if constexpr (!start) {
+    __syncthreads_lm();
+  }
+  if (threadIdx.x < nranks) {
+#if SGL_CUSTOM_AR_ATOMIC_BARRIER
+    auto flag = atomicAdd(&self_sg->self_counter[blockIdx.x][threadIdx.x], 1) + 1;
+    auto* peer = &sg.signals[threadIdx.x]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][threadIdx.x];
+    atomicExch(peer, flag);
+    while (atomicAdd(local, 0) != flag) {
+    }
+#else
+    auto flag = self_sg->self_counter[blockIdx.x][threadIdx.x] + 1;
+    self_sg->self_counter[blockIdx.x][threadIdx.x] = flag;
+    auto* peer = &sg.signals[threadIdx.x]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][threadIdx.x];
+    signal_store(peer, flag);
+    while (signal_load(local) != flag) {
+    }
+#endif
+  }
+  if constexpr (start || fence) {
+    __syncthreads_lm();
+  }
+}
+
+template <typename P, int nranks, typename A>
+__device__ __forceinline__ P packed_reduce(const P* ptrs[], int idx) {
+  A tmp = upcast(ptrs[0][idx]);
+#pragma unroll
+  for (int i = 1; i < nranks; ++i) {
+    packed_assign_add(tmp, upcast(ptrs[i][idx]));
+  }
+  return downcast<P>(tmp);
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) cross_device_reduce_1stage(
+    RankData data, RankSignals sg, Signal* self_sg, T* __restrict__ out, int rank, int size) {
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
+    reinterpret_cast<P*>(out)[idx] = packed_reduce<P, nranks, A>(reinterpret_cast<const P**>(&data.ptrs[0]), idx);
+  }
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename P>
+__device__ __forceinline__ P* get_tmp_buf(Signal* signal) {
+  return reinterpret_cast<P*>(signal + 1);
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) cross_device_reduce_2stage(
+    RankData data, RankSignals sg, Signal* self_sg, T* __restrict__ out, int rank, int size) {
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  int stride = gridDim.x * blockDim.x;
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  int part = size / nranks;
+  int start = rank * part;
+  int end = rank == nranks - 1 ? size : start + part;
+  int largest_part = part + size % nranks;
+  const P* ptrs[nranks];
+  P* tmps[nranks];
+#pragma unroll
+  for (int i = 0; i < nranks; ++i) {
+    int target = (rank + i) % nranks;
+    ptrs[i] = reinterpret_cast<const P*>(data.ptrs[target]);
+    tmps[i] = get_tmp_buf<P>(sg.signals[target]);
+  }
+  auto tmp_out = tmps[0];
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  for (int idx = start + tid; idx < end; idx += stride) {
+    tmp_out[idx - start] = packed_reduce<P, nranks, A>(ptrs, idx);
+  }
+  multi_rank_barrier<nranks, false, true>(sg, self_sg, rank);
+  for (int idx = tid; idx < largest_part; idx += stride) {
+#pragma unroll
+    for (int i = 0; i < nranks; ++i) {
+      int gather_rank = (rank + i) % nranks;
+      if (gather_rank == nranks - 1 || idx < part) {
+        reinterpret_cast<P*>(out)[gather_rank * part + idx] = tmps[i][idx];
+      }
+    }
+  }
+}
+
+template <typename T, int nranks, int vlen = 8>
+__device__ __forceinline__ void shfl_reduce(float* res) {
+  if constexpr (nranks >= 4) {
+#pragma unroll
+    for (int i = 0; i < vlen; ++i) {
+      res[i] += __shfl_xor_sync(0xffffffff, res[i], 16);
+    }
+  }
+#pragma unroll
+  for (int i = 0; i < vlen; ++i) {
+    res[i] += __shfl_xor_sync(0xffffffff, res[i], 8);
+  }
+}
+
+template <typename T, int nranks, int vlen = 8>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) custom_all_reduce_2shot(
+    RankData data, RankSignals sg, Signal* self_sg, T* __restrict__ out, int rank, int size) {
+  static_assert((nranks & (nranks - 1)) == 0, "custom_all_reduce_2shot requires power-of-two nranks");
+  constexpr int nranks_sft = (nranks >> 1) - (nranks >> 3);
+  constexpr int coalesce_num = 8;
+  constexpr int coalesce_sft = 3;
+  constexpr int group_stride_sft = nranks_sft + coalesce_sft;
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int target_rank = (tid >> coalesce_sft) & (nranks - 1);
+  const int group_id = tid >> group_stride_sft;
+  const int coalesce_tid = tid & (coalesce_num - 1);
+  const int stride = gridDim.x * blockDim.x;
+
+  typedef int16_t Vec __attribute__((vector_size(16)));
+  int idx_base = blockIdx.x * blockDim.x;
+  int idx_in_blk = coalesce_tid + (rank << coalesce_sft) + (group_id << group_stride_sft);
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  Vec* target_ptr = reinterpret_cast<Vec*>(const_cast<void*>(data.ptrs[target_rank]));
+  Vec* buffer_ptr = get_tmp_buf<Vec>(sg.signals[rank]);
+  do {
+    int idx = idx_in_blk + idx_base;
+    float acc[vlen] = {0};
+    if (idx < size) {
+#if SGL_CUSTOM_AR_VECTOR_LOAD
+      Vec raw = target_ptr[idx];
+      const T* src = reinterpret_cast<const T*>(&raw);
+#else
+      const T* src = reinterpret_cast<const T*>(&target_ptr[idx]);
+#endif
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] = to_float(src[i]);
+      }
+    }
+    shfl_reduce<T, nranks, vlen>(acc);
+    if constexpr (nranks == 8) {
+      __shared__ float smem[kMaxThreadsPerBlock << 1];
+      if (lane < coalesce_num) {
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          smem[warp * vlen * coalesce_num + coalesce_tid * vlen + i] = acc[i];
+        }
+      }
+      __syncthreads_lm();
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] += smem[(warp ^ 1) * vlen * coalesce_num + coalesce_tid * vlen + i];
+      }
+    }
+    if (rank == target_rank && idx < size) {
+      Vec res;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        reinterpret_cast<T*>(&res)[i] = downcast_s<T>(acc[i]);
+      }
+      buffer_ptr[idx] = res;
+    }
+    idx_base += stride;
+  } while (idx_base < size);
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  multi_rank_barrier<nranks, false, true>(sg, self_sg, rank);
+
+  buffer_ptr = get_tmp_buf<Vec>(sg.signals[target_rank]);
+  idx_in_blk = coalesce_tid + (target_rank << coalesce_sft) + (group_id << group_stride_sft);
+  idx_base = blockIdx.x * blockDim.x;
+  do {
+    int idx = idx_in_blk + idx_base;
+    if (idx < size) {
+      reinterpret_cast<Vec*>(out)[idx] = buffer_ptr[idx];
+    }
+    idx_base += stride;
+  } while (idx_base < size);
+}
+
+template <typename T, int nranks>
+void launch_ar(RankData data, RankSignals sg, Signal* self_sg, T* out, int rank, int size, int shot, musaStream_t stream) {
+  const int pack = packed_t<T>::P::size;
+  TVM_FFI_ICHECK_EQ(size % pack, 0);
+  int packed_size = size / pack;
+  int blocks = std::min(std::min(kDefaultBlockLimit, kMaxBlocks), (packed_size + kDefaultThreads - 1) / kDefaultThreads);
+  if (blocks <= 0) {
+    return;
+  }
+  if (shot == 1) {
+    cross_device_reduce_1stage<T, nranks><<<blocks, kDefaultThreads, 0, stream>>>(data, sg, self_sg, out, rank, packed_size);
+  } else if (shot == 2) {
+    if constexpr (std::is_same<T, float>::value || nranks == 6) {
+      cross_device_reduce_2stage<T, nranks><<<blocks, kDefaultThreads, 0, stream>>>(data, sg, self_sg, out, rank, packed_size);
+    } else {
+      custom_all_reduce_2shot<T, nranks><<<blocks, kDefaultThreads, 0, stream>>>(data, sg, self_sg, out, rank, packed_size);
+    }
+  } else {
+    TVM_FFI_THROW(ValueError) << "shot must be 1 or 2";
+  }
+}
+
+template <typename T>
+void dispatch_world_size(RankData data, RankSignals sg, Signal* self_sg, T* out, int rank, int world_size, int size, int shot, musaStream_t stream) {
+  switch (world_size) {
+    case 2:
+      launch_ar<T, 2>(data, sg, self_sg, out, rank, size, shot, stream);
+      break;
+    case 4:
+      launch_ar<T, 4>(data, sg, self_sg, out, rank, size, shot, stream);
+      break;
+    case 6:
+      launch_ar<T, 6>(data, sg, self_sg, out, rank, size, shot, stream);
+      break;
+    case 8:
+      launch_ar<T, 8>(data, sg, self_sg, out, rank, size, shot, stream);
+      break;
+    default:
+      TVM_FFI_THROW(ValueError) << "world_size must be one of 2/4/6/8";
+  }
+}
+
+}  // namespace
+
+int64_t vllm_musa_custom_ar_meta_size() {
+  return static_cast<int64_t>(sizeof(Signal));
+}
+
+void vllm_musa_custom_ar_launch_unregistered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView out,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t max_size_bytes,
+    int64_t rank,
+    int64_t world_size,
+    int64_t shot) {
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(out);
+  TVM_FFI_ICHECK_EQ(rank_data.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), out.dtype()));
+  TVM_FFI_ICHECK_EQ(tensor_numel(inp), tensor_numel(out));
+
+  RankSignals sg{};
+  const auto* ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(ptrs[i]);
+  }
+  RankData data{};
+  const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+  for (int i = 0; i < kMaxRanks; ++i) {
+    data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(out.device());
+  const int64_t numel64 = tensor_numel(out);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const int64_t nbytes = numel64 * ((static_cast<int64_t>(out.dtype().bits) * out.dtype().lanes + 7) / 8);
+  TVM_FFI_ICHECK_LE(nbytes, max_size_bytes);
+  const musaError_t copy_err = musaMemcpyAsync(
+      reinterpret_cast<void*>(self_buffer_ptr),
+      inp.data_ptr(),
+      static_cast<size_t>(nbytes),
+      musaMemcpyDeviceToDevice,
+      stream);
+  TVM_FFI_ICHECK_EQ(copy_err, musaSuccess) << "MUSA custom AR copy failed: " << musaGetErrorString(copy_err);
+  const int size = static_cast<int>(numel64);
+
+  if (dtype_equal(out.dtype(), dl_float16)) {
+    dispatch_world_size(data, sg, self_sg, static_cast<half*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_bfloat16)) {
+    dispatch_world_size(data, sg, self_sg, static_cast<__mt_bfloat16*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_float32)) {
+    dispatch_world_size(data, sg, self_sg, static_cast<float*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom ar only supports fp16/bf16/fp32";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA custom AR kernel failed: " << musaGetErrorString(err);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_meta_size, vllm_musa_custom_ar_meta_size);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_unregistered, vllm_musa_custom_ar_launch_unregistered);

--- a/vllm_musa/patches/manifest.py
+++ b/vllm_musa/patches/manifest.py
@@ -222,6 +222,7 @@ _CAT6: list[DivSpec] = [
 _SHADOW_MODULES = [
     ("4a", "vllm_musa/v1/attention/backends/flash_attn.py", "vllm/v1/attention/backends/flash_attn.py", "modified copy (sim 0.70) — drift tripwire"),
     ("4a", "vllm_musa/v1/attention/backends/mla/flashmla.py", "vllm/v1/attention/backends/mla/flashmla.py", "modified copy (sim 0.83) — drift tripwire"),
+    ("5", "vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py", None, "new MUSA JIT custom allreduce communicator"),
     ("5", "vllm_musa/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py", "vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py", "rebinds upstream (sim 0.12) — 4b-conversion candidate"),
     ("5", "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py", "vllm/model_executor/kernels/linear/scaled_mm/deep_gemm.py", "OOT subclass/register seam"),
     ("5", "vllm_musa/model_executor/kernels/linear/scaled_mm/torch_scaled_mm.py", None, "new MUSA module (no upstream)"),

--- a/vllm_musa/patches/series/0005-MUSA-vllm.distributed.device_communicators.cuda_comm.patch
+++ b/vllm_musa/patches/series/0005-MUSA-vllm.distributed.device_communicators.cuda_comm.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Wed, 3 Jun 2026 11:47:35 +0000
+Subject: [PATCH] MUSA: vllm.distributed.device_communicators.cuda_communicator
+
+---
+ .../device_communicators/cuda_communicator.py | 38 ++++++++++++++++++----
+ 1 file changed, 31 insertions(+), 7 deletions(-)
+
+diff --git a/vllm/distributed/device_communicators/cuda_communicator.py b/vllm/distributed/device_communicators/cuda_communicator.py
+index ee81bc20f..cccaf3d3c 100644
+--- a/vllm/distributed/device_communicators/cuda_communicator.py
++++ b/vllm/distributed/device_communicators/cuda_communicator.py
+@@ -99,13 +99,37 @@ class CudaCommunicator(DeviceCommunicatorBase):
+ 
+         if use_custom_allreduce and self.world_size > 1:
+             # Initialize a custom fast all-reduce implementation.
+-            self.ca_comm = CustomAllreduce(
+-                group=self.cpu_group,
+-                device=self.device,
+-                symm_mem_enabled=(
+-                    self.symm_mem_comm is not None and not self.symm_mem_comm.disabled
+-                ),
+-            )
++            if current_platform.is_musa():
++                try:
++                    from vllm_musa.distributed.device_communicators.musa_jit_custom_all_reduce import (
++                        MusaJitCustomAllreduce,
++                    )
++
++                    self.ca_comm = MusaJitCustomAllreduce(
++                        group=self.cpu_group,
++                        device=self.device,
++                        symm_mem_enabled=(
++                            self.symm_mem_comm is not None
++                            and not self.symm_mem_comm.disabled
++                        ),
++                    )
++                except Exception:
++                    logger.exception(
++                        "MUSA JIT custom all-reduce init failed; falling back "
++                        "to vLLM CustomAllreduce."
++                    )
++
++            # MUSA JIT init may fail or return a disabled communicator. In both
++            # cases, use the upstream csrc-backed CustomAllreduce fallback.
++            if self.ca_comm is None or self.ca_comm.disabled:
++                self.ca_comm = CustomAllreduce(
++                    group=self.cpu_group,
++                    device=self.device,
++                    symm_mem_enabled=(
++                        self.symm_mem_comm is not None
++                        and not self.symm_mem_comm.disabled
++                    ),
++                )
+ 
+             if current_platform.is_rocm():
+                 # Initialize a custom quick all-reduce implementation for AMD.

--- a/vllm_musa/patches/series/0062-MUSA-csrc-libtorch_stable-gptq-musa-enablement.patch
+++ b/vllm_musa/patches/series/0062-MUSA-csrc-libtorch_stable-gptq-musa-enablement.patch
@@ -79,16 +79,15 @@ index e3f79c5..5e6a99a 100644
            : (int*)q_perm.data_ptr(),
        q_weight.size(0) * 32 / bit, q_weight.size(1), bit);
 diff --git a/csrc/libtorch_stable/torch_bindings.cpp b/csrc/libtorch_stable/torch_bindings.cpp
-index 1601c3b..f16f09e 100644
+index 7de356b..0827de2 100644
 --- a/csrc/libtorch_stable/torch_bindings.cpp
 +++ b/csrc/libtorch_stable/torch_bindings.cpp
-@@ -542,3 +542,10 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CompositeExplicitAutograd, ops) {
+@@ -576,3 +576,9 @@ STABLE_TORCH_LIBRARY_IMPL(_C, PrivateUse1, ops) {
  }
- 
+ #endif
  REGISTER_EXTENSION(_C_stable_libtorch)
 +
-+// MUSA: register gptq in its own block -- the main CUDA block aborts at the
-+// uncompiled scaled int8/fp8 quant ops (static-init throw) and skips gptq.
++// MUSA: gptq in its own registration block, isolated from other ops' static-init.
 +STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, gptq_ops) {
 +  gptq_ops.impl("gptq_gemm", TORCH_BOX(&gptq_gemm));
 +  gptq_ops.impl("gptq_shuffle", TORCH_BOX(&gptq_shuffle));


### PR DESCRIPTION
## Motivation

The previous MUSA custom all-reduce path relied on pointer registration / per-input state that was fragile for CUDA/MUSA graph capture and replay. This could force fallback behavior or make the communicator unsafe in graph/Dynamo startup paths.

This change introduces a fixed-staging JIT CAR path so MUSA can use the same custom all-reduce implementation in eager execution, torch.compile, and CUDA/MUSA graph replay. The staging buffers are allocated once during communicator initialization and reused with stable addresses, avoiding dynamic allocation or pointer changes during graph replay.

## Modifications

- Add a MUSA JIT custom all-reduce wrapper in `vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py`.
- Register `torch.ops.vllm.musa_jit_custom_all_reduce` with a fake implementation so Dynamo/Inductor can treat the operation as a custom op instead of tracing through the Python JIT loader.
- Allocate fixed IPC shared metadata and staging buffers at communicator initialization.
- Support world sizes `2`, `4`, `6`, and `8`, with a guarded maximum CAR tensor size of `512 MiB`.
- Add the MUSA JIT build entry in `vllm_musa/jit_kernel/csrc/allreduce.py`.
- Add the MUSA custom all-reduce kernel source in `vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu`.
- Route the vLLM CUDA communicator patch to use `MusaJitCustomAllreduce` on MUSA.
- Keep unsupported tensors on the existing communicator fallback chain instead of forcing the JIT CAR path.
- Fall back to the existing MUSA QuickAllReduce path if JIT CAR initialization fails or returns a disabled communicator.

## Test

 Start cmd：

```
vllm serve /home/dist/models/Qwen3.5-35B-A3B-FP8 --host 127.0.0.1 --port 26063 --served-model-name qwen35 --tensor-parallel-size 4 --max-model-len 5120 --max-num-seqs 1 --max-num-batched-tokens 5120 --gpu-memory-utilization 0.90 --trust-remote-code --cudagraph-capture-sizes 1
```

Bench cmd：

```
vllm bench serve --backend openai --model qwen35 --tokenizer /home/dist/models/Qwen3.5-35B-A3B-FP8 --dataset-name random --random-input-len 4096 --random-output-len 1024 --num-prompts 1 --num-warmups 2 --max-concurrency 1 --request-rate inf --port 26063
```
baseline:

<img width="506" height="661" alt="image" src="https://github.com/user-attachments/assets/0f1bfc81-45fd-472d-995c-744d55cf9c9c" />

after opt:

<img width="506" height="661" alt="image" src="https://github.com/user-attachments/assets/56787181-9ebc-411e-a0a0-c738ddcff36b" />


Smoke tests:

| Model | TP | Backend | Result |
|---|---:|---|---|
| `/home/dist/models/Qwen3-8B-FP8` | 4 | FLASH_ATTN | PASS, JIT CAR world_size=4 |
| `/home/dist/models/Qwen3-32B-FP8` | 4 | FLASH_ATTN | PASS, JIT CAR world_size=4 |
| `/home/dist/models/DeepSeek-Coder-V2-Lite-Instruct` | 2 | FLASH_MLA | PASS, JIT CAR world_size=2 |
| `/home/dist/models/DeepSeek-V2-Lite-Chat-FP8` | 1 | FLASH_MLA | PASS |

