### PR TITLE
Add MUSA Docker image build flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+.git
+.gitignore
+.pytest_cache
+.ruff_cache
+__pycache__
+*.py[cod]
+build
+dist
+*.egg-info
+vllm_musa.egg-info
+.coverage
+htmlcov
+
+# setup.py clones and pins third_party sources inside the image. Copying a local
+# checkout makes the build context large and can hide drift from the pinned refs.
+third_party/vllm
+third_party/flashinfer
+
+# Local/editor artifacts.
+.claude
+.humanize
+assets

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The plugin leverages the following key components:
 
 | vLLM Version | PyTorch Version | Engine  | Status       |
 |--------------|-----------------|---------|--------------|
-| v0.22.0       | 2.7.1           | V1 only | ✅ Supported |
+| v0.22.0       | 2.9.x           | V1 only | ✅ Supported |
 
 > **Note**: This plugin uses vLLM's V1 engine architecture. V0 engine is not supported.
 
@@ -57,7 +57,15 @@ The plugin leverages the following key components:
     cd vllm-musa
     ```
 
-2. Install vLLM Hardware Plugin for Moore Threads MUSA:
+2. Install Python dependencies before installing `vllm-musa`. The MUSA
+   requirements entrypoint includes common dependencies and MUSA-private pins
+   such as `torch` and `torch_musa`.
+
+    ```bash
+    pip install -r requirements/build.txt -r requirements/musa.txt
+    ```
+
+3. Install vLLM Hardware Plugin for Moore Threads MUSA:
 
     ```bash
     # Standard installation (installs vLLM MUSA plugin and vLLM)
@@ -67,7 +75,7 @@ The plugin leverages the following key components:
     pip install -e . --no-build-isolation -v
     ```
 
-3. Verify the installation:
+4. Verify the installation:
 
     ```bash
     # Check plugin registration
@@ -105,6 +113,7 @@ Useful commands:
 
 ```bash
 ccache --zero-stats
+pip install -r requirements/build.txt -r requirements/musa.txt
 pip install -e . --no-build-isolation -v
 ccache --show-stats
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -44,7 +44,7 @@
 
 | vLLM 版本 | PyTorch 版本 | 引擎    | 状态         |
 |-----------|--------------|---------|--------------|
-| v0.22.0    | 2.7.1        | 仅 V1   | ✅ 已支持    |
+| v0.22.0    | 2.9.x        | 仅 V1   | ✅ 已支持    |
 
 > **注意**：本插件使用 vLLM 的 V1 引擎架构，不支持 V0 引擎。
 
@@ -57,7 +57,14 @@
     cd vllm-musa
     ```
 
-2. 安装摩尔线程 MUSA 的 vLLM 硬件插件：
+2. 安装 `vllm-musa` 前先安装 Python 依赖。MUSA requirements 入口包含通用依赖
+   和 `torch`、`torch_musa` 等 MUSA private 版本约束：
+
+    ```bash
+    pip install -r requirements/build.txt -r requirements/musa.txt
+    ```
+
+3. 安装摩尔线程 MUSA 的 vLLM 硬件插件：
 
     ```bash
     # 标准安装（安装 vLLM MUSA 插件和 vLLM）
@@ -67,7 +74,7 @@
     pip install -e . --no-build-isolation -v
     ```
 
