### PR TITLE
set flash attn block size rightful

### DIFF
--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -603,26 +603,6 @@ class MUSAPlatformBase(Platform):
                         sparse_block_size,
                     )
 
-        # Dense FMHA (FLASH_ATTN) decode reads paged KV through mate's Fmha
-        # kernel, which has a fast TME (bulk tensor-engine) gather path that the
-        # kernel only selects when page_size == 64; any other page size forces a
-        # slower load-store-unit per-page gather (force_lsu_kv). Default the dense
-        # KV block size to 64 to take the TME path (parity with the FlashMLA branch
-        # above, which forces 64 for the same hardware reason). Opt out with
-        # VLLM_MUSA_FA_BLOCK_SIZE_64=0.
-        import os as _fa_os
-
-        if (
-            model_config is not None
-            and not model_config.use_mla
-            and cache_config is not None
-            and cache_config.block_size is not None
-            and cache_config.block_size % 64 != 0
-            and _fa_os.environ.get("VLLM_MUSA_FA_BLOCK_SIZE_64", "1") != "0"
-        ):
-            cache_config.block_size = 64
-            logger.info("Forcing kv cache block size to 64 for FMHA TME decode path.")
-
         scheduler_config = vllm_config.scheduler_config
         # Note: model_config may be None during testing
         if (

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -149,7 +149,7 @@ class MUSAFlashAttentionBackend(AttentionBackend):
             # suffer from the NaN propagation problem described here:
             # https://github.com/Dao-AILab/flash-attention/issues/1974
             return [16, 32, 64]
-        return [MultipleOf(16)]
+        return [MultipleOf(64)]
 
     forward_includes_kv_cache_update: bool = False
 


### PR DESCRIPTION
Setting `cache_config.block_size=64` in `vllm_musa/platform.py` has no effect on the initialization settings of the kv cache and is misleading. Therefore, to correctly set the block size, one should start with the parameter `--block-size 64`. If not set, the value will be obtained through the `get_supported_kernel_block_sizes` method of the attention backend. Here, a default value of 64 is given for the MUSAFlashAttentionBackend.

Benchmark
| bs | before TPOT | after TPOT | TPOT变化 | before TTFT | after TTFT | TTFT变化 |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 18.59 ms | 16.09 ms | -13.4% | 143 ms | 139.9 ms | -2.2% |
| 2 | 27.68 ms | 26.11 ms | -5.7% | 234 ms | 227.1 ms | -2.9% |
| 8 | 22.34 ms | 19.61 ms | -12.2% | 701 ms | 698.9 ms | -0.3% |
| 16 | 24.55 ms | 22.69 ms | -7.6% | 1182 ms | 1103 ms | -6.7% |
| 32 | 31.23 ms | 28.25 ms | -9.5% | 2126 ms | 2136 ms | +0.5% |