### PR TITLE
Optimize GLM-5.2 index top-k path

### DIFF
--- a/csrc/musa/attention/glm52_indexer_topk.mu
+++ b/csrc/musa/attention/glm52_indexer_topk.mu
@@ -1,0 +1,949 @@
+#include <cmath>
+#include <cstdint>
+
+#include <musa_bf16.h>
+#include <musa_fp8.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+namespace {
+
+// GLM-5.2's lightning indexer shape.  Unlike the DeepSeek-V4 kernel, GLM uses
+// 32 index heads and keeps 2048 tokens.  8192 scores plus the 2048-candidate
+// sorting scratch fit in shared memory on mp_31 when the Q cache is aliased
+// with the candidate scratch after scoring.
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kNumHeads = 32;
+constexpr int64_t kScaleBytes = 4;
+constexpr int64_t kMaxSeqLen = 8192;
+constexpr int64_t kMaxTopK = 2048;
+constexpr int kThreads = 256;
+constexpr int kIndexInt32 = 1;
+constexpr int kIndexInt64 = 2;
+
+__device__ __forceinline__ float dequant_fp8_e4m3(uint8_t byte) {
+  __mt_fp8_e4m3 packed;
+  packed.__x = byte;
+  return static_cast<float>(packed);
+}
+
+__device__ __forceinline__ int64_t load_index(const void *ptr, int kind,
+                                              int64_t idx) {
+  if (kind == kIndexInt32) {
+    return static_cast<int64_t>(static_cast<const int32_t *>(ptr)[idx]);
+  }
+  return static_cast<int64_t>(static_cast<const int64_t *>(ptr)[idx]);
+}
+
+int index_kind(const torch::Tensor &tensor, const char *name) {
+  if (tensor.scalar_type() == torch::kInt32) {
+    return kIndexInt32;
+  }
+  if (tensor.scalar_type() == torch::kInt64) {
+    return kIndexInt64;
+  }
+  TORCH_CHECK(false, name, " must be int32 or int64");
+}
+
+void check_musa_tensor(const torch::Tensor &tensor, const char *name) {
+  TORCH_CHECK(tensor.device().is_privateuseone(), name,
+              " must be a MUSA tensor");
+}
+
+void check_same_device(const torch::Tensor &a, const torch::Tensor &b,
+                       const char *b_name) {
+  TORCH_CHECK(a.device() == b.device(), b_name, " must be on the same device");
+}
+
+__device__ __forceinline__ bool better_pair(float lhs_value, int lhs_index,
+                                            float rhs_value, int rhs_index) {
+  return lhs_value > rhs_value ||
+         (lhs_value == rhs_value &&
+          (rhs_index < 0 || (lhs_index >= 0 && lhs_index < rhs_index)));
+}
+
+__device__ __forceinline__ void compare_swap_score_pair(
+    float *__restrict__ scores, int *__restrict__ score_indices, int lhs,
+    int rhs, bool descending) {
+  const float lhs_value = scores[lhs];
+  const int lhs_index = score_indices[lhs];
+  const float rhs_value = scores[rhs];
+  const int rhs_index = score_indices[rhs];
+  const bool should_swap =
+      (descending && better_pair(rhs_value, rhs_index, lhs_value, lhs_index)) ||
+      (!descending && better_pair(lhs_value, lhs_index, rhs_value, rhs_index));
+  if (should_swap) {
+    scores[lhs] = rhs_value;
+    score_indices[lhs] = rhs_index;
+    scores[rhs] = lhs_value;
+    score_indices[rhs] = lhs_index;
+  }
+}
+
+__device__ __forceinline__ uint32_t ordered_float(float value) {
+  // Indexer scores are expected to be finite.  Treat a defensive NaN as the
+  // lowest possible score rather than allowing it to poison radix ordering.
+  if (isnan(value)) {
+    value = -INFINITY;
+  }
+  // Normalize signed zero so equality and radix ordering use the same tie set.
+  if (value == 0.0f) {
+    value = 0.0f;
+  }
+  const uint32_t bits = __float_as_uint(value);
+  return (bits & 0x80000000U) ? ~bits : (bits | 0x80000000U);
+}
+
+union SelectionScratch {
+  __mt_bfloat16 q_deq[kNumHeads * kHeadDim];
+  struct {
+    float scores[kMaxTopK];
+    int indices[kMaxTopK];
+  } candidates;
+};
+
+template <typename OutT>
+__device__ __forceinline__ void fill_all_indices(
+    OutT *__restrict__ topk_indices, int64_t topk_stride0,
+    int64_t topk_stride1, int64_t row, int64_t row_len, int64_t topk) {
+  for (int64_t rank = threadIdx.x; rank < topk; rank += blockDim.x) {
+    topk_indices[row * topk_stride0 + rank * topk_stride1] =
+        static_cast<OutT>(rank < row_len ? rank : -1);
+  }
+}
+
+// Select and sort the largest topk entries from shared-memory scores.  The
+// four radix passes are adapted from dashboard submission 10185, which passed
+// the S5000 streaming-aware indexer benchmark through topk=2048.  After the
+// threshold is known, only the selected 2048 candidates are bitonic-sorted so
+// the output retains the descending-score / ascending-index contract used by
+// the existing exact fallback.
+template <typename OutT>
+__device__ void radix_select_scores(
+    float *__restrict__ scores, SelectionScratch *__restrict__ scratch,
+    int *__restrict__ histogram, uint32_t *__restrict__ prefix,
+    int *__restrict__ rank_in_bucket, int *__restrict__ tie_cutoff,
+    int *__restrict__ candidate_count, OutT *__restrict__ topk_indices,
+    int64_t topk_stride0, int64_t topk_stride1, int64_t row,
+    int64_t row_len, int64_t topk) {
+  const int tid = threadIdx.x;
+  if (tid == 0) {
+    *prefix = 0U;
+    *rank_in_bucket = static_cast<int>(topk);
+    *tie_cutoff = -1;
+    *candidate_count = 0;
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (int shift = 24; shift >= 0; shift -= 8) {
+    for (int bin = tid; bin < 256; bin += blockDim.x) {
+      histogram[bin] = 0;
+    }
+    __syncthreads();
+
+    const uint32_t current_prefix = *prefix;
+    const uint32_t high_mask =
+        shift == 24 ? 0U : (0xFFFFFFFFU << (shift + 8));
+    for (int64_t pos = tid; pos < row_len; pos += blockDim.x) {
+      const uint32_t key = ordered_float(scores[pos]);
+      if ((key & high_mask) == (current_prefix & high_mask)) {
+        atomicAdd(&histogram[(key >> shift) & 0xFFU], 1);
+      }
+    }
+    __syncthreads();
+
+    if (tid == 0) {
+      int kth = *rank_in_bucket;
+      uint32_t next_prefix = *prefix;
+      for (int bin = 255; bin >= 0; --bin) {
+        if (histogram[bin] >= kth) {
+          next_prefix |= static_cast<uint32_t>(bin) << shift;
+          *prefix = next_prefix;
+          break;
+        }
+        kth -= histogram[bin];
+      }
+      *rank_in_bucket = kth;
+    }
+    __syncthreads();
+  }
+
+  const uint32_t threshold = *prefix;
+  if (tid == 0) {
+    int greater = 0;
+    for (int64_t pos = 0; pos < row_len; ++pos) {
+      greater += ordered_float(scores[pos]) > threshold ? 1 : 0;
+    }
+    int ties_needed = static_cast<int>(topk) - greater;
+    int cutoff = -1;
+    for (int64_t pos = 0; pos < row_len && ties_needed > 0; ++pos) {
+      if (ordered_float(scores[pos]) == threshold) {
+        cutoff = static_cast<int>(pos);
+        --ties_needed;
+      }
+    }
+    *tie_cutoff = cutoff;
+  }
+
+  float *candidate_scores = scratch->candidates.scores;
+  int *candidate_indices = scratch->candidates.indices;
+  for (int slot = tid; slot < kMaxTopK; slot += blockDim.x) {
+    candidate_scores[slot] = -INFINITY;
+    candidate_indices[slot] = -1;
+  }
+  __syncthreads();
+
+  const int cutoff = *tie_cutoff;
+  for (int64_t pos = tid; pos < row_len; pos += blockDim.x) {
+    const uint32_t key = ordered_float(scores[pos]);
+    if (key > threshold || (key == threshold && pos <= cutoff)) {
+      const int slot = atomicAdd(candidate_count, 1);
+      if (slot < kMaxTopK) {
+        candidate_scores[slot] = scores[pos];
+        candidate_indices[slot] = static_cast<int>(pos);
+      }
+    }
+  }
+  __syncthreads();
+
+  for (int size = 2; size <= kMaxTopK; size <<= 1) {
+    for (int stride = size >> 1; stride > 0; stride >>= 1) {
+      for (int pos = tid; pos < kMaxTopK; pos += blockDim.x) {
+        const int other = pos ^ stride;
+        if (other > pos) {
+          compare_swap_score_pair(candidate_scores, candidate_indices, pos,
+                                  other, (pos & size) == 0);
+        }
+      }
+      __syncthreads();
+    }
+  }
+
+  for (int64_t rank = tid; rank < topk; rank += blockDim.x) {
+    topk_indices[row * topk_stride0 + rank * topk_stride1] =
+        static_cast<OutT>(candidate_indices[rank]);
+  }
+}
+
+template <typename OutT>
+__global__ void sparse_indexer_fill_all_kernel(
+    const void *__restrict__ lengths, int lengths_kind, int64_t lengths_stride,
+    OutT *__restrict__ topk_indices, int64_t topk_stride0,
+    int64_t topk_stride1, int64_t rows, int64_t topk) {
+  const int64_t row = static_cast<int64_t>(blockIdx.x);
+  if (row >= rows) {
+    return;
+  }
+  const int64_t raw_len =
+      load_index(lengths, lengths_kind, row * lengths_stride);
+  const int64_t row_len = raw_len > 0 ? raw_len : 0;
+  fill_all_indices(topk_indices, topk_stride0, topk_stride1, row, row_len,
+                   topk);
+}
+
+template <typename OutT>
+__global__ void sparse_indexer_topk_kernel(
+    const float *__restrict__ logits, int64_t logits_stride0,
+    int64_t logits_stride1, int64_t columns, const void *__restrict__ row_starts,
+    int row_starts_kind, int64_t row_starts_stride,
+    const void *__restrict__ row_ends, int row_ends_kind,
+    int64_t row_ends_stride, OutT *__restrict__ topk_indices,
+    int64_t topk_stride0, int64_t topk_stride1, int64_t rows, int64_t topk,
+    bool starts_at_zero) {
+  const int64_t row = static_cast<int64_t>(blockIdx.x);
+  if (row >= rows) {
+    return;
+  }
+
+  __shared__ int histogram[256];
+  __shared__ uint32_t prefix;
+  __shared__ int rank_in_bucket;
+  __shared__ int tie_cutoff;
+  __shared__ int greater_count;
+  __shared__ int minimum_tie_index;
+
+  const int tid = threadIdx.x;
+  int64_t row_start = starts_at_zero
+                          ? 0
+                          : load_index(row_starts, row_starts_kind,
+                                       row * row_starts_stride);
+  int64_t row_end = load_index(row_ends, row_ends_kind, row * row_ends_stride);
+  row_start = row_start < 0 ? 0 : (row_start > columns ? columns : row_start);
+  row_end = row_end < row_start ? row_start
+                               : (row_end > columns ? columns : row_end);
+  const int64_t row_len = row_end - row_start;
+  if (row_len <= topk) {
+    fill_all_indices(topk_indices, topk_stride0, topk_stride1, row, row_len,
+                     topk);
+    return;
+  }
+
+  if (tid == 0) {
+    prefix = 0U;
+    rank_in_bucket = static_cast<int>(topk);
+    tie_cutoff = -1;
+    greater_count = 0;
+    minimum_tie_index = INT32_MAX;
+  }
+  __syncthreads();
+
+  const float *row_logits = logits + row * logits_stride0;
+#pragma unroll
+  for (int shift = 24; shift >= 0; shift -= 8) {
+    for (int bin = tid; bin < 256; bin += blockDim.x) {
+      histogram[bin] = 0;
+    }
+    __syncthreads();
+
+    const uint32_t current_prefix = prefix;
+    const uint32_t high_mask =
+        shift == 24 ? 0U : (0xFFFFFFFFU << (shift + 8));
+    for (int64_t pos = row_start + tid; pos < row_end; pos += blockDim.x) {
+      const uint32_t key = ordered_float(row_logits[pos * logits_stride1]);
+      if ((key & high_mask) == (current_prefix & high_mask)) {
+        atomicAdd(&histogram[(key >> shift) & 0xFFU], 1);
+      }
+    }
+    __syncthreads();
+
+    if (tid == 0) {
+      int kth = rank_in_bucket;
+      uint32_t next_prefix = prefix;
+      for (int bin = 255; bin >= 0; --bin) {
+        if (histogram[bin] >= kth) {
+          next_prefix |= static_cast<uint32_t>(bin) << shift;
+          prefix = next_prefix;
+          break;
+        }
+        kth -= histogram[bin];
+      }
+      rank_in_bucket = kth;
+    }
+    __syncthreads();
+  }
+
+  const uint32_t threshold = prefix;
+  int local_greater = 0;
+  int local_ties = 0;
+  int local_min_tie = INT32_MAX;
+  for (int64_t pos = row_start + tid; pos < row_end; pos += blockDim.x) {
+    const uint32_t key = ordered_float(row_logits[pos * logits_stride1]);
+    if (key > threshold) {
+      ++local_greater;
+    } else if (key == threshold) {
+      ++local_ties;
+      local_min_tie = min(local_min_tie, static_cast<int>(pos));
+    }
+  }
+  if (local_greater > 0) {
+    atomicAdd(&greater_count, local_greater);
+  }
+  if (local_ties > 0) {
+    atomicMin(&minimum_tie_index, local_min_tie);
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+    int ties_needed = static_cast<int>(topk) - greater_count;
+    if (ties_needed <= 0) {
+      tie_cutoff = -1;
+    } else if (ties_needed == 1) {
+      tie_cutoff = minimum_tie_index;
+    } else {
+      // Large exact-tie groups are uncommon for weighted indexer scores.  Keep
+      // a deterministic low-index fallback without penalizing the unique-key
+      // fast path with a serial scan.
+      int cutoff = -1;
+      for (int64_t pos = row_start; pos < row_end && ties_needed > 0; ++pos) {
+        if (ordered_float(row_logits[pos * logits_stride1]) == threshold) {
+          cutoff = static_cast<int>(pos);
+          --ties_needed;
+        }
+      }
+      tie_cutoff = cutoff;
+    }
+  }
+  __syncthreads();
+
+  const int cutoff = tie_cutoff;
+  int selected_count = 0;
+  for (int64_t pos = row_start + tid; pos < row_end; pos += blockDim.x) {
+    const float score = row_logits[pos * logits_stride1];
+    const uint32_t key = ordered_float(score);
+    if (key > threshold || (key == threshold && pos <= cutoff)) {
+      ++selected_count;
+    }
+  }
+  histogram[tid] = selected_count;
+  __syncthreads();
+
+  if (tid == 0) {
+    int prefix_sum = 0;
+    for (int lane = 0; lane < kThreads; ++lane) {
+      const int lane_count = histogram[lane];
+      histogram[lane] = prefix_sum;
+      prefix_sum += lane_count;
+    }
+  }
+  __syncthreads();
+
+  // Sparse MLA consumes an index set, not a score-sorted list.  Compact each
+  // thread's strided selections into a disjoint output range computed by the
+  // block-wide prefix above.  This avoids contending on one atomic counter.
+  int output_slot = histogram[tid];
+  for (int64_t pos = row_start + tid; pos < row_end; pos += blockDim.x) {
+    const uint32_t key = ordered_float(row_logits[pos * logits_stride1]);
+    if (key > threshold || (key == threshold && pos <= cutoff)) {
+      if (output_slot < topk) {
+        topk_indices[row * topk_stride0 +
+                     static_cast<int64_t>(output_slot) * topk_stride1] =
+            static_cast<OutT>(pos - row_start);
+      }
+      ++output_slot;
+    }
+  }
+}
+
+template <typename OutT>
+__global__ void glm52_indexer_topk_decode_kernel(
+    const uint8_t *__restrict__ q_quant, int64_t q_stride0, int64_t q_stride1,
+    int64_t q_stride2, const uint8_t *__restrict__ kv_cache,
+    int64_t num_blocks, int64_t block_size, int64_t block_stride,
+    const float *__restrict__ weights, int64_t weights_stride0,
+    int64_t weights_stride1, const void *__restrict__ seq_lens,
+    int seq_lens_kind, int64_t seq_lens_stride,
+    const void *__restrict__ block_table, int block_table_kind,
+    int64_t block_table_stride, OutT *__restrict__ topk_indices,
+    int64_t topk_stride0, int64_t topk_stride1, int64_t rows, int64_t topk) {
+  const int64_t row = static_cast<int64_t>(blockIdx.x);
+  if (row >= rows) {
+    return;
+  }
+
+  __shared__ float scores[kMaxSeqLen];
+  __shared__ SelectionScratch scratch;
+  __shared__ float weight_cache[kNumHeads];
+  __shared__ int histogram[256];
+  __shared__ uint32_t prefix;
+  __shared__ int rank_in_bucket;
+  __shared__ int tie_cutoff;
+  __shared__ int candidate_count;
+
+  const int tid = threadIdx.x;
+  const int64_t raw_seq_len =
+      load_index(seq_lens, seq_lens_kind, row * seq_lens_stride);
+  const int64_t seq_len = raw_seq_len > 0 ? raw_seq_len : 0;
+  if (seq_len <= topk) {
+    fill_all_indices(topk_indices, topk_stride0, topk_stride1, row, seq_len,
+                     topk);
+    return;
+  }
+  if (seq_len > kMaxSeqLen) {
+    // The host dispatcher prevents this path.  Keep the output visibly invalid
+    // if metadata changes race a caller rather than silently truncating scores.
+    fill_all_indices(topk_indices, topk_stride0, topk_stride1, row, 0, topk);
+    return;
+  }
+
+  for (int64_t elem = tid; elem < kNumHeads * kHeadDim;
+       elem += blockDim.x) {
+    const int64_t head = elem / kHeadDim;
+    const int64_t dim = elem - head * kHeadDim;
+    const uint8_t *q_ptr = q_quant + row * q_stride0 + head * q_stride1;
+    scratch.q_deq[elem] =
+        __float2bfloat16(dequant_fp8_e4m3(q_ptr[dim * q_stride2]));
+  }
+  for (int64_t head = tid; head < kNumHeads; head += blockDim.x) {
+    weight_cache[head] =
+        weights[row * weights_stride0 + head * weights_stride1];
+  }
+  __syncthreads();
+
+  for (int64_t pos = tid; pos < seq_len; pos += blockDim.x) {
+    float score = -INFINITY;
+    const int64_t logical_block = pos / block_size;
+    const int64_t pos_in_block = pos - logical_block * block_size;
+    const int64_t physical_block = load_index(
+        block_table, block_table_kind, row * block_table_stride + logical_block);
+    if (physical_block >= 0 && physical_block < num_blocks &&
+        pos_in_block >= 0 && pos_in_block < block_size) {
+      const uint8_t *block_ptr = kv_cache + physical_block * block_stride;
+      const uint8_t *k_ptr = block_ptr + pos_in_block * kHeadDim;
+      const uint8_t *scale_ptr =
+          block_ptr + block_size * kHeadDim + pos_in_block * kScaleBytes;
+      const float k_scale = *reinterpret_cast<const float *>(scale_ptr);
+      float accum = 0.0f;
+      for (int64_t head = 0; head < kNumHeads; ++head) {
+        const __mt_bfloat16 *q_ptr = scratch.q_deq + head * kHeadDim;
+        float dot = 0.0f;
+#pragma unroll 4
+        for (int64_t dim = 0; dim < kHeadDim; ++dim) {
+          dot += __bfloat162float(q_ptr[dim]) * dequant_fp8_e4m3(k_ptr[dim]);
+        }
+        accum += fmaxf(dot, 0.0f) * weight_cache[head];
+      }
+      score = accum * k_scale;
+    }
+    scores[pos] = score;
+  }
+  __syncthreads();
+
+  radix_select_scores(scores, &scratch, histogram, &prefix, &rank_in_bucket,
+                      &tie_cutoff, &candidate_count, topk_indices,
+                      topk_stride0, topk_stride1, row, seq_len, topk);
+}
+
+template <typename OutT>
+__global__ void glm52_indexer_topk_prefill_kernel(
+    const uint8_t *__restrict__ q_quant, int64_t q_stride0, int64_t q_stride1,
+    int64_t q_stride2, const uint8_t *__restrict__ kv_cache,
+    int64_t num_blocks, int64_t block_size, int64_t block_stride,
+    const float *__restrict__ weights, int64_t weights_stride0,
+    int64_t weights_stride1, const void *__restrict__ block_table,
+    int block_table_kind, int64_t block_table_stride,
+    const void *__restrict__ cu_seq_lens, int cu_seq_lens_kind,
+    int64_t cu_seq_lens_stride, const void *__restrict__ token_to_seq,
+    int token_to_seq_kind, int64_t token_to_seq_stride,
+    const void *__restrict__ cu_seqlen_ks, int cu_seqlen_ks_kind,
+    int64_t cu_seqlen_ks_stride, const void *__restrict__ cu_seqlen_ke,
+    int cu_seqlen_ke_kind, int64_t cu_seqlen_ke_stride,
+    OutT *__restrict__ topk_indices, int64_t topk_stride0,
+    int64_t topk_stride1, int64_t rows, int64_t total_seq_lens,
+    int64_t topk) {
+  const int64_t row = static_cast<int64_t>(blockIdx.x);
+  if (row >= rows) {
+    return;
+  }
+
+  __shared__ float scores[kMaxSeqLen];
+  __shared__ SelectionScratch scratch;
+  __shared__ float weight_cache[kNumHeads];
+  __shared__ int histogram[256];
+  __shared__ uint32_t prefix;
+  __shared__ int rank_in_bucket;
+  __shared__ int tie_cutoff;
+  __shared__ int candidate_count;
+
+  const int tid = threadIdx.x;
+  const int64_t row_start =
+      load_index(cu_seqlen_ks, cu_seqlen_ks_kind, row * cu_seqlen_ks_stride);
+  const int64_t row_end =
+      load_index(cu_seqlen_ke, cu_seqlen_ke_kind, row * cu_seqlen_ke_stride);
+  const int64_t raw_row_len = row_end - row_start;
+  const int64_t row_len = raw_row_len > 0 ? raw_row_len : 0;
+  if (row_len <= topk) {
+    fill_all_indices(topk_indices, topk_stride0, topk_stride1, row, row_len,
+                     topk);
+    return;
+  }
+  if (row_len > kMaxSeqLen) {
+    fill_all_indices(topk_indices, topk_stride0, topk_stride1, row, 0, topk);
+    return;
+  }
+
+  for (int64_t elem = tid; elem < kNumHeads * kHeadDim;
+       elem += blockDim.x) {
+    const int64_t head = elem / kHeadDim;
+    const int64_t dim = elem - head * kHeadDim;
+    const uint8_t *q_ptr = q_quant + row * q_stride0 + head * q_stride1;
+    scratch.q_deq[elem] =
+        __float2bfloat16(dequant_fp8_e4m3(q_ptr[dim * q_stride2]));
+  }
+  for (int64_t head = tid; head < kNumHeads; head += blockDim.x) {
+    weight_cache[head] =
+        weights[row * weights_stride0 + head * weights_stride1];
+  }
+  __syncthreads();
+
+  for (int64_t rel_pos = tid; rel_pos < row_len; rel_pos += blockDim.x) {
+    float score = -INFINITY;
+    const int64_t abs_pos = row_start + rel_pos;
+    if (abs_pos >= 0 && abs_pos < total_seq_lens) {
+      const int64_t req_idx = load_index(
+          token_to_seq, token_to_seq_kind, abs_pos * token_to_seq_stride);
+      const int64_t req_start = load_index(
+          cu_seq_lens, cu_seq_lens_kind, req_idx * cu_seq_lens_stride);
+      const int64_t local_pos = abs_pos - req_start;
+      const int64_t logical_block = local_pos / block_size;
+      const int64_t pos_in_block = local_pos - logical_block * block_size;
+      const int64_t physical_block =
+          load_index(block_table, block_table_kind,
+                     req_idx * block_table_stride + logical_block);
+      if (physical_block >= 0 && physical_block < num_blocks &&
+          pos_in_block >= 0 && pos_in_block < block_size) {
+        const uint8_t *block_ptr = kv_cache + physical_block * block_stride;
+        const uint8_t *k_ptr = block_ptr + pos_in_block * kHeadDim;
+        const uint8_t *scale_ptr =
+            block_ptr + block_size * kHeadDim + pos_in_block * kScaleBytes;
+        const float k_scale = *reinterpret_cast<const float *>(scale_ptr);
+        float accum = 0.0f;
+        for (int64_t head = 0; head < kNumHeads; ++head) {
+          const __mt_bfloat16 *q_ptr = scratch.q_deq + head * kHeadDim;
+          float dot = 0.0f;
+#pragma unroll 4
+          for (int64_t dim = 0; dim < kHeadDim; ++dim) {
+            dot += __bfloat162float(q_ptr[dim]) *
+                   dequant_fp8_e4m3(k_ptr[dim]);
+          }
+          accum += fmaxf(dot, 0.0f) * weight_cache[head];
+        }
+        score = accum * k_scale;
+      }
+    }
+    scores[rel_pos] = score;
+  }
+  __syncthreads();
+
+  radix_select_scores(scores, &scratch, histogram, &prefix, &rank_in_bucket,
+                      &tie_cutoff, &candidate_count, topk_indices,
+                      topk_stride0, topk_stride1, row, row_len, topk);
+}
+
+template <typename OutT>
+void launch_fill_all(const torch::Tensor &lengths, torch::Tensor &topk_indices,
+                     int64_t topk, musaStream_t stream) {
+  const dim3 grid(static_cast<unsigned int>(lengths.numel()));
+  const dim3 block(kThreads);
+  sparse_indexer_fill_all_kernel<OutT><<<grid, block, 0, stream>>>(
+      lengths.data_ptr(), index_kind(lengths, "lengths"), lengths.stride(-1),
+      static_cast<OutT *>(topk_indices.data_ptr()), topk_indices.stride(0),
+      topk_indices.stride(1), lengths.numel(), topk);
+}
+
+template <typename OutT>
+void launch_sparse_indexer_topk(const torch::Tensor &logits,
+                                const torch::Tensor &row_starts,
+                                const torch::Tensor &row_ends,
+                                torch::Tensor &topk_indices, int64_t topk,
+                                musaStream_t stream) {
+  const dim3 grid(static_cast<unsigned int>(logits.size(0)));
+  const dim3 block(kThreads);
+  sparse_indexer_topk_kernel<OutT><<<grid, block, 0, stream>>>(
+      static_cast<const float *>(logits.data_ptr()), logits.stride(0),
+      logits.stride(1), logits.size(1), row_starts.data_ptr(),
+      index_kind(row_starts, "row_starts"), row_starts.stride(0),
+      row_ends.data_ptr(), index_kind(row_ends, "row_ends"),
+      row_ends.stride(0), static_cast<OutT *>(topk_indices.data_ptr()),
+      topk_indices.stride(0), topk_indices.stride(1), logits.size(0), topk,
+      false);
+}
+
+template <typename OutT>
+void launch_sparse_indexer_topk_decode(const torch::Tensor &logits,
+                                       const torch::Tensor &seq_lens,
+                                       torch::Tensor &topk_indices,
+                                       int64_t topk, musaStream_t stream) {
+  const dim3 grid(static_cast<unsigned int>(logits.size(0)));
+  const dim3 block(kThreads);
+  sparse_indexer_topk_kernel<OutT><<<grid, block, 0, stream>>>(
+      static_cast<const float *>(logits.data_ptr()), logits.stride(0),
+      logits.stride(1), logits.size(1), nullptr, kIndexInt32, 0,
+      seq_lens.data_ptr(), index_kind(seq_lens, "seq_lens"),
+      seq_lens.stride(0), static_cast<OutT *>(topk_indices.data_ptr()),
+      topk_indices.stride(0), topk_indices.stride(1), logits.size(0), topk,
+      true);
+}
+
+template <typename OutT>
+void launch_glm52_decode(const torch::Tensor &q_quant,
+                         const torch::Tensor &kv_cache,
+                         const torch::Tensor &weights,
+                         const torch::Tensor &seq_lens,
+                         const torch::Tensor &block_table,
+                         torch::Tensor &topk_indices, int64_t topk,
+                         musaStream_t stream) {
+  const dim3 grid(static_cast<unsigned int>(q_quant.size(0)));
+  const dim3 block(kThreads);
+  glm52_indexer_topk_decode_kernel<OutT><<<grid, block, 0, stream>>>(
+      static_cast<const uint8_t *>(q_quant.data_ptr()), q_quant.stride(0),
+      q_quant.stride(1), q_quant.stride(2),
+      static_cast<const uint8_t *>(kv_cache.data_ptr()), kv_cache.size(0),
+      kv_cache.size(1), kv_cache.stride(0),
+      static_cast<const float *>(weights.data_ptr()), weights.stride(0),
+      weights.stride(1), seq_lens.data_ptr(), index_kind(seq_lens, "seq_lens"),
+      seq_lens.stride(0), block_table.data_ptr(),
+      index_kind(block_table, "block_table"), block_table.stride(0),
+      static_cast<OutT *>(topk_indices.data_ptr()), topk_indices.stride(0),
+      topk_indices.stride(1), q_quant.size(0), topk);
+}
+
+template <typename OutT>
+void launch_glm52_prefill(
+    const torch::Tensor &q_quant, const torch::Tensor &kv_cache,
+    const torch::Tensor &weights, const torch::Tensor &block_table,
+    const torch::Tensor &cu_seq_lens, const torch::Tensor &token_to_seq,
+    const torch::Tensor &cu_seqlen_ks, const torch::Tensor &cu_seqlen_ke,
+    torch::Tensor &topk_indices, int64_t topk, musaStream_t stream) {
+  const dim3 grid(static_cast<unsigned int>(q_quant.size(0)));
+  const dim3 block(kThreads);
+  glm52_indexer_topk_prefill_kernel<OutT><<<grid, block, 0, stream>>>(
+      static_cast<const uint8_t *>(q_quant.data_ptr()), q_quant.stride(0),
+      q_quant.stride(1), q_quant.stride(2),
+      static_cast<const uint8_t *>(kv_cache.data_ptr()), kv_cache.size(0),
+      kv_cache.size(1), kv_cache.stride(0),
+      static_cast<const float *>(weights.data_ptr()), weights.stride(0),
+      weights.stride(1), block_table.data_ptr(),
+      index_kind(block_table, "block_table"), block_table.stride(0),
+      cu_seq_lens.data_ptr(), index_kind(cu_seq_lens, "cu_seq_lens"),
+      cu_seq_lens.stride(0), token_to_seq.data_ptr(),
+      index_kind(token_to_seq, "token_to_seq"), token_to_seq.stride(0),
+      cu_seqlen_ks.data_ptr(), index_kind(cu_seqlen_ks, "cu_seqlen_ks"),
+      cu_seqlen_ks.stride(0), cu_seqlen_ke.data_ptr(),
+      index_kind(cu_seqlen_ke, "cu_seqlen_ke"), cu_seqlen_ke.stride(0),
+      static_cast<OutT *>(topk_indices.data_ptr()), topk_indices.stride(0),
+      topk_indices.stride(1), q_quant.size(0), token_to_seq.numel(), topk);
+}
+
+void check_glm52_common(const torch::Tensor &q_quant,
+                        const torch::Tensor &kv_cache,
+                        const torch::Tensor &weights,
+                        const torch::Tensor &topk_indices, int64_t topk) {
+  check_musa_tensor(q_quant, "q_quant");
+  check_same_device(q_quant, kv_cache, "kv_cache");
+  check_same_device(q_quant, weights, "weights");
+  check_same_device(q_quant, topk_indices, "topk_indices");
+  TORCH_CHECK(q_quant.scalar_type() == torch::kFloat8_e4m3fn,
+              "q_quant must be float8_e4m3fn");
+  TORCH_CHECK(kv_cache.scalar_type() == torch::kUInt8,
+              "kv_cache must be uint8");
+  TORCH_CHECK(weights.scalar_type() == torch::kFloat32,
+              "weights must be float32");
+  TORCH_CHECK(q_quant.dim() == 3 && q_quant.size(1) == kNumHeads &&
+                  q_quant.size(2) == kHeadDim,
+              "q_quant must be [rows, 32, 128]");
+  TORCH_CHECK(weights.dim() == 2 && weights.size(0) == q_quant.size(0) &&
+                  weights.size(1) == kNumHeads,
+              "weights must be [rows, 32]");
+  TORCH_CHECK(topk_indices.dim() == 2 &&
+                  topk_indices.size(0) >= q_quant.size(0),
+              "topk_indices must have at least one row per query");
+  TORCH_CHECK(topk >= 0 && topk <= topk_indices.size(1),
+              "topk must fit topk_indices width");
+  TORCH_CHECK(topk <= kMaxTopK, "topk > 2048 is not supported");
+  TORCH_CHECK(kv_cache.dim() >= 2 && kv_cache.size(1) > 0,
+              "kv_cache must include a non-empty block dimension");
+  TORCH_CHECK(kv_cache.stride(-1) == 1,
+              "kv_cache byte dimension must be contiguous");
+  TORCH_CHECK(kv_cache.stride(0) >=
+                  kv_cache.size(1) * (kHeadDim + kScaleBytes),
+              "kv_cache block stride is too small for indexer FP8 layout");
+  TORCH_CHECK(q_quant.stride(2) == 1,
+              "q_quant last dimension must be contiguous");
+  TORCH_CHECK(topk_indices.stride(1) == 1,
+              "topk_indices last dimension must be contiguous");
+}
+
+} // namespace
+
+void sparse_indexer_fill_all(const torch::Tensor &lengths,
+                             torch::Tensor &topk_indices, int64_t topk) {
+  check_musa_tensor(lengths, "lengths");
+  check_same_device(lengths, topk_indices, "topk_indices");
+  TORCH_CHECK(lengths.dim() == 1, "lengths must be 1-D");
+  TORCH_CHECK(topk_indices.dim() == 2 &&
+                  topk_indices.size(0) >= lengths.numel(),
+              "topk_indices must have at least one row per length");
+  TORCH_CHECK(topk >= 0 && topk <= topk_indices.size(1),
+              "topk must fit topk_indices width");
+  index_kind(lengths, "lengths");
+  if (lengths.numel() == 0 || topk == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(lengths));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  if (topk_indices.scalar_type() == torch::kInt32) {
+    launch_fill_all<int32_t>(lengths, topk_indices, topk, stream);
+  } else if (topk_indices.scalar_type() == torch::kInt64) {
+    launch_fill_all<int64_t>(lengths, topk_indices, topk, stream);
+  } else {
+    TORCH_CHECK(false, "topk_indices must be int32 or int64");
+  }
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess, "sparse_indexer_fill_all launch failed: ",
+              musaGetErrorString(err));
+}
+
+void sparse_indexer_topk(const torch::Tensor &logits,
+                         const torch::Tensor &row_starts,
+                         const torch::Tensor &row_ends,
+                         torch::Tensor &topk_indices, int64_t topk) {
+  check_musa_tensor(logits, "logits");
+  check_same_device(logits, row_starts, "row_starts");
+  check_same_device(logits, row_ends, "row_ends");
+  check_same_device(logits, topk_indices, "topk_indices");
+  TORCH_CHECK(logits.scalar_type() == torch::kFloat32,
+              "logits must be float32");
+  TORCH_CHECK(logits.dim() == 2, "logits must be 2-D");
+  TORCH_CHECK(row_starts.dim() == 1 && row_starts.numel() >= logits.size(0),
+              "row_starts must have at least one entry per logit row");
+  TORCH_CHECK(row_ends.dim() == 1 && row_ends.numel() >= logits.size(0),
+              "row_ends must have at least one entry per logit row");
+  TORCH_CHECK(topk_indices.dim() == 2 &&
+                  topk_indices.size(0) >= logits.size(0),
+              "topk_indices must have at least one output row per logit row");
+  TORCH_CHECK(topk >= 0 && topk <= topk_indices.size(1),
+              "topk must fit topk_indices width");
+  TORCH_CHECK(topk <= kMaxTopK, "topk > 2048 is not supported");
+  TORCH_CHECK(logits.stride(1) == 1,
+              "logits last dimension must be contiguous");
+  TORCH_CHECK(topk_indices.stride(1) == 1,
+              "topk_indices last dimension must be contiguous");
+  index_kind(row_starts, "row_starts");
+  index_kind(row_ends, "row_ends");
+  if (logits.size(0) == 0 || topk == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(logits));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  if (topk_indices.scalar_type() == torch::kInt32) {
+    launch_sparse_indexer_topk<int32_t>(logits, row_starts, row_ends,
+                                        topk_indices, topk, stream);
+  } else if (topk_indices.scalar_type() == torch::kInt64) {
+    launch_sparse_indexer_topk<int64_t>(logits, row_starts, row_ends,
+                                        topk_indices, topk, stream);
+  } else {
+    TORCH_CHECK(false, "topk_indices must be int32 or int64");
+  }
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess, "sparse_indexer_topk launch failed: ",
+              musaGetErrorString(err));
+}
+
+void sparse_indexer_topk_decode(const torch::Tensor &logits,
+                                const torch::Tensor &seq_lens,
+                                torch::Tensor &topk_indices, int64_t topk) {
+  check_musa_tensor(logits, "logits");
+  check_same_device(logits, seq_lens, "seq_lens");
+  check_same_device(logits, topk_indices, "topk_indices");
+  TORCH_CHECK(logits.scalar_type() == torch::kFloat32,
+              "logits must be float32");
+  TORCH_CHECK(logits.dim() == 2, "logits must be 2-D");
+  TORCH_CHECK(seq_lens.dim() == 1 && seq_lens.numel() >= logits.size(0),
+              "seq_lens must have at least one entry per logit row");
+  TORCH_CHECK(topk_indices.dim() == 2 &&
+                  topk_indices.size(0) >= logits.size(0),
+              "topk_indices must have at least one output row per logit row");
+  TORCH_CHECK(topk >= 0 && topk <= topk_indices.size(1),
+              "topk must fit topk_indices width");
+  TORCH_CHECK(topk <= kMaxTopK, "topk > 2048 is not supported");
+  TORCH_CHECK(logits.stride(1) == 1,
+              "logits last dimension must be contiguous");
+  TORCH_CHECK(topk_indices.stride(1) == 1,
+              "topk_indices last dimension must be contiguous");
+  index_kind(seq_lens, "seq_lens");
+  if (logits.size(0) == 0 || topk == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(logits));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  if (topk_indices.scalar_type() == torch::kInt32) {
+    launch_sparse_indexer_topk_decode<int32_t>(logits, seq_lens,
+                                               topk_indices, topk, stream);
+  } else if (topk_indices.scalar_type() == torch::kInt64) {
+    launch_sparse_indexer_topk_decode<int64_t>(logits, seq_lens,
+                                               topk_indices, topk, stream);
+  } else {
+    TORCH_CHECK(false, "topk_indices must be int32 or int64");
+  }
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "sparse_indexer_topk_decode launch failed: ",
+              musaGetErrorString(err));
+}
+
+void glm52_indexer_topk_decode(
+    const torch::Tensor &q_quant, const torch::Tensor &kv_cache,
+    const torch::Tensor &weights, const torch::Tensor &seq_lens,
+    const torch::Tensor &block_table, torch::Tensor &topk_indices,
+    int64_t topk) {
+  check_glm52_common(q_quant, kv_cache, weights, topk_indices, topk);
+  check_same_device(q_quant, seq_lens, "seq_lens");
+  check_same_device(q_quant, block_table, "block_table");
+  TORCH_CHECK(seq_lens.dim() == 1 && seq_lens.size(0) >= q_quant.size(0),
+              "seq_lens must be 1-D with at least one entry per row");
+  TORCH_CHECK(block_table.dim() == 2 &&
+                  block_table.size(0) >= q_quant.size(0),
+              "block_table must be 2-D with at least one row per query");
+  TORCH_CHECK(block_table.size(1) * kv_cache.size(1) <= kMaxSeqLen,
+              "glm52_indexer_topk_decode supports max sequence length 8192");
+  index_kind(seq_lens, "seq_lens");
+  index_kind(block_table, "block_table");
+  if (q_quant.size(0) == 0 || topk == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(q_quant));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  if (topk_indices.scalar_type() == torch::kInt32) {
+    launch_glm52_decode<int32_t>(q_quant, kv_cache, weights, seq_lens,
+                                 block_table, topk_indices, topk, stream);
+  } else if (topk_indices.scalar_type() == torch::kInt64) {
+    launch_glm52_decode<int64_t>(q_quant, kv_cache, weights, seq_lens,
+                                 block_table, topk_indices, topk, stream);
+  } else {
+    TORCH_CHECK(false, "topk_indices must be int32 or int64");
+  }
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "glm52_indexer_topk_decode launch failed: ",
+              musaGetErrorString(err));
+}
+
+void glm52_indexer_topk_prefill(
+    const torch::Tensor &q_quant, const torch::Tensor &kv_cache,
+    const torch::Tensor &weights, const torch::Tensor &block_table,
+    const torch::Tensor &cu_seq_lens, const torch::Tensor &token_to_seq,
+    const torch::Tensor &cu_seqlen_ks, const torch::Tensor &cu_seqlen_ke,
+    torch::Tensor &topk_indices, int64_t topk) {
+  check_glm52_common(q_quant, kv_cache, weights, topk_indices, topk);
+  check_same_device(q_quant, block_table, "block_table");
+  check_same_device(q_quant, cu_seq_lens, "cu_seq_lens");
+  check_same_device(q_quant, token_to_seq, "token_to_seq");
+  check_same_device(q_quant, cu_seqlen_ks, "cu_seqlen_ks");
+  check_same_device(q_quant, cu_seqlen_ke, "cu_seqlen_ke");
+  TORCH_CHECK(block_table.dim() == 2, "block_table must be 2-D");
+  TORCH_CHECK(cu_seq_lens.dim() == 1, "cu_seq_lens must be 1-D");
+  TORCH_CHECK(token_to_seq.dim() == 1, "token_to_seq must be 1-D");
+  TORCH_CHECK(cu_seqlen_ks.dim() == 1 &&
+                  cu_seqlen_ks.size(0) >= q_quant.size(0),
+              "cu_seqlen_ks must have at least one entry per row");
+  TORCH_CHECK(cu_seqlen_ke.dim() == 1 &&
+                  cu_seqlen_ke.size(0) >= q_quant.size(0),
+              "cu_seqlen_ke must have at least one entry per row");
+  TORCH_CHECK(token_to_seq.numel() <= kMaxSeqLen,
+              "glm52_indexer_topk_prefill supports chunks up to 8192 tokens");
+  index_kind(block_table, "block_table");
+  index_kind(cu_seq_lens, "cu_seq_lens");
+  index_kind(token_to_seq, "token_to_seq");
+  index_kind(cu_seqlen_ks, "cu_seqlen_ks");
+  index_kind(cu_seqlen_ke, "cu_seqlen_ke");
+  if (q_quant.size(0) == 0 || topk == 0) {
+    return;
+  }
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(q_quant));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+  if (topk_indices.scalar_type() == torch::kInt32) {
+    launch_glm52_prefill<int32_t>(
+        q_quant, kv_cache, weights, block_table, cu_seq_lens, token_to_seq,
+        cu_seqlen_ks, cu_seqlen_ke, topk_indices, topk, stream);
+  } else if (topk_indices.scalar_type() == torch::kInt64) {
+    launch_glm52_prefill<int64_t>(
+        q_quant, kv_cache, weights, block_table, cu_seq_lens, token_to_seq,
+        cu_seqlen_ks, cu_seqlen_ke, topk_indices, topk, stream);
+  } else {
+    TORCH_CHECK(false, "topk_indices must be int32 or int64");
+  }
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "glm52_indexer_topk_prefill launch failed: ",
+              musaGetErrorString(err));
+}

