### PR TITLE
Support dsv4 in vllm 0.24

### DIFF
--- a/tests/test_musa_sync.py
+++ b/tests/test_musa_sync.py
@@ -55,7 +55,7 @@ def test_probe_upstream(ms, tmp_path):
 
 
 def test_read_pin(ms):
-    assert ms.read_pin("VLLM_TAG") == "7b3d595eb197d714052ce296cc8b124f0dc8af31"
+    assert ms.read_pin("VLLM_TAG") == "6d37570a1c6d8f96e9f2b2b72594ab9fd3ae0993"
     assert ms.read_pin("DOES_NOT_EXIST", "fallback") == "fallback"
 
 

--- a/tests/test_musa_sync.py
+++ b/tests/test_musa_sync.py
@@ -33,8 +33,8 @@ def test_report(ms, capsys):
     rc = ms.main(["report"])
     out = capsys.readouterr().out
     assert rc == 0
-    assert "113 divergences" in out
-    assert "'1': 52" in out and "'2': 24" in out and "'3': 1" in out
+    assert "114 divergences" in out
+    assert "'1': 53" in out and "'2': 24" in out and "'3': 1" in out
     assert "'4a': 2" in out and "'5': 26" in out and "'6': 8" in out
 
 

--- a/third_party/PINS
+++ b/third_party/PINS
@@ -4,7 +4,7 @@
 # base. KEY=VALUE only — NOT TOML (tomllib is 3.11+, the build box is py3.10,
 # the package floor is 3.9), so the build needs no parser dependency.
 # releases/v0.24.0 branch tip (unreleased, still moving); switch to the v0.24.0 tag once upstream tags it.
-VLLM_TAG=7b3d595eb197d714052ce296cc8b124f0dc8af31
+VLLM_TAG=6d37570a1c6d8f96e9f2b2b72594ab9fd3ae0993
 # FlashInfer is intentionally DECOUPLED from upstream vLLM's choice: vLLM v0.22.0
 # uses v0.6.11.post2, which breaks the MUSA csrc_musa/include_musa build path.
 # Bump this consciously, not in lockstep with VLLM_TAG.

--- a/vllm_musa/__init__.py
+++ b/vllm_musa/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
     "register_custom_ops",
     "collect_env",
 ]
-__version__ = "0.1.22"
+__version__ = "0.1.24"
 
 logger = logging.getLogger(__name__)
 

--- a/vllm_musa/patches/series/0078-MUSA-allocate-DeepSeek-V4-sparse-MLA-KV-tensors-with.patch
+++ b/vllm_musa/patches/series/0078-MUSA-allocate-DeepSeek-V4-sparse-MLA-KV-tensors-with.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joey-gvwal <joey_gvwal@yeah.net>
+Date: Fri, 26 Jun 2026 14:33:08 +0800
+Subject: [PATCH] MUSA: allocate DeepSeek-V4 sparse MLA KV tensors without
+ offsets
+
+---
+ vllm/v1/core/kv_cache_utils.py | 43 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 43 insertions(+)
+
+diff --git a/vllm/v1/core/kv_cache_utils.py b/vllm/v1/core/kv_cache_utils.py
+index a3822e7fc..f95ad36e5 100644
+--- a/vllm/v1/core/kv_cache_utils.py
++++ b/vllm/v1/core/kv_cache_utils.py
+@@ -1281,6 +1281,17 @@ def _get_kv_cache_config_packed(
+     num_blocks = available_memory // total_num_bytes_per_block
+     num_blocks = may_override_num_blocks(vllm_config, num_blocks)
+ 
++    if _use_musa_deepseek_v4_zero_offset_kv_tensors(kv_cache_groups):
++        # MATE sparse FlashMLA decode rebuilds page views from the cache tensor
++        # storage. Offset aliases from the packed backing tensor overrun there,
++        # so keep the same per-page layout but give each page-size slot an
++        # offset-zero allocation on MUSA.
++        return num_blocks, [
++            KVCacheTensor(size=ps * num_blocks, shared_by=slot)
++            for ps, slots in buckets.items()
++            for slot in slots
++        ]
++
+     total_size = total_num_bytes_per_block * num_blocks
+ 
+     kv_cache_tensors: list[KVCacheTensor] = []
+@@ -1300,6 +1311,38 @@ def _get_kv_cache_config_packed(
+     return num_blocks, kv_cache_tensors
+ 
+ 
++def _use_musa_deepseek_v4_zero_offset_kv_tensors(
++    kv_cache_groups: list[KVCacheGroupSpec],
++) -> bool:
++    try:
++        from vllm.platforms import current_platform
++    except Exception:
++        return False
++
++    is_musa = getattr(current_platform, "is_musa", None)
++    if not callable(is_musa) or not is_musa():
++        return False
++
++    found_deepseek_v4 = False
++    found_sparse_swa = False
++    for group in kv_cache_groups:
++        spec = group.kv_cache_spec
++        specs: Iterable[KVCacheSpec]
++        if isinstance(spec, UniformTypeKVCacheSpecs):
++            specs = spec.kv_cache_specs.values()
++        else:
++            specs = (spec,)
++        for layer_spec in specs:
++            if getattr(layer_spec, "model_version", None) != "deepseek_v4":
++                continue
++            found_deepseek_v4 = True
++            if isinstance(layer_spec, SlidingWindowMLASpec):
++                found_sparse_swa = True
++
++    return found_deepseek_v4 and found_sparse_swa
++
++
+ _get_kv_cache_config_deepseek_v4 = _get_kv_cache_config_packed
+ 
+ 


### PR DESCRIPTION
## Summary

Update vLLM 0.24 pin for DeepSeek-V4 validation

## Test
Aggregate output-checked result:

| family | tp | output check |
|---|---:|---|
| `qwen3_8b_fp8` | 1 | PASS, HTTP 200, `Paris` |
| `deepseek_v2_lite_fp8` | 1 | PASS, HTTP 200, `Paris`, `FLASHMLA` |
| `qwen3_8b_bf16` | 1 | PASS, HTTP 200, `Paris` |
| `qwen3_vl_8b` | 1 | PASS, HTTP 200, red-image answer `red` |
| `qwen3_32b_fp8` | 2 | PASS, HTTP 200, `Paris` |
| `gemma_4_31b` | 2 | PASS, HTTP 200, `Paris`, `TRITON_ATTN` |
| `qwen3_5_35b_a3b_fp8` | 4 | PASS, HTTP 200, `Paris` |
| `qwen3_vl_30b` | 8 | PASS, HTTP 200, red-image answer `red` |
| `minimax_m2_5` | 8 | PASS, HTTP 200, semantic answer contains final `Paris` (response also emitted reasoning text) |
| `qwen3_235b_fp8` | 8 | PASS, HTTP 200, `Paris` |
| `deepseek_v4_flash` | 8 | PASS, HTTP 200, math answer starts `42` |