-3. 验证安装：
+4. 验证安装：
 
     ```bash
     # 检查插件注册

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,172 @@
+# Building the vLLM-MUSA image
+
+`docker/build_image.sh` builds the vLLM plugin for Moore Threads (MUSA) GPUs into
+a runnable Docker image from `docker/musa.Dockerfile`. It is the supported entry
+point — it defines every setting in one place and passes them to the build as
+`--build-arg`s, so the Dockerfile itself carries no hardcoded URLs or versions.
+
+The resulting image contains:
+
+- the MUSA runtime SDK (installed from apt),
+- the MUSA/MT Python wheels (`torch`, `torch_musa`, `mate`, `flash_attn_3`,
+  `flash_mla`, `deep-gemm`, `tilelang_musa`, `apache-tvm-ffi`,
+  `torch_c_dlpack_ext`),
+- `vllm-musa` and the vendored upstream vLLM, built from source.
+
+## Prerequisites
+
+- **Docker** on the build host.
+- **Network access** from the build to:
+  - the internal Moore Threads pip index (`MUSA_PIP_INDEX_URL`) — reachable only
+    inside the MT network; hosts the MUSA/MT wheels,
+  - a public PyPI index/mirror (`PYPI_INDEX_URL`) — ordinary third-party wheels
+    and the vendored vLLM's dependencies,
+  - the MUSA apt source (`MUSA_APT_SOURCE`) — the runtime SDK,
+  - GitHub — the vendored vLLM/flashinfer clones (and Mooncake, if enabled).
+- **A MUSA GPU visible to the build** if you want the final-stage import verify to
+  pass — see [Building on a MUSA host](#building-on-a-musa-host).
+
+## Quick start
+
+From the repository root:
+
+```bash
+bash docker/build_image.sh
+```
+
+With the defaults this produces:
+
+```
+vllm-musa:ubuntu22.04_py3.10_musa_runtime_5.1_pytorch_2_release_2.9
+```
+
+Every setting is an environment variable — override by exporting it or prefixing
+the command, e.g.:
+
+```bash
+MUSA_RUNTIME_VERSION=5.2 IMAGE_TAG=vllm-musa:dev bash docker/build_image.sh
+```
+
+Any extra arguments are forwarded verbatim to `docker build`, so you can also pass
+`--build-arg`, `--target`, `--no-cache`, etc.:
+
+```bash
+bash docker/build_image.sh --no-cache --build-arg http_proxy=http://proxy:8118
+```
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `BASE_IMAGE` | `ubuntu:22.04` | Base image. Point at a local/mirror image if Docker Hub is unreachable, or an `mthreads/musa:*-devel` image to reuse its runtime. |
+| `PYTHON_VERSION` | `3.10` | Python version (apt `python3.X`). MUSA 5.2.0 wheels cover 3.10 and 3.12. |
+| `MUSA_APT_SOURCE` | `https://dl.mthreads.com/repo/repository/ubuntu2204/` | apt repo for the MUSA runtime SDK. |
+| `INSTALL_MUSA_STACK` | `auto` | `auto`: install the MUSA apt stack unless the base already provides `mcc`; `0`: skip (base image supplies the runtime). |
+| `MUSA_RUNTIME_VERSION` | `5.1` | MUSA runtime line as `major.minor`; derives apt package names (e.g. `musa-toolkit-5-1`). |
+| `MCCL_VERSION` | `2.3.0` | MCCL (collective communication library) version. |
+| `PYPI_INDEX_URL` | `https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple` | Public index for ordinary third-party wheels **and** the vendored vLLM's dependencies. |
+| `MUSA_PIP_INDEX_URL` | `https://xxx/simple` | Internal MT index for the MUSA/MT wheels. |
+| `BUILD_MOONCAKE` | `0` | `1`: build Mooncake (KV transfer engine) from source; `0`: skip. |
+| `MOONCAKE_REPO` / `MOONCAKE_COMMIT` | GitHub / pinned SHA | Mooncake source (only used when `BUILD_MOONCAKE=1`). |
+| `IMAGE_REPOSITORY` | `vllm-musa` | Image repository name. |
+| `IMAGE_FLAVOR` | `ubuntu22.04_py<py>_musa_runtime_<ver>_pytorch_2_release_<torch>` | Tag flavor; `<torch>` is derived from `requirements/musa_private.txt`. |
+| `IMAGE_TAG` | `${IMAGE_REPOSITORY}:${IMAGE_FLAVOR}` | Full image tag. |
+
+## Common scenarios
+
+**Use a specific PyPI mirror** (ordinary wheels + vendored vLLM deps):
+
+```bash
+PYPI_INDEX_URL=https://<mirror>/simple bash docker/build_image.sh
+```
+
+**Build behind an HTTP proxy** (covers apt, git, and every pip step, including the
+nested vLLM install):
+
+```bash
+bash docker/build_image.sh \
+  --build-arg http_proxy=http://<proxy>:<port> \
+  --build-arg https_proxy=http://<proxy>:<port> \
+  --build-arg no_proxy=.mthreads.com
+```
+
+Keep `no_proxy=.mthreads.com` so the internal MUSA wheel index stays on a direct
+connection.
+
+**Docker Hub not reachable** — build from a locally-present base:
+
+```bash
+BASE_IMAGE=<local-ubuntu-22.04-image> bash docker/build_image.sh
+```
+
+**Use a MUSA 5.2 runtime** (matches the wheel line natively; the 5.1 shims no-op):
+
+```bash
+MUSA_RUNTIME_VERSION=5.2 MUSA_APT_SOURCE=<5.2-apt-repo> bash docker/build_image.sh
+```
+
+**Include Mooncake:**
+
+```bash
+BUILD_MOONCAKE=1 bash docker/build_image.sh
+```
+
+**Build only up to the dependency layer** (installs the wheels, skips the vLLM
+compile and the import verify — handy for verifying the pip install offline of a
+GPU):
+
+```bash
+bash docker/build_image.sh --target vllm_musa_deps
+```
+
+## Building on a MUSA host
+
+The `final` stage's verify step imports every MUSA package, including `tilelang`
+and `flash_mla`, which require `torch.musa.is_available()` to be `True` at import
+time. That is only satisfied when the build step can see the GPU — i.e. when the
+**MUSA container runtime is the host's default docker runtime**, so `docker build`
+`RUN` steps get the device. On a CPU-only builder the build otherwise completes
+and then fails at the verify step with
+`ImportError: cannot import name 'GPUEvent' from 'tilelang.utils.device'`.
+
+Two build-time details make this work on such a host:
+
+- **Device visibility is set only in the final stage.** `MTHREADS_VISIBLE_DEVICES`
+  is deliberately *not* set in the earlier stages: if it were, the MUSA runtime
+  would bind-mount host driver libraries into every `apt` step and break package
+  installs (`Invalid cross-device link`).
+- **MUSA 5.1 shims.** The published wheels are built for MUSA 5.2.0. When building
+  against the 5.1 runtime, the runtime stage adds a `libmupti.so.1` soname link
+  and a `libmusolver` OpenBLAS dependency so `import torch` works. Both are guarded
+  and no-op on a matching 5.2 runtime.
+
+## Verify the built image
+
+```bash
+docker run --rm <MUSA GPU flags> \
+  vllm-musa:ubuntu22.04_py3.10_musa_runtime_5.1_pytorch_2_release_2.9 \
+  python -c "import torch, torch_musa; print('musa available:', torch.musa.is_available())"
+```
+
+On a MUSA GPU you should see `musa available: True`.
+
+## How it works (build stages)
+
+`docker/musa.Dockerfile` is multi-stage:
+
+1. **base** — env and library paths.
+2. **apt_base** — build toolchain + Python (from apt).
+3. **runtime** — the MUSA SDK from apt (`INSTALL_MUSA_STACK`) + the 5.1 shims.
+4. **mooncake** — optional Mooncake source build (`BUILD_MOONCAKE`).
+5. **vllm_musa_deps** — the Python dependencies, installed in three passes:
+   1. MUSA/MT wheels from `MUSA_PIP_INDEX_URL` only (`--no-deps`),
+   2. ordinary third-party wheels from `PYPI_INDEX_URL`,
+   3. the MUSA wheels' remaining ordinary deps from `PYPI_INDEX_URL`.
+
+   The split keeps names like `torch`/`mate`/`apache-tvm-ffi` resolving from the
+   internal index only, so pip never pulls the unrelated public (CUDA) builds.
+6. **final** — copies the source, builds `vllm-musa` + the vendored vLLM, re-pins
+   `numpy`, and runs the `PASS import ...` verify block.
+
+For the reasoning behind the pip-index split and the runtime shims, see the
+comments in `docker/musa.Dockerfile`.

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+PYTHON_VERSION="${PYTHON_VERSION:-3.10}"
+BASE_IMAGE="${BASE_IMAGE:-ubuntu:22.04}"
+
+MUSA_APT_SOURCE="${MUSA_APT_SOURCE:-https://dl.mthreads.com/repo/repository/ubuntu2204/}"
+INSTALL_MUSA_STACK="${INSTALL_MUSA_STACK:-auto}"
+MUSA_RUNTIME_VERSION="${MUSA_RUNTIME_VERSION:-5.1}"
+MCCL_VERSION="${MCCL_VERSION:-2.3.0}"
+
+# Python package indexes. MUSA/MT wheels (torch, torch_musa, mate, ...) resolve
+# from the internal Moore Threads index only; ordinary third-party wheels resolve
+# from public PyPI. See docker/musa.Dockerfile for why the two are not merged.
+PYPI_INDEX_URL="${PYPI_INDEX_URL:-https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple}"
+MUSA_PIP_INDEX_URL="${MUSA_PIP_INDEX_URL:-https://dl.mthreads.com/repo/api/pypi/pypi/simple}"
+
+PYTORCH_RELEASE="$(
+    awk -F'==' '/^torch==/ {gsub(/\.\*/, "", $2); print $2; exit}' \
+        requirements/musa_private.txt
+)"
+if [[ -z "${PYTORCH_RELEASE}" ]]; then
+    echo "Failed to derive PyTorch release from requirements/musa_private.txt" >&2
+    exit 1
+fi
+
+BUILD_MOONCAKE="${BUILD_MOONCAKE:-0}"
+MOONCAKE_REPO="${MOONCAKE_REPO:-https://github.com/kvcache-ai/Mooncake.git}"
+MOONCAKE_COMMIT="${MOONCAKE_COMMIT:-b6a841dc78c707ec655a563453277d969fb8f38d}"
+
+IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-vllm-musa}"
+IMAGE_FLAVOR="${IMAGE_FLAVOR:-ubuntu22.04_py${PYTHON_VERSION}_musa_runtime_${MUSA_RUNTIME_VERSION}_pytorch_release_${PYTORCH_RELEASE}}"
+IMAGE_TAG="${IMAGE_TAG:-${IMAGE_REPOSITORY}:${IMAGE_FLAVOR}}"
+
+docker build \
+    --network host \
+    -f docker/musa.Dockerfile \
+    -t "${IMAGE_TAG}" \
+    --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+    --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+    --build-arg MUSA_APT_SOURCE="${MUSA_APT_SOURCE}" \
+    --build-arg PYPI_INDEX_URL="${PYPI_INDEX_URL}" \
+    --build-arg MUSA_PIP_INDEX_URL="${MUSA_PIP_INDEX_URL}" \
+    --build-arg INSTALL_MUSA_STACK="${INSTALL_MUSA_STACK}" \
+    --build-arg MUSA_RUNTIME_VERSION="${MUSA_RUNTIME_VERSION}" \
+    --build-arg MCCL_VERSION="${MCCL_VERSION}" \
+    --build-arg BUILD_MOONCAKE="${BUILD_MOONCAKE}" \
+    --build-arg MOONCAKE_REPO="${MOONCAKE_REPO}" \
+    --build-arg MOONCAKE_COMMIT="${MOONCAKE_COMMIT}" \
+    "$@" \
+    .