--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -139,6 +139,26 @@ void deepseek_v4_indexer_rerank_prefill(
     const torch::Tensor &cu_seqlen_ks, const torch::Tensor &cu_seqlen_ke,
     const torch::Tensor &candidate_abs_indices, torch::Tensor &topk_indices,
     int64_t topk);
+void sparse_indexer_fill_all(const torch::Tensor &lengths,
+                             torch::Tensor &topk_indices, int64_t topk);
+void sparse_indexer_topk(const torch::Tensor &logits,
+                         const torch::Tensor &row_starts,
+                         const torch::Tensor &row_ends,
+                         torch::Tensor &topk_indices, int64_t topk);
+void sparse_indexer_topk_decode(const torch::Tensor &logits,
+                                const torch::Tensor &seq_lens,
+                                torch::Tensor &topk_indices, int64_t topk);
+void glm52_indexer_topk_decode(
+    const torch::Tensor &q_quant, const torch::Tensor &kv_cache,
+    const torch::Tensor &weights, const torch::Tensor &seq_lens,
+    const torch::Tensor &block_table, torch::Tensor &topk_indices,
+    int64_t topk);
+void glm52_indexer_topk_prefill(
+    const torch::Tensor &q_quant, const torch::Tensor &kv_cache,
+    const torch::Tensor &weights, const torch::Tensor &block_table,
+    const torch::Tensor &cu_seq_lens, const torch::Tensor &token_to_seq,
+    const torch::Tensor &cu_seqlen_ks, const torch::Tensor &cu_seqlen_ke,
+    torch::Tensor &topk_indices, int64_t topk);
 std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_sparse_flashmla_decode(
     const torch::Tensor &q, const torch::Tensor &k_cache,
     const torch::Tensor &indices,

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -138,6 +138,39 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
                 &deepseek_v4_indexer_rerank_prefill);
 
   musa_ops.def(
+      "sparse_indexer_fill_all(Tensor lengths, Tensor! topk_indices, int topk) "
+      "-> ()");
+  musa_ops.impl("sparse_indexer_fill_all", torch::kMUSA,
+                &sparse_indexer_fill_all);
+
+  musa_ops.def(
+      "sparse_indexer_topk(Tensor logits, Tensor row_starts, Tensor row_ends, "
+      "Tensor! topk_indices, int topk) -> ()");
+  musa_ops.impl("sparse_indexer_topk", torch::kMUSA,
+                &sparse_indexer_topk);
+
+  musa_ops.def(
+      "sparse_indexer_topk_decode(Tensor logits, Tensor seq_lens, Tensor! "
+      "topk_indices, int topk) -> ()");
+  musa_ops.impl("sparse_indexer_topk_decode", torch::kMUSA,
+                &sparse_indexer_topk_decode);
+
+  musa_ops.def(
+      "glm52_indexer_topk_decode(Tensor q_quant, Tensor kv_cache, Tensor "
+      "weights, Tensor seq_lens, Tensor block_table, Tensor! topk_indices, "
+      "int topk) -> ()");
+  musa_ops.impl("glm52_indexer_topk_decode", torch::kMUSA,
+                &glm52_indexer_topk_decode);
+
+  musa_ops.def(
+      "glm52_indexer_topk_prefill(Tensor q_quant, Tensor kv_cache, Tensor "
+      "weights, Tensor block_table, Tensor cu_seq_lens, Tensor token_to_seq, "
+      "Tensor cu_seqlen_ks, Tensor cu_seqlen_ke, Tensor! topk_indices, int "
+      "topk) -> ()");
+  musa_ops.impl("glm52_indexer_topk_prefill", torch::kMUSA,
+                &glm52_indexer_topk_prefill);
+
+  musa_ops.def(
       "deepseek_v4_sparse_flashmla_decode(Tensor q, Tensor k_cache, "
       "Tensor indices, Tensor? topk_length, Tensor? attn_sink, "
       "Tensor? extra_k_cache, Tensor? extra_indices, Tensor? "

--- a/setup.py
+++ b/setup.py
@@ -212,6 +212,7 @@ VLLM_MUSA_CSRC_SOURCES = [
     "csrc/musa/attention/deepseek_v4_fused_qkv_rmsnorm.mu",
     "csrc/musa/attention/deepseek_v4_cache_utils.mu",
     "csrc/musa/attention/deepseek_v4_indexer_topk.mu",
+    "csrc/musa/attention/glm52_indexer_topk.mu",
     "csrc/musa/attention/deepseek_v4_sparse_flashmla.mu",
     "csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu",
     "csrc/musa/mhc/deepseek_v4_mhc_pre.mu",

--- a/tests/test_glm52_indexer_topk_source.py
+++ b/tests/test_glm52_indexer_topk_source.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source-level coverage for the GLM-5.2 native indexer top-k path."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text()
+
+
+def test_glm52_indexer_kernel_matches_model_shape_and_topk():
+    source = _read("csrc/musa/attention/glm52_indexer_topk.mu")
+
+    assert "constexpr int64_t kNumHeads = 32;" in source
+    assert "constexpr int64_t kHeadDim = 128;" in source
+    assert "constexpr int64_t kMaxTopK = 2048;" in source
+    assert "constexpr int64_t kMaxSeqLen = 8192;" in source
+    assert "for (int shift = 24; shift >= 0; shift -= 8)" in source
+    assert "for (int size = 2; size <= kMaxTopK; size <<= 1)" in source
+    assert "if (seq_len <= topk)" in source
+    assert "if (row_len <= topk)" in source
+
+
+def test_glm52_indexer_ops_are_built_registered_and_wrapped():
+    setup = _read("setup.py")
+    bindings = _read("csrc/musa/torch_bindings.cpp")
+    headers = _read("csrc/musa/musa_ops.h")
+    custom_ops = _read("vllm_musa/_custom_ops.py")
+
+    assert '"csrc/musa/attention/glm52_indexer_topk.mu"' in setup
+    for op in (
+        "sparse_indexer_fill_all",
+        "sparse_indexer_topk",
+        "sparse_indexer_topk_decode",
+        "glm52_indexer_topk_decode",
+        "glm52_indexer_topk_prefill",
+    ):
+        assert f'"{op}(' in bindings
+        assert f'&{op}' in bindings
+        assert f"void {op}(" in headers
+        assert f"def {op}(" in custom_ops
+        assert f"torch.ops._C_musa_ops.{op}" in custom_ops
+
+
+def test_glm52_indexer_dispatch_has_shortcut_and_safe_fallback_boundary():
+    series = _read(
+        "vllm_musa/patches/series/"
+        "0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch"
+    )
+
+    assert "VLLM_MUSA_GLM52_INDEXER_TOPK_NATIVE" in series
+    assert "_musa_try_fill_all_sparse_indexer_indices" in series
+    assert "int(metadata.max_seq_len) > int(topk_tokens)" in series
+    assert "_musa_custom_ops.sparse_indexer_fill_all(" in series
+    assert "VLLM_MUSA_GLM52_INDEXER_TOPK_MATERIALIZED" in series
+    assert 'VLLM_MUSA_GLM52_INDEXER_TOPK_FUSED", "0"' in series
+    assert "q_quant.shape[1] == 32" in series
+    assert "topk_tokens <= 2048" in series
+    assert "<= 8192" in series
+    assert "_musa_custom_ops.glm52_indexer_topk_decode(" in series
+    assert "_musa_custom_ops.glm52_indexer_topk_prefill(" in series
+    assert "_musa_custom_ops.sparse_indexer_topk_decode(" in series
+    assert "decode_metadata.schedule_metadata" in series
+    assert "is_glm52_graph_path" in series
+
+
+def test_musa_decode_schedule_metadata_is_precomputed_for_graph_capture():
+    series = _read(
+        "vllm_musa/patches/series/"
+        "0086-MUSA-vllm.v1.attention.backends.mla.indexer.patch"
+    )
+
+    assert "current_platform.is_musa()" in series
+    assert "get_paged_mqa_logits_metadata" in series
+    assert "schedule_metadata = self.scheduler_metadata_buffer" in series
+    assert "schedule_metadata=schedule_metadata" in series
+
+
+def test_deepseek_v4_dispatch_stays_shape_isolated():
+    series = _read(
+        "vllm_musa/patches/series/"
+        "0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch"
+    )
+
+    assert "q_quant.shape[1] != 64" in series
+    assert "topk_tokens > 512" in series
+    assert "_musa_custom_ops.deepseek_v4_indexer_topk_decode(" in series
+    assert "_musa_custom_ops.deepseek_v4_indexer_topk_prefill(" in series
+
+
+def test_sparse_mla_sanitizes_indices_before_kv_loads():
+    source = _read("vllm_musa/v1/attention/ops/sparse_mla_tilelang.py")
+
+    assert 'kv_indices = T.alloc_fragment([BI], "int32")' in source
+    assert "valid = (index >= 0) & (index < seq_len_kv)" in source
+    assert "kv_indices[bi_i] = T.if_then_else(valid, index, 0)" in source
+    assert "KV[b_i, kv_indices[bi_i], g_i, d_i]" in source
+    assert "b_i, kv_indices[bi_i], g_i, D + d_i" in source

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -543,6 +543,94 @@ def deepseek_v4_indexer_rerank_prefill(
     )
 
 
+def sparse_indexer_fill_all(
+    lengths: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk: int,
+) -> None:
+    return torch.ops._C_musa_ops.sparse_indexer_fill_all(
+        lengths,
+        topk_indices,
+        topk,
+    )
+
+
+def sparse_indexer_topk(
+    logits: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk: int,
+) -> None:
+    return torch.ops._C_musa_ops.sparse_indexer_topk(
+        logits,
+        row_starts,
+        row_ends,
+        topk_indices,
+        topk,
+    )
+
+
+def sparse_indexer_topk_decode(
+    logits: torch.Tensor,
+    seq_lens: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk: int,
+) -> None:
+    return torch.ops._C_musa_ops.sparse_indexer_topk_decode(
+        logits,
+        seq_lens,
+        topk_indices,
+        topk,
+    )
+
+
+def glm52_indexer_topk_decode(
+    q_quant: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk: int,
+) -> None:
+    return torch.ops._C_musa_ops.glm52_indexer_topk_decode(
+        q_quant,
+        kv_cache,
+        weights,
+        seq_lens,
+        block_table,
+        topk_indices,
+        topk,
+    )
+
+
+def glm52_indexer_topk_prefill(
+    q_quant: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seq_lens: torch.Tensor,
+    token_to_seq: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk: int,
+) -> None:
+    return torch.ops._C_musa_ops.glm52_indexer_topk_prefill(
+        q_quant,
+        kv_cache,
+        weights,
+        block_table,
+        cu_seq_lens,
+        token_to_seq,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        topk_indices,
+        topk,
+    )
+
+
 def deepseek_v4_sparse_flashmla_decode(
     q: torch.Tensor,
     k_cache: torch.Tensor,

--- a/vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch
+++ b/vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch
@@ -24,7 +24,7 @@ index fe2b268cd..eadc6f533 100644
  from vllm import _custom_ops as ops
  from vllm._aiter_ops import rocm_aiter_ops
  from vllm.compilation.breakable_cudagraph import eager_break_during_capture
-@@ -31,6 +34,982 @@ from vllm.v1.worker.workspace import current_workspace_manager
+@@ -31,6 +34,1311 @@ from vllm.v1.worker.workspace import current_workspace_manager
  
  logger = init_logger(__name__)
  
@@ -197,6 +197,20 @@ index fe2b268cd..eadc6f533 100644
 +    return os.getenv("VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_NATIVE", "1") == "1"
 +
 +
++def _musa_sparse_indexer_glm52_native_enabled() -> bool:
++    return os.getenv("VLLM_MUSA_GLM52_INDEXER_TOPK_NATIVE", "1") == "1"
++
++
++def _musa_sparse_indexer_glm52_fused_enabled() -> bool:
++    # The single-block fused scorer is useful for correctness experiments but
++    # slower than the materialized MQA scorer on S5000 for rows above top-k.
++    return os.getenv("VLLM_MUSA_GLM52_INDEXER_TOPK_FUSED", "0") == "1"
++
++
++def _musa_sparse_indexer_glm52_materialized_enabled() -> bool:
++    return os.getenv("VLLM_MUSA_GLM52_INDEXER_TOPK_MATERIALIZED", "1") == "1"
++
++
 +def _musa_sparse_indexer_materialized_prefill_enabled() -> bool:
 +    return os.getenv(
 +        "VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_PREFILL_MATERIALIZED_LOGITS",
@@ -261,6 +275,174 @@ index fe2b268cd..eadc6f533 100644
 +    return block_table.repeat_interleave(rows // block_rows, dim=0)
 +
 +
++def _musa_try_fill_all_sparse_indexer_indices(
++    hidden_states: torch.Tensor,
++    k_cache_prefix: LayerNameType,
++    topk_tokens: int,
++    topk_indices_buffer: torch.Tensor,
++) -> bool:
++    """Skip indexer scoring when every causal window fits in top-k.
++
++    This is the production form of the GLM-5.2 dashboard SOTA's full-row
++    shortcut: if all valid keys are selected, their scores cannot affect the
++    selected set.  Fill the contiguous local indices directly and avoid KV
++    gather, dequantization, einsum, and top-k entirely.
++    """
++    attn_metadata = get_forward_context().attn_metadata
++    if not isinstance(attn_metadata, dict):
++        return False
++
++    metadata = attn_metadata.get(_resolve_layer_name(k_cache_prefix))
++    if not isinstance(metadata, DeepseekV32IndexerMetadata):
++        return False
++    if int(metadata.max_seq_len) > int(topk_tokens):
++        return False
++
++    topk = min(int(topk_tokens), topk_indices_buffer.shape[1])
++    topk_indices_buffer[: hidden_states.shape[0], :topk] = -1
++    if topk <= 0:
++        return True
++
++    if metadata.num_decodes > 0 and metadata.decode is not None:
++        lengths = metadata.decode.seq_lens.reshape(-1)
++        rows = min(
++            int(metadata.num_decode_tokens),
++            lengths.numel(),
++            topk_indices_buffer.shape[0],
++        )
++        if rows > 0:
++            _musa_custom_ops.sparse_indexer_fill_all(
++                lengths[:rows],
++                topk_indices_buffer[:rows, :topk],
++                topk,
++            )
++
++    if metadata.num_prefills > 0 and metadata.prefill is not None:
++        for chunk in metadata.prefill.chunks:
++            token_start = int(chunk.token_start)
++            token_end = min(
++                int(chunk.token_end),
++                topk_indices_buffer.shape[0],
++            )
++            rows = max(0, token_end - token_start)
++            if rows <= 0:
++                continue
++            lengths = (
++                chunk.cu_seqlen_ke[:rows] - chunk.cu_seqlen_ks[:rows]
++            ).contiguous()
++            _musa_custom_ops.sparse_indexer_fill_all(
++                lengths,
++                topk_indices_buffer[token_start:token_end, :topk],
++                topk,
++            )
++
++    return True
++
++
++def _musa_try_fill_decode_topk_from_materialized_logits(
++    q_quant: torch.Tensor,
++    kv_cache: torch.Tensor,
++    weights: torch.Tensor,
++    decode_metadata,
++    topk_indices: torch.Tensor,
++    topk_tokens: int,
++    head_dim: int,
++    max_model_len: int,
++) -> bool:
++    if (
++        not _musa_sparse_indexer_glm52_materialized_enabled()
++        or head_dim != 128
++        or q_quant.ndim != 3
++        or q_quant.shape[1] != 32
++        or topk_tokens > 2048
++        or q_quant.dtype != torch.float8_e4m3fn
++        or kv_cache.dtype != torch.uint8
++        or weights.dtype != torch.float32
++        or kv_cache.ndim != 3
++        or decode_metadata.schedule_metadata is None
++    ):
++        return False
++
++    context_lens = decode_metadata.seq_lens
++    if context_lens.ndim == 1:
++        context_lens = context_lens.reshape(-1, 1)
++    if context_lens.ndim != 2:
++        return False
++    batch_size, next_n = context_lens.shape
++    rows = min(q_quant.shape[0], context_lens.numel(), topk_indices.shape[0])
++    topk = min(int(topk_tokens), topk_indices.shape[1])
++    materialized_width = max(0, int(max_model_len))
++    if rows <= 0 or topk <= 0:
++        return True
++    if materialized_width <= topk:
++        return False
++    if rows != batch_size * next_n:
++        return False
++
++    context_lens = context_lens.contiguous()
++    if context_lens.dtype != torch.int32:
++        context_lens = context_lens.to(torch.int32)
++    seq_lens = context_lens.reshape(-1)
++    block_table = decode_metadata.block_table[:batch_size].contiguous()
++    q_native = q_quant[:rows].reshape(
++        batch_size,
++        next_n,
++        q_quant.shape[1],
++        q_quant.shape[2],
++    )
++    kv_paged = kv_cache.unsqueeze(-2)
++
++    def _select(logits: torch.Tensor) -> bool:
++        if logits.shape[0] < rows or logits.shape[1] < materialized_width:
++            return False
++        _musa_custom_ops.sparse_indexer_topk_decode(
++            logits[:rows, :materialized_width],
++            seq_lens,
++            topk_indices[:rows, :topk],
++            topk,
++        )
++        return True
++
++    for provider_name in ("mate.deep_gemm", "deep_gemm"):
++        try:
++            if provider_name == "mate.deep_gemm":
++                from mate import deep_gemm as _musa_deep_gemm
++            else:
++                import deep_gemm as _musa_deep_gemm
++
++            logits = _musa_deep_gemm.fp8_paged_mqa_logits(
++                q_native,
++                kv_paged,
++                weights[:rows].contiguous(),
++                context_lens,
++                block_table,
++                decode_metadata.schedule_metadata,
++                materialized_width,
++                False,
++            )
++            if _select(logits):
++                return True
++        except Exception:
++            pass
++
++    try:
++        from vllm.utils import deep_gemm as _vllm_deep_gemm
++
++        logits = _vllm_deep_gemm.fp8_fp4_paged_mqa_logits(
++            (q_native, None),
++            kv_paged,
++            weights[:rows].contiguous(),
++            context_lens,
++            block_table,
++            schedule_metadata=decode_metadata.schedule_metadata,
++            max_model_len=materialized_width,
++            clean_logits=False,
++        )
++        return _select(logits)
++    except Exception:
++        return False
++
++
 +def _musa_try_fill_decode_topk_from_indexer_cache_native(
 +    q_quant: torch.Tensor,
 +    kv_cache: torch.Tensor,
@@ -269,12 +451,66 @@ index fe2b268cd..eadc6f533 100644
 +    topk_indices_buffer: torch.Tensor,
 +    topk_tokens: int,
 +    head_dim: int,
++    max_model_len: int,
++    allow_materialized: bool = True,
 +) -> bool:
++    if allow_materialized and _musa_try_fill_decode_topk_from_materialized_logits(
++        q_quant,
++        kv_cache,
++        weights,
++        decode_metadata,
++        topk_indices_buffer,
++        topk_tokens,
++        head_dim,
++        max_model_len,
++    ):
++        return True
++
++    if (
++        _musa_sparse_indexer_glm52_fused_enabled()
++        and head_dim == 128
++        and q_quant.ndim == 3
++        and q_quant.shape[1] == 32
++        and topk_tokens <= 2048
++        and q_quant.dtype == torch.float8_e4m3fn
++        and kv_cache.dtype == torch.uint8
++        and weights.dtype == torch.float32
++        and decode_metadata.block_table.shape[1] * kv_cache.shape[1] <= 8192
++    ):
++        seq_lens = decode_metadata.seq_lens.reshape(-1)
++        rows = min(
++            q_quant.shape[0],
++            seq_lens.numel(),
++            topk_indices_buffer.shape[0],
++        )
++        topk = min(int(topk_tokens), topk_indices_buffer.shape[1])
++        if rows <= 0 or topk <= 0:
++            return True
++        block_table = _musa_decode_block_table_for_token_rows(
++            decode_metadata.block_table,
++            rows,
++        )
++        if block_table is None:
++            return False
++        _musa_custom_ops.glm52_indexer_topk_decode(
++            q_quant[:rows],
++            kv_cache,
++            weights[:rows],
++            seq_lens[:rows],
++            block_table,
++            topk_indices_buffer[:rows, :topk],
++            topk,
++        )
++        return True
++
 +    if (
 +        not _musa_sparse_indexer_native_decode_enabled()
 +        or head_dim != 128
++        or q_quant.ndim != 3
++        or q_quant.shape[1] != 64
 +        or topk_tokens > 512
 +        or q_quant.dtype != torch.float8_e4m3fn
++        or kv_cache.dtype != torch.uint8
 +        or weights.dtype != torch.float32
 +        or decode_metadata.block_table.shape[1] * kv_cache.shape[1] > 4096
 +    ):
@@ -314,15 +550,29 @@ index fe2b268cd..eadc6f533 100644
 +    topk_tokens: int,
 +    head_dim: int,
 +) -> bool:
++    is_glm52 = (
++        q_quant.ndim == 3
++        and q_quant.shape[1] == 32
++        and topk_tokens <= 2048
++    )
++    is_deepseek_v4 = (
++        q_quant.ndim == 3
++        and q_quant.shape[1] == 64
++        and topk_tokens <= 512
++    )
++    implementation_enabled = (
++        is_glm52 and _musa_sparse_indexer_glm52_materialized_enabled()
++    ) or (
++        is_deepseek_v4 and _musa_sparse_indexer_materialized_prefill_enabled()
++    )
 +    if (
-+        not _musa_sparse_indexer_materialized_prefill_enabled()
++        not implementation_enabled
 +        or head_dim != 128
-+        or topk_tokens > 512
 +        or q_quant.dtype != torch.float8_e4m3fn
 +        or kv_cache.dtype != torch.uint8
 +        or weights.dtype != torch.float32
 +        or kv_cache.ndim != 3
-+        or int(chunk.total_seq_lens) > 4096
++        or (is_deepseek_v4 and int(chunk.total_seq_lens) > 4096)
 +        or int(chunk.num_reqs) != 1
 +    ):
 +        return False
@@ -375,6 +625,16 @@ index fe2b268cd..eadc6f533 100644
 +        logits = logits[:chunk_rows, :total_seq_lens]
 +        starts = row_starts[row_start:row_end]
 +        ends = row_ends[row_start:row_end]
++        if is_glm52:
++            _musa_custom_ops.sparse_indexer_topk(
++                logits,
++                starts,
++                ends,
++                topk_indices[row_start:row_end, :topk],
++                topk,
++            )
++            return True
++
 +        valid_positions = (
 +            (positions.unsqueeze(0) >= starts.unsqueeze(1))
 +            & (positions.unsqueeze(0) < ends.unsqueeze(1))
@@ -532,8 +792,58 @@ index fe2b268cd..eadc6f533 100644
 +    head_dim: int,
 +) -> bool:
 +    if (
++        q_quant.ndim == 3
++        and q_quant.shape[1] == 32
++        and _musa_try_fill_prefill_topk_from_materialized_logits(
++            q_quant,
++            kv_cache,
++            weights,
++            chunk,
++            topk_indices,
++            topk_tokens,
++            head_dim,
++        )
++    ):
++        return True
++
++    if (
++        _musa_sparse_indexer_glm52_fused_enabled()
++        and head_dim == 128
++        and q_quant.ndim == 3
++        and q_quant.shape[1] == 32
++        and topk_tokens <= 2048
++        and q_quant.dtype == torch.float8_e4m3fn
++        and kv_cache.dtype == torch.uint8
++        and weights.dtype == torch.float32
++        and int(chunk.total_seq_lens) <= 8192
++    ):
++        rows = min(
++            q_quant.shape[0],
++            chunk.cu_seqlen_ks.numel(),
++            topk_indices.shape[0],
++        )
++        topk = min(int(topk_tokens), topk_indices.shape[1])
++        if rows <= 0 or topk <= 0:
++            return True
++        _musa_custom_ops.glm52_indexer_topk_prefill(
++            q_quant[:rows],
++            kv_cache,
++            weights[:rows],
++            chunk.block_table,
++            chunk.cu_seq_lens,
++            chunk.token_to_seq,
++            chunk.cu_seqlen_ks[:rows],
++            chunk.cu_seqlen_ke[:rows],
++            topk_indices[:rows, :topk],
++            topk,
++        )
++        return True
++
++    if (
 +        not _musa_sparse_indexer_native_decode_enabled()
 +        or head_dim != 128
++        or q_quant.ndim != 3
++        or q_quant.shape[1] != 64
 +        or topk_tokens > 512
 +        or q_quant.dtype != torch.float8_e4m3fn
 +        or kv_cache.dtype != torch.uint8
@@ -839,6 +1149,7 @@ index fe2b268cd..eadc6f533 100644
 +    weights: torch.Tensor,
 +    topk_tokens: int,
 +    head_dim: int,
++    max_model_len: int,
 +    topk_indices_buffer: torch.Tensor,
 +    use_fp4_cache: bool,
 +) -> torch.Tensor:
@@ -871,6 +1182,7 @@ index fe2b268cd..eadc6f533 100644
 +            topk_indices_buffer[: metadata.num_decode_tokens, :topk_tokens],
 +            topk_tokens,
 +            head_dim,
++            max_model_len,
 +        ):
 +            q_deq = q_quant.to(torch.float32)
 +            weights_fp32 = weights.to(torch.float32)
@@ -903,11 +1215,26 @@ index fe2b268cd..eadc6f533 100644
 +    weights: torch.Tensor,
 +    topk_tokens: int,
 +    head_dim: int,
++    max_model_len: int,
 +    topk_indices_buffer: torch.Tensor,
 +    use_fp4_cache: bool,
 +) -> torch.Tensor:
++    if _musa_try_fill_all_sparse_indexer_indices(
++        hidden_states,
++        k_cache_prefix,
++        topk_tokens,
++        topk_indices_buffer,
++    ):
++        return topk_indices_buffer
++
 +    if _musa_sparse_indexer_is_current_stream_capturing():
-+        if _musa_sparse_indexer_graph_exact_decode_enabled():
++        is_glm52_graph_path = (
++            not isinstance(q_quant, tuple)
++            and q_quant.ndim == 3
++            and q_quant.shape[1] == 32
++            and _musa_sparse_indexer_glm52_materialized_enabled()
++        )
++        if is_glm52_graph_path or _musa_sparse_indexer_graph_exact_decode_enabled():
 +            return _musa_fill_exact_sparse_indexer_indices_capture(
 +                hidden_states,
 +                k_cache_prefix,
@@ -916,6 +1243,7 @@ index fe2b268cd..eadc6f533 100644
 +                weights,
 +                topk_tokens,
 +                head_dim,
++                max_model_len,
 +                topk_indices_buffer,
 +                use_fp4_cache,
 +            )
@@ -987,6 +1315,7 @@ index fe2b268cd..eadc6f533 100644
 +            topk_indices_buffer[: metadata.num_decode_tokens, :topk_tokens],
 +            topk_tokens,
 +            head_dim,
++            max_model_len,
 +        ):
 +            if q_deq is None:
 +                q_deq = q_quant.to(torch.float32)
@@ -1007,7 +1336,7 @@ index fe2b268cd..eadc6f533 100644
  RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
  
  # MXFP4 layout: 2 values packed per byte, ue8m0 (1-byte) scale per block of 32.
-@@ -482,6 +1461,40 @@ class SparseAttnIndexer(CustomOp):
+@@ -482,6 +1790,46 @@ class SparseAttnIndexer(CustomOp):
              return self.forward_cuda(hidden_states, q_quant, k, weights)
          elif current_platform.is_rocm():
              return self.forward_hip(hidden_states, q_quant, k, weights)
@@ -1016,6 +1345,11 @@ index fe2b268cd..eadc6f533 100644
 +            and (
 +                os.getenv(
 +                    "VLLM_MUSA_ENABLE_DEEPSEEK_V4_SPARSE_INDEXER_MUSA_IMPL",
++                    "1",
++                )
++                == "1"
++                or os.getenv(
++                    "VLLM_MUSA_ENABLE_GLM52_SPARSE_INDEXER_MUSA_IMPL",
 +                    "1",
 +                )
 +                == "1"
@@ -1035,6 +1369,7 @@ index fe2b268cd..eadc6f533 100644
 +                    weights,
 +                    self.topk_tokens,
 +                    self.head_dim,
++                    self.max_model_len,
 +                    self.topk_indices_buffer,
 +                    self.use_fp4_cache,
 +                )

--- a/vllm_musa/patches/series/0086-MUSA-vllm.v1.attention.backends.mla.indexer.patch
+++ b/vllm_musa/patches/series/0086-MUSA-vllm.v1.attention.backends.mla.indexer.patch
@@ -1,0 +1,53 @@
+diff --git a/vllm/v1/attention/backends/mla/indexer.py b/vllm/v1/attention/backends/mla/indexer.py
+--- a/vllm/v1/attention/backends/mla/indexer.py
++++ b/vllm/v1/attention/backends/mla/indexer.py
+@@ -194,7 +194,7 @@ class DeepSeekV32IndexerDecodeMetadata:
+     seq_lens: torch.Tensor
+     decode_lens: torch.Tensor
+     requires_padding: bool
+-    schedule_metadata: torch.Tensor
++    schedule_metadata: torch.Tensor | None
+
+
+ @dataclass
+@@ -612,18 +612,37 @@ class DeepSeekV32IndexerMetadataBuilder(
+             if seq_lens.dim() == 1:
+                 seq_lens = seq_lens.unsqueeze(-1)
+
+-            # DeepGEMM is required for the paged MQA logits on CUDA devices
+-            if current_platform.is_cuda() and has_deep_gemm():
++            schedule_metadata = None
++            if current_platform.is_musa():
++                try:
++                    from mate import deep_gemm as _musa_deep_gemm
++
++                    self.scheduler_metadata_buffer[:] = (
++                        _musa_deep_gemm.get_paged_mqa_logits_metadata(
++                            seq_lens,
++                            self.kv_cache_spec.storage_block_size,
++                            self.num_sms,
++                        )
++                    )
++                    schedule_metadata = self.scheduler_metadata_buffer
++                except Exception:
++                    logger.warning_once(
++                        "MUSA sparse indexer could not prepare paged MQA "
++                        "schedule metadata; exact materialized decode will "
++                        "fall back to the Torch path."
++                    )
++            elif current_platform.is_cuda() and has_deep_gemm():
+                 self.scheduler_metadata_buffer[:] = get_paged_mqa_logits_metadata(
+                     seq_lens,
+                     self.kv_cache_spec.storage_block_size,
+                     self.num_sms,
+                 )
++                schedule_metadata = self.scheduler_metadata_buffer
+
+             decode_metadata = DeepSeekV32IndexerDecodeMetadata(
+                 block_table=block_table,
+                 seq_lens=seq_lens,
+                 decode_lens=decode_lens,
+                 requires_padding=requires_padding,
+-                schedule_metadata=self.scheduler_metadata_buffer,
++                schedule_metadata=schedule_metadata,
+             )

--- a/vllm_musa/v1/attention/ops/sparse_mla_tilelang.py
+++ b/vllm_musa/v1/attention/ops/sparse_mla_tilelang.py
@@ -1,6 +1,7 @@
-# MUSA sparse-MLA attention using a MUSA-tuned TileLang kernel.
-# Kernel = musa_sparse_attention_fwd_kernel_v1; annotate_layout per GEMM fixes
-# the KV_shared layout conflict on MUSA TileLang.
+# MUSA sparse-MLA attention via SGLang's MUSA-tuned TileLang kernel.
+# Kernel = musa_sparse_attention_fwd_kernel_v1, verbatim from
+# sglang/srt/layers/attention/nsa/tilelang_kernel.py:402-614 (annotate_layout
+# per-GEMM fixes the KV_shared layout conflict on MUSA tilelang).
 
 import tilelang
 import tilelang.language as T
@@ -36,7 +37,6 @@ tilelang.disable_cache()
 def musa_sparse_attention_fwd_kernel_v1(
     num_heads, dim, tail_dim, topk, *, kv_group=1, sm_scale=None,
     is_causal=True, block_I=64, num_stages=0, threads=512,
-    use_topk_length=False,
 ):
     assert dim == tilelang.math.next_power_of_2(dim), f"dim={dim}"
     assert tail_dim == tilelang.math.next_power_of_2(tail_dim), f"tail_dim={tail_dim}"
@@ -55,7 +55,6 @@ def musa_sparse_attention_fwd_kernel_v1(
     kv_shape = [batch, seq_len_kv, kv_group, dim + tail_dim]
     o_shape = [batch, seq_len, num_heads, dim]
     indices_shape = [batch, seq_len, kv_group, topk]
-    topk_length_shape = [batch, seq_len, kv_group]
     dtype = "bfloat16"
     accum_dtype = "float"
 
@@ -79,7 +78,6 @@ def musa_sparse_attention_fwd_kernel_v1(
         Q: T.Tensor(q_shape, dtype),
         KV: T.Tensor(kv_shape, dtype),
         Indices: T.Tensor(indices_shape, "int32"),
-        TopkLength: T.Tensor(topk_length_shape, "int32"),
         Output: T.Tensor(o_shape, dtype),
     ):
         with T.Kernel(seq_len * REPLICATE_H, batch, kv_group, threads=threads) as (bx, by, bz):
@@ -114,10 +112,6 @@ def musa_sparse_attention_fwd_kernel_v1(
                 for bi_i in T.Parallel(BI):
                     index = Indices[b_i, s_i, g_i, i_i * BI + bi_i]
                     valid = (index >= 0) & (index < seq_len_kv)
-                    if use_topk_length:
-                        valid = valid & (
-                            i_i * BI + bi_i < TopkLength[b_i, s_i, g_i]
-                        )
                     mask[bi_i] = valid
                     kv_indices[bi_i] = T.if_then_else(valid, index, 0)
 
@@ -166,32 +160,23 @@ def musa_sparse_attention_fwd_kernel_v1(
     return main
 
 
-def sparse_mla_fwd_bf16(q, kv, indices, sm_scale, d_v=512, topk_length=None):
+def sparse_mla_fwd_bf16(
+    q, kv, indices, sm_scale, d_v=512, topk_length=None
+):
+    # The v0.24 sparse-MLA wrapper always forwards ``topk_length``.  This
+    # kernel masks padded entries directly from negative indices, so the
+    # explicit lengths are not needed, but the argument remains part of the
+    # backend contract.
+    del topk_length
     num_heads = q.shape[1]
     dim = q.shape[2]
     tail_dim = dim - d_v
     topk = indices.shape[-1]
     assert topk == 2048, f"kernel requires topk==2048, got {topk}"
-    use_topk_length = topk_length is not None
-    if topk_length is not None:
-        topk_length = topk_length.reshape(indices.shape[:-1]).contiguous()
-    else:
-        topk_length = indices.new_empty(indices.shape[:-1])
     kernel = musa_sparse_attention_fwd_kernel_v1(
-        num_heads,
-        d_v,
-        tail_dim,
-        topk,
-        sm_scale=sm_scale,
-        num_stages=0,
-        use_topk_length=use_topk_length,
+        num_heads, d_v, tail_dim, topk, sm_scale=sm_scale, num_stages=0
     )
-    out = kernel(
-        q.unsqueeze(0),
-        kv.unsqueeze(0),
-        indices.unsqueeze(0),
-        topk_length.unsqueeze(0),
-    )
+    out = kernel(q.unsqueeze(0), kv.unsqueeze(0), indices.unsqueeze(0))
     return out.squeeze(0)
 
 


### PR DESCRIPTION
## Summary

GLM-5.2 uses 32 index heads with `index_topk=2048`. The existing MUSA path is
optimized for DeepSeek-V4 (`topk<=512`, 64 heads), so GLM-5.2 falls back to
the PyTorch indexer/top-k implementation.

This PR adds a dedicated MUSA path for GLM-5.2 and restores the optimized
sparse-MLA attention path required to keep decode performance on the latest
`v0.24.0-dev` branch.

## Changes

- Add native MUSA indexer top-k kernels for 32 heads and `topk<=2048`.
- Add a fast fill-all path when `seq_len<=topk`.
- Add materialized radix-selection decode and prefill paths.
- Reuse precomputed paged-MQA metadata for graph-compatible execution.
- Integrate the optimized sparse-MLA attention implementation.
- Preserve the existing DeepSeek-V4 64-head, `topk<=512` path.
- Add source tests for registration, dispatch guards, graph metadata, and
  DeepSeek-V4 path isolation.

## Performance

Configuration: GLM-5.2-FP8, two S5000 nodes, TP8+PP2+EP, eager mode,
1024 input tokens, 1024 output tokens, 8 prompts, concurrency 4.

### Comparison

| Metric | Baseline | Optimized | Improvement |
|---|---:|---:|---:|
| Output TPS | 12.85 tok/s | 15.61 tok/s | **+21.48%** |
| Total TPS | 25.85 tok/s | 31.39 tok/s | **+21.43%** |
| Mean TTFT | 45895.69 ms | 24140.54 ms | **-47.40%** |
| Mean TPOT | 266.71 ms | 232.92 ms | **-12.67%** |
| Duration | 637.60 s | 524.95 s | **-17.67%** |

## Reproduction

### Start the Service

```bash
export HEAD_HOST=<head-node-ip>
export WORKER_HOST=<worker-node-ip>
export HEAD_CONTAINER=glm52-head
export WORKER_CONTAINER=glm52-worker
export MODEL=/home/dist/models/zai-org/GLM-5.2-FP8
export MASTER_PORT=29500
```

Head node:

```bash
vllm serve "$MODEL" \
  --enable-expert-parallel \
  --tensor-parallel-size 8 --pipeline-parallel-size 2 \
  --nnodes 2 --master-addr "$HEAD_HOST" --master-port "$MASTER_PORT" \
  --trust-remote-code --served-model-name glm52 \
  --max-model-len 16384 \
  --tool-call-parser glm47 --enable-auto-tool-choice \
  --reasoning-parser glm45 --enforce-eager \
  --node-rank 0 --host 127.0.0.1 --port 8012 \
  > "$OUT/serve_head.log" 2>&1
```

Worker node:

```bash
vllm serve "$MODEL" \
  --enable-expert-parallel \
  --tensor-parallel-size 8 --pipeline-parallel-size 2 \
  --nnodes 2 --master-addr "$HEAD_HOST" --master-port "$MASTER_PORT" \
  --trust-remote-code --served-model-name glm52 \
  --max-model-len 16384 \
  --tool-call-parser glm47 --enable-auto-tool-choice \
  --reasoning-parser glm45 --enforce-eager \
  --node-rank 1 --headless \
  > "$OUT/serve_worker.log" 2>&1
```

### Correctness and Warmup

```bash
docker exec "$HEAD_CONTAINER" curl -sS \
  http://127.0.0.1:8012/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model":"glm52",
    "messages":[{"role":"user","content":"What is 6 multiplied by 7? Answer with only the number."}],
    "temperature":0,
    "max_tokens":32,
    "chat_template_kwargs":{"enable_thinking":false}
  }'
```

Expected content: `42`.

### Benchmark

```bash
vllm bench serve \
  --backend openai-chat --host 127.0.0.1 --port 8012 \
  --endpoint /v1/chat/completions --model glm52 \
  --tokenizer "$MODEL" --dataset-name random \
  --random-input-len 1024 --random-output-len 1024 \
  --num-prompts 8 --max-concurrency 4 --ignore-eos \
  --save-result \
  --result-filename "$OUT/bench_1024x1024_np8_mc4.json"
```
