### PR TITLE
FLASH_ATTN: route Qwen3 prefill/decode attention to mate's fast kernels

### DIFF
--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -345,6 +345,11 @@ class FlashAttentionMetadata:
 
     causal: bool = True
 
+    # MUSA: pure-prefill batch with no cached prefix (every context_len == 0),
+    # so prefill attention reads contiguous K/V (no block_table) and mate routes
+    # to the faster mubin TCE flash-attention.
+    prefill_no_prefix: bool = False
+
 
 def _get_sliding_window_configs(
     vllm_config: VllmConfig,
@@ -564,10 +569,14 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             )
             prefill_seq_lens = common_attn_metadata.seq_lens[num_decodes:num_reqs]
             prefill_max_seq_len = int(prefill_seq_lens.max().item())
+            # MUSA: sum(seq_lens) == num_prefill_tokens iff every prefill request
+            # has zero cached context (seq_len_i >= query_len_i), i.e. no prefix.
+            prefill_no_prefix = int(prefill_seq_lens.sum().item()) == num_prefill_tokens
         else:
             prefill_query_start_loc = None
             prefill_seq_lens = None
             prefill_max_seq_len = 0
+            prefill_no_prefix = False
         # ========================== END ==========================
 
         if envs.VLLM_BATCH_INVARIANT:
@@ -716,6 +725,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             num_prefill_tokens=num_prefill_tokens,
             prefill_query_start_loc=prefill_query_start_loc,
             prefill_max_seq_len=prefill_max_seq_len,
+            prefill_no_prefix=prefill_no_prefix,
             cu_seqlens_k=cu_seqlens_k,
             block_table=block_table_tensor,
             slot_mapping=slot_mapping,
@@ -817,6 +827,15 @@ class FlashAttentionImpl(AttentionImpl):
                 "Sinks must have the same number of heads as the number of "
                 "heads in the layer"
             )
+
+        # MUSA: layer-static eligibility for the contiguous-KV mubin-TCE prefill
+        # path (none of these features can be represented by the plain varlen call).
+        self._mubin_prefill_ok = (
+            self.sinks is None
+            and (self.sliding_window is None or self.sliding_window[0] < 0)
+            and not self.logits_soft_cap
+            and not self.kv_cache_dtype.startswith("fp8")
+        )
 
         self.supports_quant_query_input = False
 
@@ -976,9 +995,42 @@ class FlashAttentionImpl(AttentionImpl):
                         softcap=self.logits_soft_cap,
                         k_descale=layer._k_scale.expand(decode_descale_shape),
                         v_descale=layer._v_scale.expand(decode_descale_shape),
+                        scheduler_metadata=attn_metadata.scheduler_metadata,
                         num_splits=attn_metadata.max_num_splits,
                     )
                     output[:num_decode_tokens] = decode_output
+                elif (
+                    num_decodes == 0
+                    and num_prefills > 0
+                    and attn_metadata.prefill_no_prefix
+                    and attn_metadata.causal
+                    and not attn_metadata.use_cascade
+                    and self._mubin_prefill_ok
+                ):
+                    # MUSA: pure prefill, no cached prefix -> attend the contiguous
+                    # new K/V (no block_table/seqused_k) so mate routes to the
+                    # faster mubin TCE flash-attention.
+                    flash_attn_varlen_func(
+                        q=query[:num_actual_tokens].view(
+                            -1, self.num_heads, self.head_size
+                        ),
+                        k=key[:num_actual_tokens].view(
+                            -1, self.num_kv_heads, self.head_size
+                        ),
+                        v=value[:num_actual_tokens].view(
+                            -1, self.num_kv_heads, self.head_size
+                        ),
+                        out=output[:num_actual_tokens].view(
+                            -1, self.num_heads, self.head_size
+                        ),
+                        cu_seqlens_q=cu_seqlens_q,
+                        cu_seqlens_k=cu_seqlens_q,
+                        max_seqlen_q=max_seqlen_q,
+                        max_seqlen_k=max_seqlen_q,
+                        softmax_scale=self.scale,
+                        causal=True,
+                        num_splits=attn_metadata.max_num_splits,
+                    )
                 else:
                     # Eagle verifier and mixed/extend batches may have multiple
                     # query tokens per request, so they must attend through the

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -831,7 +831,8 @@ class FlashAttentionImpl(AttentionImpl):
         # MUSA: layer-static eligibility for the contiguous-KV mubin-TCE prefill
         # path (none of these features can be represented by the plain varlen call).
         self._mubin_prefill_ok = (
-            self.sinks is None
+            self.attn_type == AttentionType.DECODER
+            and self.sinks is None
             and (self.sliding_window is None or self.sliding_window[0] < 0)
             and not self.logits_soft_cap
             and not self.kv_cache_dtype.startswith("fp8")


### PR DESCRIPTION
## Summary

Two small FLASH_ATTN dispatch fixes so the MUSA backend reaches the faster mate
kernels it already exposes — one for decode, one for pure prefill. Both are
opt-in by the shape/feature guards and fall back to the existing path otherwise.

## 1. Decode: split-KV flash-decode via `scheduler_metadata`

The decode fast path already builds the per-step scheduler metadata and split
count, but only `num_splits` was forwarded to `flash_attn_with_kvcache`; without
`scheduler_metadata`, mate runs a single `SingleTileScheduler` kernel over the
whole KV. Forwarding it routes mate to the split-KV (flash-decoding) path —
partial `FmhaFwd` + `FmhaFwdCombine`.

- `scheduler_metadata` defaults to `None`, so the call degrades to the single
  kernel whenever the metadata isn't built — no behavior change off the fast path.
- Captures cleanly under `FULL_DECODE_ONLY` CUDAGraph (the metadata lives in a
  persistent buffer).
- Output is bit-identical to the single-kernel path.

Qwen3-8B, TP1, MTT S5000, graph-ON `FULL_DECODE_ONLY`, bs=1, in2500/out1500:
**Mean TPOT 18.54 → 16.85 ms (−9.1%), output throughput +10.0%.**

## 2. Prefill: contiguous-KV mubin-TCE path

On a pure-prefill step with no cached prefix, the new K/V is contiguous, so it
can be attended directly through `flash_attn_varlen_func` without the paged
`block_table`/`seqused_k`. mate's `enable_mubin` then selects the TCE flash
kernel (`bf16tce_flash_atten...causal_persistence`).

A new `prefill_no_prefix` metadata flag (`sum(seq_lens) == num_prefill_tokens`)
gates the path, together with the cases the contiguous form represents
correctly: pure prefill, no prefix, causal, and none of
cascade/sinks/sliding-window/softcap/fp8-KV (the feature guards are layer-static
and precomputed once). Everything else falls through to the existing paged path.

Qwen3-8B prefill attention: **21.8 → 7.2 ms / 36 layers (~3×)**; ~10% faster
low-concurrency prefill latency, neutral at high concurrency where TTFT is
scheduling-bound.