### PR TITLE
Fix MUSA seeded sampling on v0.22

### DIFF
--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -91,6 +91,7 @@ class Envs:
     VLLM_MUSA_FUSED_ADD_RMSNORM = EnvBool(True)
     VLLM_MUSA_ENABLE_JIT_TOPK = EnvBool(True)
     VLLM_MUSA_SAMPLER_FAST_PATH = EnvBool(True)
+    VLLM_MUSA_SEEDED_MULTINOMIAL = EnvBool(True)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
 
 

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -25,6 +25,10 @@ def sampler_fast_path_enabled() -> bool:
     return envs.VLLM_MUSA_SAMPLER_FAST_PATH.get()
 
 
+def musa_seeded_multinomial_enabled() -> bool:
+    return envs.VLLM_MUSA_SEEDED_MULTINOMIAL.get()
+
+
 def is_musa_tensor(tensor: torch.Tensor) -> bool:
     return tensor.device.type == "musa"
 
@@ -130,6 +134,28 @@ def sample_from_logits(
     return sample_from_probs(probs, top_k, top_p, min_p)
 
 
+def sample_probs_seeded_multinomial(
+    probs: torch.Tensor,
+    generators: dict[int, torch.Generator],
+) -> torch.Tensor:
+    samples = []
+    for row_idx in range(probs.shape[0]):
+        generator = generators.get(row_idx)
+        if generator is None:
+            sample = torch.multinomial(
+                probs[row_idx], num_samples=1, replacement=True
+            )
+        else:
+            sample = torch.multinomial(
+                probs[row_idx],
+                num_samples=1,
+                replacement=True,
+                generator=generator,
+            )
+        samples.append(sample)
+    return torch.cat(samples, dim=0).to(dtype=torch.long).view(-1)
+
+
 def _apply_top_k_top_p_musa_topk_prefilter(
     logits: torch.Tensor, k: torch.Tensor, p: torch.Tensor
 ) -> torch.Tensor:
@@ -200,6 +226,23 @@ def forward_musa(
     p: torch.Tensor | None,
     min_p: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
+    if (
+        generators
+        and musa_seeded_multinomial_enabled()
+        and current_platform.is_musa()
+        and is_musa_tensor(logits)
+        and self.logprobs_mode not in ("processed_logits", "processed_logprobs")
+    ):
+        if min_p is not None:
+            return self.forward_native(logits, generators, k, p)
+        logits = _apply_top_k_top_p(logits, k, p)
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+        vllm_topk_topp_sampler.logger.info_once(
+            "Using MUSA seeded multinomial sampling for per-request generators.",
+            scope="global",
+        )
+        return sample_probs_seeded_multinomial(probs, generators), None
+
     if not can_use_musa_sampler(logits, generators, self.logprobs_mode):
         if generators:
             logger.debug(
@@ -367,6 +410,27 @@ def has_worker_user_seed(sampling_states: Any, idx_mapping_np: np.ndarray) -> bo
     return bool(np.any(has_user_seed[idx_mapping_np]))
 
 
+def can_use_worker_seeded_multinomial(
+    logits: torch.Tensor,
+    logprobs_mode: LogprobsMode,
+    sampling_states: Any,
+    idx_mapping_np: np.ndarray,
+) -> bool:
+    if not musa_seeded_multinomial_enabled():
+        return False
+    if not current_platform.is_musa() or not is_musa_tensor(logits):
+        return False
+    if logprobs_mode == "processed_logprobs":
+        return False
+    if not has_worker_user_seed(sampling_states, idx_mapping_np):
+        return False
+    if np.any(sampling_states.temperature.np[idx_mapping_np] <= _SAMPLING_EPS):
+        return False
+    if getattr(sampling_states, "musa_generators", None) is None:
+        return False
+    return True
+
+
 def can_use_worker_sampler(
     logits: torch.Tensor,
     logprobs_mode: LogprobsMode,
@@ -403,16 +467,37 @@ def sample_worker_logits(
     return sample_from_logits(logits, top_k, top_p, min_p)
 
 
+def sample_worker_logits_seeded_multinomial(
+    logits: torch.Tensor,
+    sampling_states: Any,
+    idx_mapping_np: np.ndarray,
+) -> torch.Tensor:
+    probs = logits.softmax(dim=-1, dtype=torch.float32)
+    generators = {
+        row_idx: sampling_states.musa_generators.get(int(req_idx))
+        for row_idx, req_idx in enumerate(idx_mapping_np)
+    }
+    return sample_probs_seeded_multinomial(probs, generators)
+
+
 def _sampling_states_init(self: Any, max_num_reqs: int, vocab_size: int):
     original_init = vllm_worker_states.SamplingStates._musa_original_init
     original_init(self, max_num_reqs, vocab_size)
     self.has_user_seed = np.zeros(self.max_num_reqs, dtype=np.bool_)
+    self.musa_generators = {}
 
 
 def _sampling_states_add_request(self: Any, req_idx: int, sampling_params: Any) -> None:
     original_add_request = vllm_worker_states.SamplingStates._musa_original_add_request
     original_add_request(self, req_idx, sampling_params)
-    self.has_user_seed[req_idx] = sampling_params.seed is not None
+    seed = sampling_params.seed
+    self.has_user_seed[req_idx] = seed is not None
+    if seed is None:
+        self.musa_generators.pop(req_idx, None)
+    else:
+        generator = torch.Generator(device="musa")
+        generator.manual_seed(seed)
+        self.musa_generators[req_idx] = generator
 
 
 def _apply_worker_sampling_params_defer_filters(
@@ -448,6 +533,30 @@ def _apply_worker_sampling_params_defer_filters(
     return logits
 
 
+def _apply_worker_sampling_filters_for_seeded_multinomial(
+    sampler: Any,
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    idx_mapping_np: np.ndarray,
+) -> torch.Tensor:
+    logits = torch.empty_like(logits, dtype=torch.float32).copy_(logits)
+
+    vocab_size = sampler.sampling_states.vocab_size
+    use_top_k = np.any(sampler.sampling_states.top_k.np[idx_mapping_np] != vocab_size)
+    use_top_p = np.any(sampler.sampling_states.top_p.np[idx_mapping_np] != 1.0)
+    use_min_p = np.any(sampler.sampling_states.min_p.np[idx_mapping_np] != 0.0)
+    top_k = (
+        sampler.sampling_states.top_k.gpu[expanded_idx_mapping] if use_top_k else None
+    )
+    top_p = (
+        sampler.sampling_states.top_p.gpu[expanded_idx_mapping] if use_top_p else None
+    )
+    logits = _apply_top_k_top_p(logits, top_k, top_p)
+    if use_min_p:
+        sampler.sampling_states.apply_min_p(logits, expanded_idx_mapping, idx_mapping_np)
+    return logits
+
+
 def _worker_sample(
     self: Any,
     logits: torch.Tensor,
@@ -457,6 +566,36 @@ def _worker_sample(
     input_ids: torch.Tensor,
     expanded_local_pos: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if (
+        logits.shape[0] == idx_mapping_np.shape[0]
+        and can_use_worker_seeded_multinomial(
+            logits, self.logprobs_mode, self.sampling_states, idx_mapping_np
+        )
+    ):
+        vllm_topk_topp_sampler.logger.info_once(
+            "Using MUSA seeded multinomial sampling for user-seeded requests.",
+            scope="global",
+        )
+        processed_logits = _apply_worker_sampling_params_defer_filters(
+            self,
+            logits,
+            expanded_idx_mapping,
+            idx_mapping_np,
+            pos,
+            input_ids,
+            expanded_local_pos,
+        )
+        sampling_logits = _apply_worker_sampling_filters_for_seeded_multinomial(
+            self,
+            processed_logits,
+            expanded_idx_mapping,
+            idx_mapping_np,
+        )
+        sampled = sample_worker_logits_seeded_multinomial(
+            sampling_logits, self.sampling_states, idx_mapping_np
+        )
+        return sampled, processed_logits
+
     if can_use_worker_sampler(
         logits, self.logprobs_mode, self.sampling_states, idx_mapping_np
     ):


### PR DESCRIPTION
## Summary

This PR fixes unstable seeded random sampling on MUSA for vLLM v0.22.0-dev.

When requests use per-request `seed` / `torch.Generator`, the previous MUSA sampler path fell back to upstream vLLM's PyTorch-native random sampling path. On MUSA this path goes through the Gumbel/exponential trick and can produce corrupted token sampling results under high-temperature multi-output generation, causing abnormal tokens such as `_malloc`, `.connector`, `ubuntu`, `efeller`, `Petunia`, or mixed non-target-language fragments in generated text and JSON answers.

The fix keeps seeded sampling on MUSA by using `torch.multinomial(..., generator=...)` on MUSA tensors, avoiding CPU fallback and avoiding the unstable upstream exponential trick path.

## Changes

- Add `VLLM_MUSA_SEEDED_MULTINOMIAL`, enabled by default.
- Add MUSA seeded multinomial sampling for per-request generators.
- Add worker-side seeded multinomial handling for user-seeded requests.
- Preserve existing native MUSA top-k/top-p/min-p fast path for non-seeded sampling.
- Keep fallback behavior available by setting `VLLM_MUSA_SEEDED_MULTINOMIAL=0`.

## Root Cause

For seeded random sampling, `vllm_musa` previously rejected the MUSA native sampler when `generators` existed, then fell back to upstream vLLM's native PyTorch sampling implementation.

That upstream fallback uses the Gumbel/exponential sampling trick. In the MUSA runtime this path is unstable for the affected seeded multi-sample workload, producing invalid sampled token ids semantically observed as corrupted text and malformed JSON outputs.

## Validation

Environment:

| Item | Value |
|---|---|
| Model | `/home/dist/models/OneThinker-SFT-Qwen3-8B` |
| Original script | `/tmp/vllm_omni_musa_inputs/vllm_inference_simple.py` |

Test command shape:

```bash
TORCHDYNAMO_DISABLE=1 \
VLLM_WORKER_MULTIPROC_METHOD=spawn \
PYTHONUNBUFFERED=1 \
PYTHONPATH="/tmp/vllm-musa-v022-mm-seeded:/home/dist/vllm-musa/third_party/vllm" \
python /tmp/vllm_omni_musa_inputs/vllm_inference_simple.py
```

Pre-fix / negative-control run used:

```bash
VLLM_MUSA_SEEDED_MULTINOMIAL=0
```

### Original Script Results

| Test | Mode | Samples | Bad token hits | Closed `<answer>` | Valid JSON | Result |
|---|---:|---:|---:|---:|---:|---|
| Original script, image + video | fix enabled | 16 | 0 | 15 | 14 | PASS |
| Same script, same seed | `VLLM_MUSA_SEEDED_MULTINOMIAL=0` | 16 | 7 | 13 | 10 | FAIL |

Bad tokens reproduced with fix disabled:

| Token pattern | Observed |
|---|---:|
| `_malloc` | yes |
| `.connector` | yes |
| `ubuntu` | yes |
| `efeller` | yes |
| `Petunia` | yes |
| Mixed invalid characters in JSON | yes |

With the fix enabled, none of these corrupted token patterns appeared in the 16 generated outputs.

### Focused Reproduction

| Test | Before fix | After fix |
|---|---:|---:|
| Image-only seeded reproduction, `n=8` | `bad=2`, `closed=7`, `json_ok=5` | `bad=0`, `closed=8`, `json_ok=8` |

The patched run also logged:

```text
Using MUSA seeded multinomial sampling for per-request generators.
```

### Text Regression

| Test | Result |
|---|---|
| Qwen3-8B greedy QA | PASS |
| Qwen3-8B seeded text generation | PASS |
| Bad token scan | PASS |

## Conclusion

The original v0.22.0-dev code can reproduce corrupted outputs when seeded random sampling falls back to the upstream exponential trick path on MUSA. This PR keeps seeded sampling on MUSA using generator-aware multinomial sampling, removes the corrupted-token behavior in the original script, and does not require CPU fallback.