--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -1,0 +1,411 @@
+# vllm-musa image for Ubuntu 22.04 and the MUSA apt stack. Release flow only --
+# do not add validation-only wheel/tar download-and-extract logic here.
+
+ARG BASE_IMAGE=ubuntu:22.04
+ARG PYTHON_VERSION=3.10
+
+FROM ${BASE_IMAGE} AS base
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG PYTHON_VERSION
+
+# torch_musa uses "31"; MATE 0.2.3 parses dotted arch tokens such as "3.1".
+# MTHREADS_VISIBLE_DEVICES is set only in the final stage: under a MUSA default
+# runtime it bind-mounts host driver libs into every build step, breaking apt
+# ("Invalid cross-device link").
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_CACHE_DIR=/root/.cache/pip \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1 \
+    MUSA_HOME=/usr/local/musa \
+    MTGPU_TARGET=mp_31 \
+    TORCH_MUSA_ARCH_LIST=31 \
+    MATE_MUSA_ARCH_LIST=3.1
+ENV PATH=/usr/local/mtshmem/bin:${MUSA_HOME}/bin:${MUSA_HOME}/mudnn/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/mtshmem/lib:${MUSA_HOME}/lib:${MUSA_HOME}/mudnn/lib:/usr/local/lib
+
+FROM base AS apt_base
+
+ARG PYTHON_VERSION
+
+RUN sed -i 's@http://archive.ubuntu.com/ubuntu/@http://mirrors.aliyun.com/ubuntu/@g' /etc/apt/sources.list
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        bash \
+        build-essential \
+        ca-certificates \
+        ccache \
+        cmake \
+        curl \
+        g++-12 \
+        gcc-12 \
+        git \
+        git-lfs \
+        gnupg \
+        infiniband-diags \
+        libcurl4-openssl-dev \
+        libdrm2 \
+        libibverbs-dev \
+        libmkl-core \
+        libmkl-gnu-thread \
+        libmkl-intel-lp64 \
+        libnuma1 \
+        libomp-dev \
+        libopenblas-base \
+        libopenmpi-dev \
+        librdmacm-dev \
+        libssl-dev \
+        libstdc++-12-dev \
+        libtool \
+        libyaml-dev \
+        lsb-release \
+        lsof \
+        make \
+        ninja-build \
+        numactl \
+        openmpi-bin \
+        openssh-client \
+        patchelf \
+        pkg-config \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-dev \
+        python3-pip \
+        python-is-python3 \
+        rdma-core \
+        unzip \
+        xz-utils \
+        zip && \
+    python -m pip install --upgrade pip && \
+    rm -rf /var/lib/apt/lists/*
+
+# The torch 2.9.x MUSA wheel links MKL with .so.2 sonames. Ubuntu 22.04 apt
+# ships the same logical MKL components without that suffix.
+RUN ln -sf /usr/lib/x86_64-linux-gnu/libmkl_intel_lp64.so \
+        /usr/lib/x86_64-linux-gnu/libmkl_intel_lp64.so.2 && \
+    ln -sf /usr/lib/x86_64-linux-gnu/libmkl_gnu_thread.so \
+        /usr/lib/x86_64-linux-gnu/libmkl_gnu_thread.so.2 && \
+    ln -sf /usr/lib/x86_64-linux-gnu/libmkl_core.so \
+        /usr/lib/x86_64-linux-gnu/libmkl_core.so.2 && \
+    ldconfig
+
+FROM apt_base AS runtime
+
+ARG MUSA_APT_SOURCE=https://dl.mthreads.com/repo/repository/ubuntu2204/
+ARG INSTALL_MUSA_STACK=auto
+ARG MUSA_RUNTIME_VERSION=5.1
+ARG MCCL_VERSION=2.3.0
+# The muDNN libs (libmudnn3-musa-5*) and mthreads-mtml lack a "-5-1" suffix, so
+# pin them by version: muDNN 5.1 is 3.3.0.0 (5.2 would be 3.4.0.0).
+ARG MUSA_MUDNN_VERSION=3.3.0.0
+ARG MUSA_MTML_VERSION=2.4.1
+
+# Install the MUSA stack from the apt source. MUSA_RUNTIME_VERSION (major.minor,
+# e.g. 5.1) is the single version selector and derives the "-5-1" package suffix.
+RUN printf 'deb [trusted=true] %s jammy main\n' "${MUSA_APT_SOURCE}" \
+        > /etc/apt/sources.list.d/musa.list && \
+    if [[ "${INSTALL_MUSA_STACK}" == "0" ]]; then \
+        echo "Skipping MUSA apt stack install because INSTALL_MUSA_STACK=0"; \
+        exit 0; \
+    fi && \
+    if [[ "${INSTALL_MUSA_STACK}" == "auto" ]] && command -v mcc >/dev/null 2>&1; then \
+        echo "Keeping MUSA stack from BASE_IMAGE"; \
+        mcc --version || true; \
+        exit 0; \
+    fi && \
+    apt-get update && \
+    if [[ "${MUSA_RUNTIME_VERSION}" =~ ^([0-9]+)\.([0-9]+)(\.|$) ]]; then \
+        runtime_major="${BASH_REMATCH[1]}"; \
+        runtime_minor="${BASH_REMATCH[2]}"; \
+        runtime_suffix="${runtime_major}-${runtime_minor}"; \
+    else \
+        echo "MUSA_RUNTIME_VERSION must start with <major>.<minor>, got ${MUSA_RUNTIME_VERSION}" >&2; \
+        exit 1; \
+    fi && \
+    resolve_apt_package() { \
+        local logical="$1"; \
+        local versions="$2"; \
+        local allow_unversioned="$3"; \
+        shift 3; \
+        local spec=""; \
+        local version pkg found_version; \
+        for version in ${versions}; do \
+            for pkg in "$@"; do \
+                if ! apt-cache show "${pkg}" >/dev/null 2>&1; then \
+                    continue; \
+                fi; \
+                found_version="$(apt-cache madison "${pkg}" | awk -v w="${version}" '$3 ~ "^" w "([-+~:]|$)" && ex=="" {ex=$3} $3 ~ "^" w "[.]" && pf=="" {pf=$3} END {print (ex!="" ? ex : pf)}')"; \
+                if [[ -n "${found_version}" ]]; then \
+                    spec="${pkg}=${found_version}"; \
+                    break 2; \
+                fi; \
+            done; \
+        done; \
+        if [[ -z "${spec}" && "${allow_unversioned}" == "1" ]]; then \
+            for pkg in "$@"; do \
+                if apt-cache show "${pkg}" >/dev/null 2>&1; then \
+                    spec="${pkg}"; \
+                    break; \
+                fi; \
+            done; \
+        fi; \
+        if [[ -z "${spec}" ]]; then \
+            echo "No apt package found for ${logical} with versions [${versions}]; checked: $*" >&2; \
+            return 1; \
+        fi; \
+        echo "${spec}"; \
+    } && \
+    # Pin the whole MUSA stack to the runtime line and install it in ONE apt
+    # transaction: the source now mixes 5.1.0/5.2.0 builds, so an unversioned or
+    # per-package install can split it across /usr/local/musa-5.1 and -5.2. The
+    # "-5-1" suffix pins most packages; the rest are pinned by version. Entry
+    # format: "logical|version-prefixes|candidate,packages" (empty prefixes take
+    # the name as-is, else matched against apt-cache madison -- an exact version
+    # match wins over a longer one, while a line prefix like 5.1 matches 5.1.0).
+    # TODO: replace mccl-s5000 with generic mccl once MCCL ships a unified package.
+    musa_pkg_defs=( \
+        "musa-toolkit||musa-toolkit-${runtime_suffix}" \
+        "musa-toolkit-config||musa-toolkit-${runtime_suffix}-config-common" \
+        "mtcc||mtcc-${runtime_suffix}" \
+        "musa-musart||musa-musart-${runtime_suffix}" \
+        "musa-mupti||musa-mupti-${runtime_suffix}" \
+        "musa-mualg||musa-mualg-${runtime_suffix}" \
+        "musa-muthrust||musa-muthrust-${runtime_suffix}" \
+        "musify||musify-${runtime_suffix}" \
+        "libmublas||libmublas-${runtime_suffix}" \
+        "libmufft||libmufft-${runtime_suffix}" \
+        "libmupp||libmupp-${runtime_suffix}" \
+        "libmurand||libmurand-${runtime_suffix}" \
+        "libmusparse||libmusparse-${runtime_suffix}" \
+        "libmusolver||libmusolver-${runtime_suffix}" \
+        "libmublaslt||libmublaslt-${runtime_suffix}" \
+        "libmthreads-compute|${MUSA_RUNTIME_VERSION}|libmthreads-compute" \
+        "libmudnn3|${MUSA_MUDNN_VERSION}|libmudnn3-musa-${runtime_major}" \
+        "libmudnn3-dev|${MUSA_MUDNN_VERSION}|libmudnn3-musa-${runtime_major}-dev" \
+        "libmthreads-mtml|${MUSA_MTML_VERSION}|libmthreads-mtml" \
+        "mccl-s5000|${MCCL_VERSION}|mccl-s5000" \
+    ) && \
+    musa_specs=() && \
+    for musa_def in "${musa_pkg_defs[@]}"; do \
+        IFS='|' read -r musa_logical musa_versions musa_pkgs <<< "${musa_def}"; \
+        IFS=',' read -r -a musa_pkg_arr <<< "${musa_pkgs}"; \
+        if [[ -n "${musa_versions}" ]]; then musa_allow_unv=0; else musa_allow_unv=1; fi; \
+        musa_spec="$(resolve_apt_package "${musa_logical}" "${musa_versions}" "${musa_allow_unv}" "${musa_pkg_arr[@]}")" || exit 1; \
+        echo "Pinning ${musa_logical}: ${musa_spec}"; \
+        musa_specs+=("${musa_spec}"); \
+    done && \
+    apt-get install -y --allow-downgrades --no-install-recommends "${musa_specs[@]}" && \
+    printf '%s\n' \
+        "${MUSA_HOME}/lib" \
+        "${MUSA_HOME}/mudnn/lib" \
+        "/usr/local/mtshmem/lib" \
+        "/usr/lib/x86_64-linux-gnu" \
+        > /etc/ld.so.conf.d/musa-runtime.conf && \
+    ldconfig && \
+    rm -rf /var/lib/apt/lists/*
+
+# Point /usr/local/musa at whichever /usr/local/musa-* dir actually holds the
+# runtime library (libmusart.so.5.*) and register the MUSA lib dirs, in case a
+# base image aimed the symlink at a toolkit-less dir. Runs before the shims so
+# they act on the right lib dir; a no-op on a correctly set-up base.
+RUN real_lib="$(ls /usr/local/musa-*/lib/libmusart.so.5.* 2>/dev/null | sort -V | tail -1)"; \
+    if [ -n "${real_lib}" ]; then \
+        musa_dir="$(cd "$(dirname "${real_lib}")/.." && pwd)"; \
+        if [ "$(readlink -f /usr/local/musa 2>/dev/null)" != "${musa_dir}" ]; then \
+            ln -sfn "${musa_dir}" /usr/local/musa; \
+            echo "musa-path: repointed /usr/local/musa -> ${musa_dir}"; \
+        fi; \
+    fi; \
+    { echo "${MUSA_HOME}/lib"; \
+      echo "${MUSA_HOME}/mudnn/lib"; \
+      for d in /usr/local/musa-*/lib /usr/local/musa-*/mudnn/lib; do \
+          [ -d "$d" ] && echo "$d"; \
+      done; \
+      echo /usr/local/mtshmem/lib; \
+      echo /usr/lib/x86_64-linux-gnu; } \
+      > /etc/ld.so.conf.d/musa-runtime.conf; \
+    ldconfig
+
+# --- MUSA 5.1 runtime shims for the MUSA 5.2.0 wheel line ---
+# The torch/torch_musa wheels target MUSA 5.2.0 but apt ships 5.1; two 5.1 libs
+# otherwise break `import torch`:
+#   1. libmupti: 5.1 ships libmupti.so.1.2; the wheels link soname libmupti.so.1.
+#   2. libmusolver: the 5.1 build leaves LAPACK zgeqr2_ undefined -- add OpenBLAS
+#      as a direct NEEDED of libmusolver only (surgical; torch keeps using MKL).
+# Guarded, no-op on a matching 5.2 runtime. Drop once MUSA_RUNTIME_VERSION is 5.2.
+RUN musa_lib="${MUSA_HOME}/lib"; \
+    mupti_target="$(ls "${musa_lib}"/libmupti.so.1.* 2>/dev/null | sort -V | tail -1)"; \
+    if [[ -n "${mupti_target}" && ! -e "${musa_lib}/libmupti.so.1" ]]; then \
+        ln -sf "$(basename "${mupti_target}")" "${musa_lib}/libmupti.so.1"; \
+        echo "musa5.1-shim: libmupti.so.1 -> $(basename "${mupti_target}")"; \
+    fi; \
+    solver="$(readlink -f "${musa_lib}/libmusolver.so.1" 2>/dev/null)"; \
+    if [[ -n "${solver}" && -e "${solver}" ]] \
+        && nm -D "${solver}" 2>/dev/null | grep -qE ' U zgeqr2_?$' \
+        && ! objdump -p "${solver}" 2>/dev/null | grep -q 'NEEDED.*libopenblas'; then \
+        patchelf --add-needed libopenblas.so.0 "${solver}"; \
+        echo "musa5.1-shim: libopenblas.so.0 added to $(basename "${solver}")"; \
+    fi; \
+    ldconfig
+
+FROM runtime AS mooncake
+
+ARG BUILD_MOONCAKE=1
+ARG MOONCAKE_REPO=https://github.com/kvcache-ai/Mooncake.git
+ARG MOONCAKE_COMMIT=b6a841dc78c707ec655a563453277d969fb8f38d
+
+ENV PATH=/usr/local/go/bin:${PATH}
+
+# Mooncake is a standalone component; do not route it through the vllm-musa pip
+# index args.
+RUN if [[ "${BUILD_MOONCAKE}" == "1" ]]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            autoconf \
+            ethtool \
+            ibverbs-utils \
+            openssh-server \
+            perftest \
+            rdmacm-utils \
+            wget && \
+        rm -rf /var/lib/apt/lists/* && \
+        git clone "${MOONCAKE_REPO}" /workspace/Mooncake && \
+        cd /workspace/Mooncake && \
+        git checkout "${MOONCAKE_COMMIT}" && \
+        git submodule update --init --recursive && \
+        bash dependencies.sh -y && \
+        mkdir -p build && \
+        cd build && \
+        cmake .. \
+            -DBUILD_UNIT_TESTS=OFF \
+            -DUSE_HTTP=ON \
+            -DUSE_ETCD=ON \
+            -DUSE_MUSA=ON \
+            -DSTORE_USE_ETCD=ON \
+            -DCMAKE_BUILD_TYPE=Release && \
+        cmake --build . -j"$(nproc)" && \
+        cmake --install . && \
+        cd /workspace/Mooncake && \
+        mkdir -p build/mooncake-transfer-engine/nvlink-allocator && \
+        cd mooncake-transfer-engine/nvlink-allocator && \
+        bash build.sh --use-mcc ../../build/mooncake-transfer-engine/nvlink-allocator/ && \
+        cd /workspace/Mooncake && \
+        OUTPUT_DIR=dist ./scripts/build_wheel.sh && \
+        python -m pip install --no-cache-dir dist/*.whl && \
+        rm -rf /workspace/Mooncake /root/.cache/pip /tmp/pip-*; \
+    elif [[ "${BUILD_MOONCAKE}" == "0" ]]; then \
+        echo "Skipping Mooncake build because BUILD_MOONCAKE=0"; \
+    else \
+        echo "Unsupported BUILD_MOONCAKE=${BUILD_MOONCAKE}" >&2; \
+        exit 1; \
+    fi
+
+FROM mooncake AS vllm_musa_deps
+
+# vllm-musa Python deps, installed before the source copy so the layers cache.
+# Split across two indexes (per the MUSA release_5.2.0 wheel guide):
+#   * PYPI_INDEX_URL (public PyPI): build tools, common.txt runtime deps,
+#     transformers, and the MUSA wheels' ordinary deps.
+#   * MUSA_PIP_INDEX_URL (internal MT index): the MUSA/MT wheels pinned in
+#     requirements/musa_private.txt (torch, torch_musa, MATE, flash_attn_3, ...).
+# Some MUSA names (torch, mate, apache-tvm-ffi) also exist on public PyPI, so the
+# two indexes must never be merged into one resolve or pip may pick the wrong
+# (CUDA/CPU) wheel. URLs live only in docker/build_image.sh and come in as build
+# args; a bare `docker build` must supply --build-arg PYPI_INDEX_URL and
+# MUSA_PIP_INDEX_URL.
+ARG PYPI_INDEX_URL
+ARG MUSA_PIP_INDEX_URL
+
+COPY requirements/ /workspace/vllm-musa/requirements/
+WORKDIR /workspace/vllm-musa
+
+# 1. MUSA/MT wheels from the internal index only, FIRST and --no-deps (their
+#    ordinary deps come in steps 2-3). MUSA torch must land before the public
+#    phase: torchada/transformers declare an unpinned `torch`, so a public-first
+#    resolve would pull public CUDA torch and the multi-GB nvidia-cuda-* stack.
+RUN python -m pip install \
+        --no-deps \
+        --index-url "${MUSA_PIP_INDEX_URL}" \
+        -r requirements/musa_private.txt
+
+# 2. Ordinary third-party wheels from public PyPI: build tools, common.txt, and
+#    musa.txt's direct pins (transformers). Step 1 already satisfies `torch`.
+RUN musa_public_extras="$(grep -vE '^[[:space:]]*(#|-r[[:space:]]|--|$)' requirements/musa.txt || true)" && \
+    python -m pip install \
+        --index-url "${PYPI_INDEX_URL}" \
+        -r requirements/build.txt \
+        -r requirements/common.txt \
+        ${musa_public_extras}
+
+# 3. Fill in the MUSA wheels' ordinary deps (sympy, networkx, ...) from public
+#    PyPI. Step 1 already pinned every MUSA wheel, so none are re-resolved here.
+RUN python -m pip install \
+        --index-url "${MUSA_PIP_INDEX_URL}" \
+        --extra-index-url "${PYPI_INDEX_URL}" \
+        -r requirements/musa_private.txt
+
+FROM vllm_musa_deps AS final
+
+# setup.py's develop_dynamic_library() runs a nested `pip install` for the
+# vendored vLLM, pulling vLLM's runtime deps (huggingface-hub, ...) from pip's
+# default index. Route those -- and the numpy re-pin below -- through the same
+# public index as the deps stage. PYPI_INDEX_URL comes from docker/build_image.sh.
+ARG PYPI_INDEX_URL
+ENV PIP_INDEX_URL=${PYPI_INDEX_URL}
+
+# Set device visibility only now (see the base-stage note): build stages ran
+# without it to keep apt clean; from here `docker run` and the verify below see
+# the GPU.
+ENV MTHREADS_VISIBLE_DEVICES=all
+
+COPY . /workspace/vllm-musa
+RUN python -m pip install \
+        -e . --no-build-isolation -v && \
+    python -m pip install numpy==1.26
+
+RUN python - <<'PY'
+import importlib
+import re
+from pathlib import Path
+from importlib.metadata import version
+
+def requirement_prefix(dist_name):
+    pattern = re.compile(rf"^{re.escape(dist_name)}==(.+)$")
+    for line in Path("requirements/musa_private.txt").read_text().splitlines():
+        match = pattern.match(line.strip())
+        if match:
+            return match.group(1).split("*", 1)[0]
+    raise RuntimeError(f"missing {dist_name} pin in requirements/musa_private.txt")
+
+expected = (
+    ("numpy", "numpy", "1.26."),
+    ("torch", "torch", requirement_prefix("torch")),
+    ("torch_musa", "torch_musa", requirement_prefix("torch_musa")),
+    ("mate", "mate", ""),
+    ("flash_attn_3", "flash_attn_3", ""),
+    ("flash_mla", "flash_mla", ""),
+    ("deep-gemm", "deep_gemm", ""),
+    ("tilelang_musa", "tilelang", ""),
+    ("apache-tvm-ffi", "tvm_ffi", ""),
+    ("torch_c_dlpack_ext", "torch_c_dlpack_ext", ""),
+)
+
+for dist_name, module_name, prefix in expected:
+    module = importlib.import_module(module_name)
+    installed = version(dist_name)
+    if prefix and not installed.startswith(prefix):
+        raise RuntimeError(f"{dist_name} expected {prefix}, got {installed}")
+    print(f"PASS import {module_name} version={installed}")
+
+for module_name in ("torchada", "vllm", "vllm_musa"):
+    module = importlib.import_module(module_name)
+    print(f"PASS import {module_name} version={getattr(module, '__version__', 'unknown')}")
+PY
+
+RUN rm -rf \
+        /root/.cache/pip \
+        /root/.cache/vllm-musa \
+        /tmp/pip-*
+
+CMD ["/bin/bash"]

--- a/docs/mdm-developer-guide.md
+++ b/docs/mdm-developer-guide.md
@@ -43,10 +43,14 @@ is fine for running but not for `regen`.
 
 ## 1. Build & install
 
-Prereqs: a MUSA environment (`torch_musa`, `torchada`, `mate`, … per
-`pyproject.toml`).
+Prereqs: a MUSA runtime/toolkit environment. Install the build, common, and
+MUSA-private Python dependencies, including torch/torch_musa, from the
+requirements entrypoints before installing `vllm-musa`.
 
 ```bash
+# required before pip install . / pip install -e .
+pip install -r requirements/build.txt -r requirements/musa.txt
+
 # developer install (recommended) — vllm-musa editable:
 pip install -e . --no-build-isolation -v
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,7 @@
 [build-system]
+# Keep build tool pins mirrored in requirements/build.txt. vllm-musa is
+# installed with --no-build-isolation in MUSA images after MUSA-private runtime
+# requirements such as torch/torch_musa have been installed.
 requires = ["setuptools>=80.10.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
@@ -25,18 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-dependencies = [
-    "torch",
-    "torch_musa",
-    "torchada>=0.1.62",
-    "mate>=0.2.1",
-    "flash_attn_3>=0.1.4",
-    "mthreads-ml-py>=2.2.11",
-    "numpy<2.0",
-    "openai>=2.24.0",
-    "transformers==5.5.3",
-    "tilelang_musa>=0.1.8"
-]
+dynamic = ["dependencies"]
 
 [project.optional-dependencies]
 dev = [

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,16 @@
+# Build dependencies used by docker/musa.Dockerfile before
+# pip install -e . --no-build-isolation -v.
+#
+# torch and torch_musa are hardware-private runtime dependencies. Keep their
+# version pins in requirements/musa_private.txt, not in this build-only file.
+cmake>=3.26.1
+ninja
+packaging>=24.2
+setuptools>=80.10.2
+setuptools-scm>=8
+setuptools-rust>=1.9.0
+wheel
+jinja2>=3.1.6
+regex
+build
+protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.*

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,0 +1,6 @@
+# Runtime Python dependencies that are portable across MUSA images.
+torchada>=0.1.62
+mthreads-ml-py>=2.2.11
+numpy==1.26
+openai>=2.24.0
+transformers==5.5.3

--- a/requirements/musa.txt
+++ b/requirements/musa.txt
@@ -1,0 +1,3 @@
+# Common dependencies
+-r common.txt
+-r musa_private.txt

--- a/requirements/musa_private.txt
+++ b/requirements/musa_private.txt
@@ -1,0 +1,24 @@
+# MUSA/MT self-built wheels, published on the internal Moore Threads index:
+#   https://dl.mthreads.com/repo/api/pypi/pypi/simple
+#
+# Install these with the internal index as the sole --index-url (see
+# docker/musa.Dockerfile). Do NOT add --index-url/--extra-index-url directives to
+# this file: it is pulled in by requirements/musa.txt (and thus setup.py
+# install_requires), and a pip index directive in a requirements file applies to
+# the whole invocation. It would then route the ordinary public-PyPI deps
+# (torchada, numpy, transformers, ...) at the internal index, which hosts only
+# MUSA/MT wheels. Names such as torch, mate and apache-tvm-ffi also exist as
+# unrelated projects on public PyPI, so they must resolve from the internal
+# index only. Versions below track the MUSA release_5.2.0 Python Wheel guide.
+
+torch==2.9.1
+torch_musa==2.9.1
+mate==0.2.3
+flash_attn_3==0.2.3
+flash_mla==0.2.3
+deep-gemm==0.2.3
+deep_ep==1.1.0+musa5.2.0torch2.9.1
+tilelang_musa==0.1.8
+triton==3.2.0
+apache-tvm-ffi==0.1.9.post3+musa.1
+torch-c-dlpack-ext==0.1.5+musa5.2.0torch2.9.1

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,6 @@ from pathlib import Path
 
 import torch
 
-
-def _ensure_numpy_compatible():
-    """Ensure numpy<2 (MUSA/torch requirement); the vLLM install can pull numpy>=2."""
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy<2", "-q"])
-
-
 def _ensure_torchada_installed():
     """Ensure torchada is installed (needed for torch.cuda patching)."""
     try:
@@ -30,7 +24,6 @@ def _ensure_torchada_installed():
 
 
 # Run dependency checks at setup start
-_ensure_numpy_compatible()
 _ensure_torchada_installed()
 
 from setuptools import setup
@@ -60,6 +53,32 @@ def _read_pins():
 
 
 _PINS = _read_pins()
+
+
+def _read_requirements(filename, seen=None):
+    """Read pip requirements files with local -r includes."""
+    requirements_dir = root / "requirements"
+    path = requirements_dir / filename
+    seen = set() if seen is None else seen
+    if path in seen:
+        return []
+    seen.add(path)
+
+    requirements = []
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if " #" in line:
+            line = line.split(" #", 1)[0].strip()
+        if line.startswith("--"):
+            continue
+        if line.startswith("-r "):
+            requirements.extend(_read_requirements(line.split(maxsplit=1)[1], seen))
+        else:
+            requirements.append(line)
+    return requirements
+
 
 configure_compiler_cache(root)
 
@@ -454,9 +473,6 @@ class _CustomBuildExt(BuildExtension):
 
         self._install_vllm(_VLLM_REPO.source_dir)
 
-        # Re-ensure numpy<2 after vllm installation (vllm may pull in numpy>=2)
-        _ensure_numpy_compatible()
-
         super().run()
 
 
@@ -464,13 +480,10 @@ setup(
     ext_modules=EXT_MODULES,
     cmdclass={"build_ext": _CustomBuildExt.with_options(use_ninja=True)},
     include_package_data=False,
-    # pinned here because --no-build-isolation skips pyproject.toml deps
-    install_requires=[
-        "torchada>=0.1.62",
-        "mthreads-ml-py>=2.2.11",
-        "numpy<2",
-        "openai>=2.24.0",
-    ],
+    # Runtime dependencies live in requirements/musa.txt so Docker and package
+    # metadata share one source. MUSA-private pins, including torch/torch_musa,
+    # are kept in requirements/musa_private.txt.
+    install_requires=_read_requirements("musa.txt"),
 )
 
 # place the built vllm.* extensions into the editable vLLM clone (see the function).


### PR DESCRIPTION
## Summary

  - Add a formal `docker/musa.Dockerfile` flow for vllm-musa based on `upstream/v0.22.0-dev`.
  - Split Python dependencies following the MetaX pattern: `requirements/common.txt`, `requirements/musa.txt`, and `requirements/musa_private.txt`.
  - Move MUSA-private runtime pins, including `torch==2.9.*` and `torch_musa==2.9.*`, into `requirements/musa_private.txt`.
  - Keep Dockerfile stages focused: `base -> apt_base -> runtime -> mooncake -> vllm_musa_deps -> final`.

## Validation

  - `bash -n docker/build_image.sh`
  - `python3 -m py_compile setup.py`
  - `git diff --check`

  Image build and MUSA hardware smoke are intentionally deferred until official torch/torch_musa and MATE-family package sources are available.