### PR TITLE
Fix DeepSeek V4 grouped DeepGEMM MoE prefill

### DIFF
--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -340,7 +340,10 @@ def _deepseek_v4_moe_deepgemm_prefill_impl(
         deepgemm_moe_permute,
         deepgemm_unpermute_and_reduce,
     )
-    from vllm.utils.deep_gemm import m_grouped_fp8_gemm_nt_contiguous
+    from vllm.utils.deep_gemm import (
+        m_grouped_fp8_gemm_nt_contiguous,
+        mk_alignment_scope,
+    )
 
     logger.info_once(
         "Using DeepSeek-V4 MUSA grouped DeepGEMM MoE prefill path "
@@ -356,7 +359,13 @@ def _deepseek_v4_moe_deepgemm_prefill_impl(
         block_shape=[128, 128],
     )
 
-    qhidden_perm, qhidden_scale_perm, expert_ids, inv_perm = deepgemm_moe_permute(
+    (
+        qhidden_perm,
+        qhidden_scale_perm,
+        expert_ids,
+        inv_perm,
+        align_used,
+    ) = deepgemm_moe_permute(
         aq=qhidden,
         aq_scale=a1_scale,
         topk_ids=topk_ids,
@@ -366,40 +375,41 @@ def _deepseek_v4_moe_deepgemm_prefill_impl(
     )
 
     _, N, K = w1.shape
-    mm1_out = torch.empty(
-        (qhidden_perm.shape[0], N),
-        device=hidden_states.device,
-        dtype=hidden_states.dtype,
-    )
-    m_grouped_fp8_gemm_nt_contiguous(
-        (qhidden_perm, qhidden_scale_perm.contiguous()),
-        (w1, w1_scale.contiguous()),
-        mm1_out,
-        expert_ids,
-    )
+    with mk_alignment_scope(align_used):
+        mm1_out = torch.empty(
+            (qhidden_perm.shape[0], N),
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        m_grouped_fp8_gemm_nt_contiguous(
+            (qhidden_perm, qhidden_scale_perm.contiguous()),
+            (w1, w1_scale.contiguous()),
+            mm1_out,
+            expert_ids,
+        )
 
-    a2q = torch.empty(
-        (qhidden_perm.shape[0], N // 2),
-        device=hidden_states.device,
-        dtype=torch.float8_e4m3fn,
-    )
-    a2q, a2q_scale = _silu_mul_per_token_group_fp8_quant_musa_large(
-        mm1_out.view(-1, N),
-        a2q,
-        group_size=128,
-    )
+        a2q = torch.empty(
+            (qhidden_perm.shape[0], N // 2),
+            device=hidden_states.device,
+            dtype=torch.float8_e4m3fn,
+        )
+        a2q, a2q_scale = _silu_mul_per_token_group_fp8_quant_musa_large(
+            mm1_out.view(-1, N),
+            a2q,
+            group_size=128,
+        )
 
-    mm2_out = torch.empty(
-        (qhidden_perm.shape[0], K),
-        device=hidden_states.device,
-        dtype=hidden_states.dtype,
-    )
-    m_grouped_fp8_gemm_nt_contiguous(
-        (a2q, a2q_scale.contiguous()),
-        (w2, w2_scale.contiguous()),
-        mm2_out,
-        expert_ids,
-    )
+        mm2_out = torch.empty(
+            (qhidden_perm.shape[0], K),
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        m_grouped_fp8_gemm_nt_contiguous(
+            (a2q, a2q_scale.contiguous()),
+            (w2, w2_scale.contiguous()),
+            mm2_out,
+            expert_ids,
+        )
 
     if inplace and not disable_inplace():
         output = hidden_states


### PR DESCRIPTION
## Summary

Fix DeepSeek-V4 grouped DeepGEMM MoE prefill on the vLLM 0.24 adaptation.

The MUSA bridge was still unpacking the old 4-value return from
`deepgemm_moe_permute()`. In vLLM 0.24 this helper returns a fifth value,
`align_used`, so the grouped DeepGEMM prefill path failed with
`too many values to unpack (expected 4)` and fell back to native MUSA GEMV.

## Modifications

This PR updates the DeepSeek-V4 MUSA MoE prefill bridge to:

- unpack `align_used` from `deepgemm_moe_permute()`
- wrap the grouped DeepGEMM calls with `mk_alignment_scope(align_used)`
- preserve the existing native GEMV fallback behavior for non-prefill/decode paths

## Test

Output correctness:

```text
model=/home/dist/models/DeepSeek-V4-Flash-Base
serve=TP8 + MTP4 + cudagraph
http_code=200
semantic_oracle=contains_beijing=True
```

MoE path evidence:

```text
deepgemm_path_count=1
fallback_count=0
traceback_count=0
```

Note: the native GEMV log can still appear during decode/cudagraph capture. The
targeted 4096-token prefill benchmark used grouped DeepGEMM and did not emit the
grouped-DeepGEMM fallback warning.

start cmd:

```
export SAFETENSORS_FAST_GPU=1
export VLLM_DEEP_GEMM_WARMUP=skip
export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
export VLLM_USE_DEEP_GEMM=1
export VLLM_USE_DEEP_GEMM_E8M0=0
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export PYTHONUNBUFFERED=1
export VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE=aggressive_long_prefill
export VLLM_MUSA_DEEPSEEK_V4_DISABLE_AUX_OVERLAP=1
export VLLM_MUSA_DEEPSEEK_V4_MHC_PRE_DECODE_PRENORM_IMPL=deepgemm
export VLLM_MUSA_SPEC_METADATA_SINGLE_REQ_CACHE=1
export VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL=1
unset TORCHDYNAMO_DISABLE
unset VLLM_ATTENTION_BACKEND

PORT=25606
MODEL=/home/dist/models/DeepSeek-V4-Flash-Base
SERVED_MODEL=deepseek
COMPILATION_CONFIG='{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","max_cudagraph_capture_size":5,"cudagraph_capture_sizes":[5],"cudagraph_copy_inputs":false}'
SPECULATIVE_CONFIG='{"method":"mtp","num_speculative_tokens":4}'

vllm serve "$MODEL" \
  --served-model-name "$SERVED_MODEL" \
  --gpu-memory-utilization 0.95 \
  --max-model-len 6144 \
  --max-num-seqs 1 \
  --max-num-batched-tokens 8195 \
  --tensor-parallel-size 8 \
  -ac.backend FLASHMLA \
  --port "$PORT" \
  --host 0.0.0.0 \
  --kv-cache-dtype fp8 \
  --no-enable-prefix-caching \
  --async-scheduling \
  --compilation-config "$COMPILATION_CONFIG" \
  --speculative-config "$SPECULATIVE_CONFIG"
```

## Benchmark

Shape: TP8, random input `4096`, output `1500`, one prompt, five warmups,
concurrency 1.

| Row | Env | Completed | Failed | Output tokens | Output TPS | TTFT ms | TPOT ms |
|---|---|---:|---:|---:|---:|---:|---:|
| Baseline native GEMV | `VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL=0` | 1 | 0 | 1500 | 53.076825 | 4739.252 | 15.624 |
| Candidate grouped DeepGEMM | `VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL=1` | 1 | 0 | 1500 | 76.430249 | 1447.820 | 12.059 |

