### PR TITLE
Optimize MUSA custom allreduce RMSNorm fusion

### DIFF
--- a/tests/test_fused_ar_registered_graph_source.py
+++ b/tests/test_fused_ar_registered_graph_source.py
@@ -23,10 +23,199 @@ FUSED_OPS = ROOT / "vllm_musa/fused_allreduce_rmsnorm_ops.py"
 FUSION_PASS = ROOT / "vllm_musa/_inductor/musa_allreduce_rms_fusion.py"
 
 
+def _python_function_source(
+    source: str, function_name: str, class_name: str | None = None
+) -> str:
+    tree = ast.parse(source)
+    scope: ast.AST = tree
+    if class_name is not None:
+        classes = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ClassDef) and node.name == class_name
+        ]
+        assert len(classes) == 1
+        scope = classes[0]
+    functions = [
+        node
+        for node in ast.walk(scope)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == function_name
+    ]
+    assert len(functions) == 1
+    function = functions[0]
+    assert function.end_lineno is not None
+    return "\n".join(source.splitlines()[function.lineno - 1 : function.end_lineno])
+
+
+def _isolated_fusion_helpers(torch_namespace: object, fx_namespace: object) -> type:
+    """Load the actual fail-closed helpers without importing vLLM or MUSA."""
+    tree = ast.parse(FUSION_PASS.read_text())
+    fusion_classes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "MusaAllReduceRMSNormFusionPass"
+    ]
+    assert len(fusion_classes) == 1
+    fusion_class = fusion_classes[0]
+    helper_names = {
+        "_is_add_node",
+        "_node_tensor_meta",
+        "_manual_residual_inputs_supported",
+    }
+    methods = [
+        node
+        for node in fusion_class.body
+        if isinstance(node, ast.FunctionDef) and node.name in helper_names
+    ]
+    assert {method.name for method in methods} == helper_names
+    for method in methods:
+        method.returns = None
+        arguments = (
+            method.args.posonlyargs + method.args.args + method.args.kwonlyargs
+        )
+        for argument in arguments:
+            argument.annotation = None
+        if method.args.vararg is not None:
+            method.args.vararg.annotation = None
+        if method.args.kwarg is not None:
+            method.args.kwarg.annotation = None
+
+    helper_class = ast.ClassDef(
+        name="_IsolatedFusionHelpers",
+        bases=[],
+        keywords=[],
+        body=methods,
+        decorator_list=[],
+    )
+    ast.copy_location(helper_class, fusion_class)
+    helper_class.end_lineno = fusion_class.end_lineno
+    helper_class.end_col_offset = fusion_class.end_col_offset
+    module = ast.fix_missing_locations(ast.Module(body=[helper_class], type_ignores=[]))
+    namespace = {"torch": torch_namespace, "fx": fx_namespace}
+    exec(compile(module, str(FUSION_PASS), "exec"), namespace)
+    return namespace["_IsolatedFusionHelpers"]
+
+
+class _FakeDevice:
+    def __init__(self, device_type: str, index: int = 0) -> None:
+        self.type = device_type
+        self.index = index
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, _FakeDevice)
+            and self.type == other.type
+            and self.index == other.index
+        )
+
+
+class _FakeTensor:
+    def __init__(
+        self,
+        shape: tuple[int, ...],
+        dtype: object,
+        device: _FakeDevice,
+        contiguous: bool = True,
+    ) -> None:
+        self.shape = shape
+        self.dtype = dtype
+        self.device = device
+        self._contiguous = contiguous
+
+    def dim(self) -> int:
+        return len(self.shape)
+
+    def numel(self) -> int:
+        result = 1
+        for size in self.shape:
+            result *= size
+        return result
+
+    def is_contiguous(self) -> bool:
+        return self._contiguous
+
+
+_MISSING = object()
+
+
+class _FakeNode:
+    def __init__(
+        self,
+        *,
+        op: str = "call_function",
+        target: object | None = None,
+        args: tuple[object, ...] = (),
+        kwargs: dict[str, object] | None = None,
+        value: object = _MISSING,
+    ) -> None:
+        self.op = op
+        self.target = target
+        self.args = args
+        self.kwargs = {} if kwargs is None else kwargs
+        self.meta = {} if value is _MISSING else {"val": value}
+
+
+def _fake_fusion_namespaces() -> tuple[object, object, object, object, object]:
+    tensor_overload = object()
+    scalar_overload = object()
+    add_packet = type(
+        "_FakeAddPacket",
+        (),
+        {"Tensor": tensor_overload, "Scalar": scalar_overload},
+    )
+    torch_namespace = type(
+        "_FakeTorch",
+        (),
+        {
+            "Tensor": _FakeTensor,
+            "float16": "float16",
+            "bfloat16": "bfloat16",
+            "float32": "float32",
+            "ops": type(
+                "_FakeOps",
+                (),
+                {"aten": type("_FakeAten", (), {"add": add_packet})},
+            ),
+        },
+    )
+    fx_namespace = type("_FakeFx", (), {"Node": _FakeNode})
+    return (
+        torch_namespace,
+        fx_namespace,
+        tensor_overload,
+        scalar_overload,
+        torch_namespace.bfloat16,
+    )
+
+
 def _ffi_function_source(source: str, function_name: str) -> str:
     start = source.index(f"void {function_name}(")
-    next_start = source.find("\nvoid vllm_musa_", start + 1)
-    return source[start:] if next_start == -1 else source[start:next_start]
+    opening_brace = source.index("{", start)
+    depth = 0
+    for index in range(opening_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated C++ function: {function_name}")
+
+
+def _cpp_braced_block(source: str, marker: str, start: int = 0) -> tuple[str, int]:
+    marker_start = source.index(marker, start)
+    opening_brace = source.index("{", marker_start)
+    depth = 0
+    for index in range(opening_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[marker_start : index + 1], index + 1
+    raise AssertionError(f"unterminated C++ block after: {marker}")
 
 
 def test_fused_path_gates_can_be_disabled_independently() -> None:
@@ -56,43 +245,136 @@ def test_fusion_uses_one_canonical_feature_gate() -> None:
     assert canonical in fusion_source
 
 
-def test_python_registered_path_is_syntax_valid_and_dependency_free() -> None:
+def test_python_registered_path_uses_shared_graph_lifecycle() -> None:
     comm_source = COMM.read_text()
     launcher_source = LAUNCHER.read_text()
-    ast.parse(comm_source)
+    comm_tree = ast.parse(comm_source)
     ast.parse(launcher_source)
-    assert "_register_graph_buffers()" in comm_source
-    assert "capture_succeeded" in comm_source
-    assert "def _graph_rank_data_for_input" in comm_source
-    assert "_pending_graph_inputs" in comm_source
+    comm_class = "_MusaJitCustomAllreduceImpl"
+
+    # Registration belongs to the communicator's existing capture lifecycle;
+    # a second object would duplicate buffers and slot accounting.
     assert "_GraphInputRegistration" not in comm_source
-    assert "torch.get_device_module().is_current_stream_capturing()" in comm_source
-    assert "torch.musa.synchronize(self.device)" in comm_source
-    assert "_graph_registered_input_eligible" in comm_source
-    assert comm_source.count("_use_registered_graph_input(input)") == 3
-    # Ordinary CAR and the three fused variants share the same graph slots.
-    assert comm_source.count("_graph_rank_data_for_input(input)") == 4
-    assert launcher_source.count("_check_registered_rank_data(rank_data)") == 3
+    assert not any(
+        isinstance(node, ast.ClassDef) and node.name == "_GraphInputRegistration"
+        for node in ast.walk(comm_tree)
+    )
+    assert "self.graph_rank_data: torch.Tensor | None = None" in comm_source
+    assert "self._pending_graph_inputs: list[torch.Tensor] = []" in comm_source
+
+    capture_source = _python_function_source(comm_source, "capture", comm_class)
+    first_reset = capture_source.index("self._pending_graph_inputs = []")
+    registration = capture_source.index("self._register_graph_buffers()")
+    final_reset = capture_source.rindex("self._pending_graph_inputs = []")
+    assert first_reset < capture_source.index("yield") < registration < final_reset
+    assert "if capture_succeeded and self._pending_graph_inputs:" in capture_source
+
+    registration_source = _python_function_source(
+        comm_source, "_register_graph_buffers", comm_class
+    )
+    for expected in (
+        "count = len(self._pending_graph_inputs)",
+        "dist.broadcast_object_list(",
+        "self.graph_rank_data[start:end].copy_(rank_data_cpu.to(self.device))",
+        "torch.musa.synchronize(self.device)",
+        "self._graph_input_refs.extend(self._pending_graph_inputs)",
+        "self._pending_graph_inputs = []",
+        "self._next_graph_slot = end",
+    ):
+        assert expected in registration_source
+
+    slot_source = _python_function_source(
+        comm_source, "_graph_rank_data_for_input", comm_class
+    )
+    assert "slot = self._next_graph_slot + len(self._pending_graph_inputs)" in slot_source
+    assert "self._pending_graph_inputs.append(tensor)" in slot_source
+    assert "return self.graph_rank_data[slot]" in slot_source
+
+    eligibility_source = _python_function_source(
+        comm_source, "_use_registered_graph_input", comm_class
+    )
+    assert "self._graph_registered_input_eligible(tensor)" in eligibility_source
+    assert "self._IS_CAPTURING" in eligibility_source
+    assert "self._is_current_stream_capturing()" in eligibility_source
+
+    graph_ar_source = _python_function_source(
+        comm_source, "_graph_custom_all_reduce_impl", comm_class
+    )
+    assert graph_ar_source.count("self._graph_rank_data_for_input(input)") == 1
+    assert "jit_ar.launch_graph_registered(" in graph_ar_source
+
+    fused_impls = {
+        "_fused_allreduce_rmsnorm_impl": (
+            "launch_fused_allreduce_rmsnorm_registered",
+            "launch_fused_allreduce_rmsnorm_unregistered",
+        ),
+        "_fused_allreduce_residual_rmsnorm_impl": (
+            "launch_fused_allreduce_residual_rmsnorm_registered",
+            "launch_fused_allreduce_residual_rmsnorm_unregistered",
+        ),
+        "_fused_allreduce_residual_rmsnorm_no_raw_impl": (
+            "launch_fused_allreduce_residual_rmsnorm_no_raw_registered",
+            "launch_fused_allreduce_residual_rmsnorm_no_raw_unregistered",
+        ),
+    }
+    for function_name, launchers in fused_impls.items():
+        function_source = _python_function_source(
+            comm_source, function_name, comm_class
+        )
+        assert function_source.count("self._use_registered_graph_input(input)") == 1
+        assert function_source.count("self._graph_rank_data_for_input(input)") == 1
+        for launcher in launchers:
+            assert f"jit_ar.{launcher}" in function_source
+
+    registered_launchers = {
+        "launch_fused_allreduce_rmsnorm_registered": (
+            "launch_fused_allreduce_rmsnorm_unregistered"
+        ),
+        "launch_fused_allreduce_residual_rmsnorm_registered": (
+            "launch_fused_allreduce_residual_rmsnorm_unregistered"
+        ),
+        "launch_fused_allreduce_residual_rmsnorm_no_raw_registered": (
+            "launch_fused_allreduce_residual_rmsnorm_no_raw_unregistered"
+        ),
+    }
+    for function_name, staging_launcher in registered_launchers.items():
+        function_source = _python_function_source(launcher_source, function_name)
+        assert "_check_registered_rank_data(rank_data)" in function_source
+        assert f"{staging_launcher}(" in function_source
 
 
 def test_fused_kernel_copy_is_cpu_rank_data_only() -> None:
     source = KERNEL.read_text()
-    for function_name in (
+    fused_apis = (
         "vllm_musa_fused_ar_rmsnorm_launch_unregistered",
         "vllm_musa_fused_ar_residual_rmsnorm_launch_unregistered",
         "vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered",
-    ):
+    )
+    for function_name in fused_apis:
         function_source = _ffi_function_source(source, function_name)
         assert "const bool rank_data_on_cpu" in function_source
-        assert "const bool rank_data_on_musa" in function_source
         assert (
             "rank_data.device().device_type == inp.device().device_type"
             in function_source
         )
         assert "const RankData* device_data = nullptr;" in function_source
-        assert "if (rank_data_on_cpu) {\n    const musaError_t copy_err" in (
-            function_source
+
+        rank_data_block, first_block_end = _cpp_braced_block(
+            function_source, "if (rank_data_on_cpu)"
         )
+        second_guard = function_source.index(
+            "if (rank_data_on_cpu)", first_block_end
+        )
+        copy_block, _ = _cpp_braced_block(
+            function_source, "if (rank_data_on_cpu)", first_block_end
+        )
+        device_branch = function_source[first_block_end:second_guard]
+        assert "musaMemcpyAsync(" not in rank_data_block
+        assert "device_data = reinterpret_cast<const RankData*>" in device_branch
+        assert copy_block.count("musaMemcpyAsync(") == 1
+        assert "self_buffer_ptr" in copy_block
+        assert "inp.data_ptr()" in copy_block
+        assert "data, device_data, sg" in function_source
         assert function_source.count("musaMemcpyAsync(") == 1
 
 
@@ -128,6 +410,100 @@ def test_manual_rewrite_is_scoped_to_comm_and_full_variance() -> None:
     assert "self._car_comm_id(node) == self.jit_comm_id" in source
     assert "if not self._is_target_musa_car_node(car):" in source
     assert source.count("variance_size is not None") == 3
+    rewrite_source = _python_function_source(
+        source,
+        "_manual_rewrite_residual_musa_jit_car_rmsnorm",
+        "MusaAllReduceRMSNormFusionPass",
+    )
+    assert rewrite_source.count("self._manual_residual_inputs_supported(") == 2
+
+
+def test_manual_add_rewrite_accepts_only_tensor_overload_with_unit_alpha() -> None:
+    (
+        torch_namespace,
+        fx_namespace,
+        tensor_overload,
+        scalar_overload,
+        _,
+    ) = _fake_fusion_namespaces()
+    helpers = _isolated_fusion_helpers(torch_namespace, fx_namespace)
+    lhs = _FakeNode(op="placeholder")
+    rhs = _FakeNode(op="placeholder")
+
+    assert helpers._is_add_node(
+        _FakeNode(target=tensor_overload, args=(lhs, rhs))
+    )
+    assert helpers._is_add_node(
+        _FakeNode(target=tensor_overload, args=(lhs, rhs), kwargs={"alpha": 1.0})
+    )
+    assert not helpers._is_add_node(
+        _FakeNode(target=tensor_overload, args=(lhs, rhs), kwargs={"alpha": 2})
+    )
+    assert not helpers._is_add_node(
+        _FakeNode(target=scalar_overload, args=(lhs, 1))
+    )
+    assert not helpers._is_add_node(
+        _FakeNode(target=tensor_overload, args=(lhs, rhs, 1))
+    )
+    assert not helpers._is_add_node(
+        _FakeNode(
+            target=tensor_overload,
+            args=(lhs, rhs),
+            kwargs={"alpha": 1, "out": _FakeNode(op="placeholder")},
+        )
+    )
+
+
+def test_manual_residual_metadata_gate_is_positive_and_fail_closed() -> None:
+    (
+        torch_namespace,
+        fx_namespace,
+        _,
+        _,
+        input_dtype,
+    ) = _fake_fusion_namespaces()
+    helpers = _isolated_fusion_helpers(torch_namespace, fx_namespace)()
+    helpers.hidden_dim = 16
+    device = _FakeDevice("musa", 0)
+
+    def tensor_node(
+        shape: tuple[int, ...],
+        dtype: object = input_dtype,
+        tensor_device: _FakeDevice = device,
+        contiguous: bool = True,
+    ) -> _FakeNode:
+        return _FakeNode(
+            op="placeholder",
+            value=_FakeTensor(shape, dtype, tensor_device, contiguous),
+        )
+
+    input_node = tensor_node((4, 16))
+    car = _FakeNode(args=(input_node,), value=_FakeTensor((4, 16), input_dtype, device))
+    residual = tensor_node((4, 16))
+    weight = tensor_node((16,), torch_namespace.float32)
+
+    assert helpers._manual_residual_inputs_supported(car, residual, weight)
+    assert not helpers._manual_residual_inputs_supported(car, 1, weight)
+    assert not helpers._manual_residual_inputs_supported(
+        car, _FakeNode(op="placeholder", value=1), weight
+    )
+    assert not helpers._manual_residual_inputs_supported(
+        car, tensor_node((2, 16)), weight
+    )
+    assert not helpers._manual_residual_inputs_supported(
+        car, tensor_node((4, 16), "float32"), weight
+    )
+    assert not helpers._manual_residual_inputs_supported(
+        car, tensor_node((4, 16), tensor_device=_FakeDevice("musa", 1)), weight
+    )
+    assert not helpers._manual_residual_inputs_supported(
+        car, tensor_node((4, 16), contiguous=False), weight
+    )
+    assert not helpers._manual_residual_inputs_supported(
+        car, residual, tensor_node((8,), torch_namespace.float32)
+    )
+    helpers.hidden_dim = 8
+    assert not helpers._manual_residual_inputs_supported(car, residual, weight)
 
 
 def test_fusion_runtime_state_participates_in_cache_uuid() -> None:
@@ -147,10 +523,35 @@ def test_fused_kernel_validates_world_size_before_fixed_registry_arrays() -> Non
         "vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered",
     ):
         function_source = _ffi_function_source(source, function_name)
-        assert function_source.count("validate_world_size(world_size);") == 1
-        assert function_source.index("validate_world_size(world_size);") < (
-            function_source.index("RankSignals sg{};")
-        )
+        validate = function_source.index("validate_world_size(world_size);")
+        rank_signals = function_source.index("RankSignals sg{};")
+        assert validate < rank_signals, function_name
+
+
+def test_base_all_gather_and_indirect_graph_abis_are_retained() -> None:
+    kernel_source = KERNEL.read_text()
+    launcher_source = LAUNCHER.read_text()
+    all_gather = _ffi_function_source(
+        kernel_source, "vllm_musa_custom_ar_launch_all_gather"
+    )
+    graph_registered = _ffi_function_source(
+        kernel_source, "vllm_musa_custom_ar_launch_graph_registered"
+    )
+    assert "dispatch_all_gather_world_size" in all_gather
+    assert "dispatch_world_size_indirect" in graph_registered
+    assert (
+        ".vllm_musa_custom_ar_launch_all_gather("
+        in _python_function_source(launcher_source, "launch_all_gather")
+    )
+    assert (
+        ".vllm_musa_custom_ar_launch_graph_registered("
+        in _python_function_source(launcher_source, "launch_graph_registered")
+    )
+    for function_name in (
+        "vllm_musa_custom_ar_launch_all_gather",
+        "vllm_musa_custom_ar_launch_graph_registered",
+    ):
+        assert f"TVM_FFI_DLL_EXPORT_TYPED_FUNC({function_name}," in kernel_source
 
 
 def test_no_raw_one_shot_matches_raw_dtype_rounding_order() -> None:

--- a/tests/test_fused_ar_registered_graph_source.py
+++ b/tests/test_fused_ar_registered_graph_source.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import ast
+import os
+import runpy
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).parents[1]
@@ -20,17 +23,35 @@ FUSED_OPS = ROOT / "vllm_musa/fused_allreduce_rmsnorm_ops.py"
 FUSION_PASS = ROOT / "vllm_musa/_inductor/musa_allreduce_rms_fusion.py"
 
 
-def test_registered_graph_flag_is_opt_in() -> None:
+def test_fused_path_defaults_on_with_independent_fallback_gates() -> None:
     source = ENVIRON.read_text()
     assert (
-        "VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT = "
-        "EnvBool(False)"
-    ) in source
+        "VLLM_MUSA_FUSED_AR_RMSNORM = EnvBool(True)"
+        in source
+    )
     assert (
-        "VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT_MAX_BYTES "
-        "= EnvInt("
+        "VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT = "
+        "EnvBool(True)"
     ) in source
-    assert "512 * 1024" in source
+    assert "VLLM_MUSA_FUSED_AR_RMSNORM_DEBUG" not in source
+    assert "GRAPH_REGISTERED_INPUT_MAX_BYTES = EnvInt" not in source
+
+
+def test_fused_path_gates_can_be_disabled_independently() -> None:
+    namespace = runpy.run_path(str(ENVIRON))
+    envs = namespace["envs"]
+    fused = envs.VLLM_MUSA_FUSED_AR_RMSNORM
+    registered = envs.VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT
+
+    with patch.dict(os.environ, {}, clear=True):
+        assert fused.get() is True
+        assert registered.get() is True
+        with fused.override(False):
+            assert fused.get() is False
+            assert registered.get() is True
+        with registered.override(False):
+            assert fused.get() is True
+            assert registered.get() is False
 
 
 def test_fusion_uses_one_canonical_feature_gate() -> None:
@@ -45,12 +66,11 @@ def test_fusion_uses_one_canonical_feature_gate() -> None:
     assert "VLLM_MUSA_FUSED_ALLREDUCE_RMSNORM" not in fusion_source
 
 
-def test_python_registered_path_is_syntax_valid_and_sglang_independent() -> None:
+def test_python_registered_path_is_syntax_valid_and_dependency_free() -> None:
     comm_source = COMM.read_text()
     launcher_source = LAUNCHER.read_text()
     ast.parse(comm_source)
     ast.parse(launcher_source)
-    assert "sglang" not in comm_source.lower()
     assert "_register_graph_inputs()" in comm_source
     assert "capture_succeeded" in comm_source
     assert "torch.get_device_module().is_current_stream_capturing()" in comm_source
@@ -76,12 +96,10 @@ def test_fused_kernel_copy_is_cpu_rank_data_only() -> None:
     ) == 3
 
 
-def test_sglang_mr413_tp2_fast_paths_preserve_vllm_abis() -> None:
+def test_tp2_specialized_fast_paths_preserve_vllm_abis() -> None:
     source = KERNEL.read_text()
-    assert "fused_ar_rmsnorm_tp2_mr413_kernel" in source
-    assert source.count("launch_fused_ar_rmsnorm_tp2_mr413<T, WT,") == 3
-    assert "VLLM_MUSA_FUSED_AR_TP2_REGCACHE" in source
-    assert "VLLM_MUSA_FUSED_AR_TP2_VEC2RANK" in source
+    assert "fused_ar_rmsnorm_tp2_specialized_kernel" in source
+    assert source.count("launch_fused_ar_rmsnorm_tp2_specialized<T, WT,") == 3
     assert "hidden == 5120 && rows <= 128" in source
     assert "hidden == 2048 && rows <= 128" in source
     assert "load_weight_scalar<WT>" in source
@@ -149,21 +167,11 @@ def test_no_raw_one_shot_matches_raw_dtype_rounding_order() -> None:
     )
 
 
-def test_tp4_rows64_two_shot_defaults_to_cap32() -> None:
+def test_tp4_rows64_two_shot_uses_bounded_block_count() -> None:
     launcher_source = LAUNCHER.read_text()
     kernel_source = KERNEL.read_text()
-    assert (
-        '"VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP",\n'
-        '            "32",'
-    ) in launcher_source
-    assert "f\"_tp4bs64bc{tp4_bs64_2shot_block_cap}\"" in launcher_source
-    assert (
-        "-DVLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP="
-    ) in launcher_source
-    assert (
-        "#define VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP 32"
-        in kernel_source
-    )
+    assert "kTp4Rows64TwoShotBlockLimit = 32" in kernel_source
+    assert "tp4bs64bc" not in launcher_source
     assert "if constexpr (nranks == 4)" in kernel_source
     assert "if (rows == 64 && hidden == 2048)" in kernel_source
     assert (
@@ -172,3 +180,20 @@ def test_tp4_rows64_two_shot_defaults_to_cap32() -> None:
         )
         == 3
     )
+
+
+def test_registered_graph_input_has_a_fixed_staging_boundary() -> None:
+    comm_source = COMM.read_text()
+    assert "_GRAPH_REGISTERED_INPUT_MAX_BYTES = 512 * 1024" in comm_source
+    assert (
+        "tensor.numel() * tensor.element_size()\n"
+        "            <= self._GRAPH_REGISTERED_INPUT_MAX_BYTES"
+    ) in comm_source
+    assert "_graph_registered_input_enabled" in comm_source
+
+
+def test_launcher_has_no_external_kernel_tuning_controls() -> None:
+    source = LAUNCHER.read_text()
+    assert "import os" not in source
+    assert "os.environ" not in source
+    assert "return threads, blocks, 0, 1, max(120, blocks)" in source

--- a/tests/test_fused_ar_registered_graph_source.py
+++ b/tests/test_fused_ar_registered_graph_source.py
@@ -23,18 +23,10 @@ FUSED_OPS = ROOT / "vllm_musa/fused_allreduce_rmsnorm_ops.py"
 FUSION_PASS = ROOT / "vllm_musa/_inductor/musa_allreduce_rms_fusion.py"
 
 
-def test_fused_path_defaults_on_with_independent_fallback_gates() -> None:
-    source = ENVIRON.read_text()
-    assert (
-        "VLLM_MUSA_FUSED_AR_RMSNORM = EnvBool(True)"
-        in source
-    )
-    assert (
-        "VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT = "
-        "EnvBool(True)"
-    ) in source
-    assert "VLLM_MUSA_FUSED_AR_RMSNORM_DEBUG" not in source
-    assert "GRAPH_REGISTERED_INPUT_MAX_BYTES = EnvInt" not in source
+def _ffi_function_source(source: str, function_name: str) -> str:
+    start = source.index(f"void {function_name}(")
+    next_start = source.find("\nvoid vllm_musa_", start + 1)
+    return source[start:] if next_start == -1 else source[start:next_start]
 
 
 def test_fused_path_gates_can_be_disabled_independently() -> None:
@@ -62,8 +54,6 @@ def test_fusion_uses_one_canonical_feature_gate() -> None:
     assert canonical in env_source
     assert canonical in comm_source
     assert canonical in fusion_source
-    assert "VLLM_MUSA_FUSED_ALLREDUCE_RMSNORM" not in env_source
-    assert "VLLM_MUSA_FUSED_ALLREDUCE_RMSNORM" not in fusion_source
 
 
 def test_python_registered_path_is_syntax_valid_and_dependency_free() -> None:
@@ -71,29 +61,39 @@ def test_python_registered_path_is_syntax_valid_and_dependency_free() -> None:
     launcher_source = LAUNCHER.read_text()
     ast.parse(comm_source)
     ast.parse(launcher_source)
-    assert "_register_graph_inputs()" in comm_source
+    assert "_register_graph_buffers()" in comm_source
     assert "capture_succeeded" in comm_source
+    assert "def _graph_rank_data_for_input" in comm_source
+    assert "_pending_graph_inputs" in comm_source
+    assert "_GraphInputRegistration" not in comm_source
     assert "torch.get_device_module().is_current_stream_capturing()" in comm_source
-    assert "torch.get_device_module().synchronize()" in comm_source
-    assert "Refusing to keep a potentially incorrect Graph" in comm_source
+    assert "torch.musa.synchronize(self.device)" in comm_source
     assert "_graph_registered_input_eligible" in comm_source
     assert comm_source.count("_use_registered_graph_input(input)") == 3
-    assert comm_source.count("_graph_rank_data_for_input(input,") == 3
+    # Ordinary CAR and the three fused variants share the same graph slots.
+    assert comm_source.count("_graph_rank_data_for_input(input)") == 4
     assert launcher_source.count("_check_registered_rank_data(rank_data)") == 3
 
 
 def test_fused_kernel_copy_is_cpu_rank_data_only() -> None:
     source = KERNEL.read_text()
-    assert source.count("const RankData* device_data") >= 10
-    assert source.count("if (device_data != nullptr)") >= 5
-    # One unconditional copy remains for ordinary non-fused CAR. The three
-    # fused copies remain as the eager/default-Graph fallback, each guarded by
-    # CPU rank_data; device rank_data skips them.
-    assert source.count("musaMemcpyAsync(") == 4
-    assert source.count("if (rank_data_on_cpu) {") == 6
-    assert source.count(
-        "rank_data.device().device_type == inp.device().device_type"
-    ) == 3
+    for function_name in (
+        "vllm_musa_fused_ar_rmsnorm_launch_unregistered",
+        "vllm_musa_fused_ar_residual_rmsnorm_launch_unregistered",
+        "vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered",
+    ):
+        function_source = _ffi_function_source(source, function_name)
+        assert "const bool rank_data_on_cpu" in function_source
+        assert "const bool rank_data_on_musa" in function_source
+        assert (
+            "rank_data.device().device_type == inp.device().device_type"
+            in function_source
+        )
+        assert "const RankData* device_data = nullptr;" in function_source
+        assert "if (rank_data_on_cpu) {\n    const musaError_t copy_err" in (
+            function_source
+        )
+        assert function_source.count("musaMemcpyAsync(") == 1
 
 
 def test_tp2_specialized_fast_paths_preserve_vllm_abis() -> None:
@@ -119,10 +119,6 @@ def test_fused_ops_reuse_the_lifecycle_managed_jit_registry() -> None:
     ast.parse(fused_source)
     assert "def get_musa_jit_custom_allreduce_comm" in comm_source
     assert "get_musa_jit_custom_allreduce_comm" in fused_source
-    assert "_COMM_ID_BY_OBJECT" not in fused_source
-    assert "_NEXT_COMM_ID" not in fused_source
-    assert "register_musa_fused_ar_rmsnorm_comm" not in fused_source
-    assert "register_musa_fused_ar_rmsnorm_comm" not in fusion_source
     assert "self.comm_id = self.jit_comm_id" in fusion_source
 
 
@@ -143,16 +139,15 @@ def test_fusion_runtime_state_participates_in_cache_uuid() -> None:
     assert '"group_name": self.group_name' in source
 
 
-def test_kernel_validates_world_size_before_fixed_registry_arrays() -> None:
+def test_fused_kernel_validates_world_size_before_fixed_registry_arrays() -> None:
     source = KERNEL.read_text()
-    assert source.count("validate_world_size(world_size);") == 4
     for function_name in (
-        "vllm_musa_custom_ar_launch_unregistered",
         "vllm_musa_fused_ar_rmsnorm_launch_unregistered",
         "vllm_musa_fused_ar_residual_rmsnorm_launch_unregistered",
         "vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered",
     ):
-        function_source = source[source.index(f"void {function_name}") :]
+        function_source = _ffi_function_source(source, function_name)
+        assert function_source.count("validate_world_size(world_size);") == 1
         assert function_source.index("validate_world_size(world_size);") < (
             function_source.index("RankSignals sg{};")
         )
@@ -168,10 +163,8 @@ def test_no_raw_one_shot_matches_raw_dtype_rounding_order() -> None:
 
 
 def test_tp4_rows64_two_shot_uses_bounded_block_count() -> None:
-    launcher_source = LAUNCHER.read_text()
     kernel_source = KERNEL.read_text()
     assert "kTp4Rows64TwoShotBlockLimit = 32" in kernel_source
-    assert "tp4bs64bc" not in launcher_source
     assert "if constexpr (nranks == 4)" in kernel_source
     assert "if (rows == 64 && hidden == 2048)" in kernel_source
     assert (
@@ -189,11 +182,3 @@ def test_registered_graph_input_has_a_fixed_staging_boundary() -> None:
         "tensor.numel() * tensor.element_size()\n"
         "            <= self._GRAPH_REGISTERED_INPUT_MAX_BYTES"
     ) in comm_source
-    assert "_graph_registered_input_enabled" in comm_source
-
-
-def test_launcher_has_no_external_kernel_tuning_controls() -> None:
-    source = LAUNCHER.read_text()
-    assert "import os" not in source
-    assert "os.environ" not in source
-    assert "return threads, blocks, 0, 1, max(120, blocks)" in source

--- a/tests/test_fused_ar_registered_graph_source.py
+++ b/tests/test_fused_ar_registered_graph_source.py
@@ -21,6 +21,10 @@ KERNEL = ROOT / (
 ENVIRON = ROOT / "vllm_musa/utils/environ.py"
 FUSED_OPS = ROOT / "vllm_musa/fused_allreduce_rmsnorm_ops.py"
 FUSION_PASS = ROOT / "vllm_musa/_inductor/musa_allreduce_rms_fusion.py"
+PASS_MANAGER_PATCH = ROOT / (
+    "vllm_musa/patches/series/"
+    "0003-MUSA-vllm.compilation.passes.pass_manager.patch"
+)
 
 
 def _python_function_source(
@@ -61,6 +65,8 @@ def _isolated_fusion_helpers(torch_namespace: object, fx_namespace: object) -> t
     fusion_class = fusion_classes[0]
     helper_names = {
         "_is_add_node",
+        "_max_fusable_tokens",
+        "is_applicable_for_range",
         "_node_tensor_meta",
         "_manual_residual_inputs_supported",
     }
@@ -157,9 +163,12 @@ class _FakeNode:
         self.meta = {} if value is _MISSING else {"val": value}
 
 
-def _fake_fusion_namespaces() -> tuple[object, object, object, object, object]:
+def _fake_fusion_namespaces() -> tuple[
+    object, object, object, object, object, object
+]:
     tensor_overload = object()
     scalar_overload = object()
+    addmm_overload = object()
     add_packet = type(
         "_FakeAddPacket",
         (),
@@ -176,7 +185,20 @@ def _fake_fusion_namespaces() -> tuple[object, object, object, object, object]:
             "ops": type(
                 "_FakeOps",
                 (),
-                {"aten": type("_FakeAten", (), {"add": add_packet})},
+                {
+                    "aten": type(
+                        "_FakeAten",
+                        (),
+                        {
+                            "add": add_packet,
+                            "addmm": type(
+                                "_FakeAddmmPacket",
+                                (),
+                                {"default": addmm_overload},
+                            ),
+                        },
+                    )
+                },
             ),
         },
     )
@@ -186,6 +208,7 @@ def _fake_fusion_namespaces() -> tuple[object, object, object, object, object]:
         fx_namespace,
         tensor_overload,
         scalar_overload,
+        addmm_overload,
         torch_namespace.bfloat16,
     )
 
@@ -424,6 +447,7 @@ def test_manual_add_rewrite_accepts_only_tensor_overload_with_unit_alpha() -> No
         fx_namespace,
         tensor_overload,
         scalar_overload,
+        addmm_overload,
         _,
     ) = _fake_fusion_namespaces()
     helpers = _isolated_fusion_helpers(torch_namespace, fx_namespace)
@@ -443,6 +467,9 @@ def test_manual_add_rewrite_accepts_only_tensor_overload_with_unit_alpha() -> No
         _FakeNode(target=scalar_overload, args=(lhs, 1))
     )
     assert not helpers._is_add_node(
+        _FakeNode(target=addmm_overload, args=(lhs, rhs, lhs))
+    )
+    assert not helpers._is_add_node(
         _FakeNode(target=tensor_overload, args=(lhs, rhs, 1))
     )
     assert not helpers._is_add_node(
@@ -458,6 +485,7 @@ def test_manual_residual_metadata_gate_is_positive_and_fail_closed() -> None:
     (
         torch_namespace,
         fx_namespace,
+        _,
         _,
         _,
         input_dtype,
@@ -513,6 +541,38 @@ def test_fusion_runtime_state_participates_in_cache_uuid() -> None:
     assert '"comm_id": self.comm_id' in source
     assert '"jit_comm_id": self.jit_comm_id' in source
     assert '"group_name": self.group_name' in source
+    assert '"max_tokens_by_comm": self.max_tokens_by_comm' in source
+    assert '"jit_comm_max_size": self.jit_comm_max_size' in source
+
+
+def test_fusion_compile_range_respects_jit_comm_byte_limit() -> None:
+    (
+        torch_namespace,
+        fx_namespace,
+        _,
+        _,
+        _,
+        _,
+    ) = _fake_fusion_namespaces()
+    helpers = _isolated_fusion_helpers(torch_namespace, fx_namespace)()
+    max_size = 512 * 1024 * 1024
+    helpers.max_token_num = helpers._max_fusable_tokens(
+        20_000, max_size, 16_384, 2
+    )
+    assert helpers.max_token_num == 16_384
+    helpers.disabled = False
+    compile_range = type("_FakeRange", (), {"end": 16_384})()
+    assert helpers.is_applicable_for_range(compile_range)
+    compile_range.end = 16_385
+    assert not helpers.is_applicable_for_range(compile_range)
+
+
+def test_musa_fusion_respects_vllm_standard_disable_switch() -> None:
+    source = PASS_MANAGER_PATCH.read_text()
+    assert (
+        "if current_platform.is_musa() and self.pass_config.fuse_allreduce_rms:"
+        in source
+    )
 
 
 def test_fused_kernel_validates_world_size_before_fixed_registry_arrays() -> None:

--- a/tests/test_fused_ar_registered_graph_source.py
+++ b/tests/test_fused_ar_registered_graph_source.py
@@ -1,0 +1,174 @@
+"""Source-level guards for fused CAR-RMSNorm and its Graph input path."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+COMM = ROOT / (
+    "vllm_musa/distributed/device_communicators/"
+    "musa_jit_custom_all_reduce.py"
+)
+LAUNCHER = ROOT / "vllm_musa/jit_kernel/csrc/allreduce.py"
+KERNEL = ROOT / (
+    "vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu"
+)
+ENVIRON = ROOT / "vllm_musa/utils/environ.py"
+FUSED_OPS = ROOT / "vllm_musa/fused_allreduce_rmsnorm_ops.py"
+FUSION_PASS = ROOT / "vllm_musa/_inductor/musa_allreduce_rms_fusion.py"
+
+
+def test_registered_graph_flag_is_opt_in() -> None:
+    source = ENVIRON.read_text()
+    assert (
+        "VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT = "
+        "EnvBool(False)"
+    ) in source
+    assert (
+        "VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT_MAX_BYTES "
+        "= EnvInt("
+    ) in source
+    assert "512 * 1024" in source
+
+
+def test_fusion_uses_one_canonical_feature_gate() -> None:
+    env_source = ENVIRON.read_text()
+    comm_source = COMM.read_text()
+    fusion_source = FUSION_PASS.read_text()
+    canonical = "VLLM_MUSA_FUSED_AR_RMSNORM"
+    assert canonical in env_source
+    assert canonical in comm_source
+    assert canonical in fusion_source
+    assert "VLLM_MUSA_FUSED_ALLREDUCE_RMSNORM" not in env_source
+    assert "VLLM_MUSA_FUSED_ALLREDUCE_RMSNORM" not in fusion_source
+
+
+def test_python_registered_path_is_syntax_valid_and_sglang_independent() -> None:
+    comm_source = COMM.read_text()
+    launcher_source = LAUNCHER.read_text()
+    ast.parse(comm_source)
+    ast.parse(launcher_source)
+    assert "sglang" not in comm_source.lower()
+    assert "_register_graph_inputs()" in comm_source
+    assert "capture_succeeded" in comm_source
+    assert "torch.get_device_module().is_current_stream_capturing()" in comm_source
+    assert "torch.get_device_module().synchronize()" in comm_source
+    assert "Refusing to keep a potentially incorrect Graph" in comm_source
+    assert "_graph_registered_input_eligible" in comm_source
+    assert comm_source.count("_use_registered_graph_input(input)") == 3
+    assert comm_source.count("_graph_rank_data_for_input(input,") == 3
+    assert launcher_source.count("_check_registered_rank_data(rank_data)") == 3
+
+
+def test_fused_kernel_copy_is_cpu_rank_data_only() -> None:
+    source = KERNEL.read_text()
+    assert source.count("const RankData* device_data") >= 10
+    assert source.count("if (device_data != nullptr)") >= 5
+    # One unconditional copy remains for ordinary non-fused CAR. The three
+    # fused copies remain as the eager/default-Graph fallback, each guarded by
+    # CPU rank_data; device rank_data skips them.
+    assert source.count("musaMemcpyAsync(") == 4
+    assert source.count("if (rank_data_on_cpu) {") == 6
+    assert source.count(
+        "rank_data.device().device_type == inp.device().device_type"
+    ) == 3
+
+
+def test_sglang_mr413_tp2_fast_paths_preserve_vllm_abis() -> None:
+    source = KERNEL.read_text()
+    assert "fused_ar_rmsnorm_tp2_mr413_kernel" in source
+    assert source.count("launch_fused_ar_rmsnorm_tp2_mr413<T, WT,") == 3
+    assert "VLLM_MUSA_FUSED_AR_TP2_REGCACHE" in source
+    assert "VLLM_MUSA_FUSED_AR_TP2_VEC2RANK" in source
+    assert "hidden == 5120 && rows <= 128" in source
+    assert "hidden == 2048 && rows <= 128" in source
+    assert "load_weight_scalar<WT>" in source
+    assert "if constexpr (WriteReduced)" in source
+    assert source.count(
+        'TVM_FFI_ICHECK(shot == 1 || shot == 2) << "shot must be 1 or 2";'
+    ) == 3
+    assert source.count(
+        "if (shot == 1) {\n    if constexpr (nranks == 2)"
+    ) == 3
+
+
+def test_fused_ops_reuse_the_lifecycle_managed_jit_registry() -> None:
+    comm_source = COMM.read_text()
+    fused_source = FUSED_OPS.read_text()
+    fusion_source = FUSION_PASS.read_text()
+    ast.parse(fused_source)
+    assert "def get_musa_jit_custom_allreduce_comm" in comm_source
+    assert "get_musa_jit_custom_allreduce_comm" in fused_source
+    assert "_COMM_ID_BY_OBJECT" not in fused_source
+    assert "_NEXT_COMM_ID" not in fused_source
+    assert "register_musa_fused_ar_rmsnorm_comm" not in fused_source
+    assert "register_musa_fused_ar_rmsnorm_comm" not in fusion_source
+    assert "self.comm_id = self.jit_comm_id" in fusion_source
+
+
+def test_manual_rewrite_is_scoped_to_comm_and_full_variance() -> None:
+    source = FUSION_PASS.read_text()
+    assert "def _is_target_musa_car_node" in source
+    assert "self._car_comm_id(node) == self.jit_comm_id" in source
+    assert "if not self._is_target_musa_car_node(car):" in source
+    assert source.count("variance_size is not None") == 3
+
+
+def test_fusion_runtime_state_participates_in_cache_uuid() -> None:
+    source = FUSION_PASS.read_text()
+    assert "def uuid(self) -> str:" in source
+    assert '"enabled": not self.disabled' in source
+    assert '"comm_id": self.comm_id' in source
+    assert '"jit_comm_id": self.jit_comm_id' in source
+    assert '"group_name": self.group_name' in source
+
+
+def test_kernel_validates_world_size_before_fixed_registry_arrays() -> None:
+    source = KERNEL.read_text()
+    assert source.count("validate_world_size(world_size);") == 4
+    for function_name in (
+        "vllm_musa_custom_ar_launch_unregistered",
+        "vllm_musa_fused_ar_rmsnorm_launch_unregistered",
+        "vllm_musa_fused_ar_residual_rmsnorm_launch_unregistered",
+        "vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered",
+    ):
+        function_source = source[source.index(f"void {function_name}") :]
+        assert function_source.index("validate_world_size(world_size);") < (
+            function_source.index("RankSignals sg{};")
+        )
+
+
+def test_no_raw_one_shot_matches_raw_dtype_rounding_order() -> None:
+    source = KERNEL.read_text()
+    assert "const T reduced_value = from_float<T>(acc[i]);" in source
+    assert (
+        "to_float(reduced_value) + to_float(residual_pack.data[i])"
+        in source
+    )
+
+
+def test_tp4_rows64_two_shot_defaults_to_cap32() -> None:
+    launcher_source = LAUNCHER.read_text()
+    kernel_source = KERNEL.read_text()
+    assert (
+        '"VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP",\n'
+        '            "32",'
+    ) in launcher_source
+    assert "f\"_tp4bs64bc{tp4_bs64_2shot_block_cap}\"" in launcher_source
+    assert (
+        "-DVLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP="
+    ) in launcher_source
+    assert (
+        "#define VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP 32"
+        in kernel_source
+    )
+    assert "if constexpr (nranks == 4)" in kernel_source
+    assert "if (rows == 64 && hidden == 2048)" in kernel_source
+    assert (
+        kernel_source.count(
+            "fused_ar_rmsnorm_2shot_blocks<nranks>(rows, hidden)"
+        )
+        == 3
+    )

--- a/vllm_musa/_inductor/musa_allreduce_rms_fusion.py
+++ b/vllm_musa/_inductor/musa_allreduce_rms_fusion.py
@@ -1,0 +1,871 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA allreduce + RMSNorm fusion pass.
+
+This is the MUSA peer of the platform-specific fusion passes wired by vLLM's
+post-grad pass manager. It handles the decomposed v0.22 graph shapes:
+
+    custom_all_reduce(input) -> rms_norm(allreduce_output)
+    custom_all_reduce(input) -> add(allreduce_output, residual) -> rms_norm(add)
+
+It also handles the equivalent v0.24 IR form without decomposing the existing
+vLLM op:
+
+    custom_all_reduce(input) -> fused_add_rms_norm(allreduce_output, residual)
+
+The replacements are opaque MUSA custom ops. Their graph-level ABI preserves
+the tensor consumed by downstream users: all-reduced output for no-residual
+graphs and residual output for residual graphs.
+"""
+
+from __future__ import annotations
+
+import operator
+from typing import Any
+
+import torch
+import torch._inductor.pattern_matcher as pm
+import torch.fx as fx
+from torch._inductor.pattern_matcher import PatternMatcherPass
+
+import vllm.ir.ops
+from vllm.compilation.passes.inductor_pass import enable_fake_mode
+from vllm.compilation.passes.vllm_inductor_pass import (
+    VllmInductorPass,
+    VllmPatternMatcherPass,
+)
+from vllm.config import VllmConfig
+from vllm.config.utils import Range
+from vllm.distributed import get_tp_group
+from vllm.distributed.parallel_state import get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm_musa.fused_allreduce_rmsnorm_ops import (
+    musa_fused_allreduce_residual_rms_norm,
+    musa_fused_allreduce_residual_rms_norm_no_raw,
+    musa_fused_allreduce_rms_norm,
+)
+from vllm_musa.utils.environ import envs as musa_envs
+
+logger = init_logger(__name__)
+
+
+def _rms_input_weight_supported_dtype(match: pm.Match) -> bool:
+    """Allow RMSNorm weights supported by unfused Qwen3.5/Gemma semantics.
+
+    vllm.ir.ops.rms_norm upcasts activations to fp32 and multiplies in the
+    weight dtype before casting the output back to the activation dtype. Qwen3.5
+    uses GemmaRMSNorm, whose native path intentionally passes fp32 weights, so
+    input/weight dtype equality is not a semantic requirement. Keep this check
+    limited to fused-kernel capability: fp16/bf16 activations with either same
+    dtype or fp32 weights.
+    """
+    for node in match.nodes:
+        if node.op != "call_function":
+            continue
+        target = str(node.target)
+        residual = None
+        if "fused_add_rms_norm.default" in target:
+            if len(node.args) < 3:
+                return True
+            x, residual, weight = node.args[0], node.args[1], node.args[2]
+            variance_size = (
+                node.args[4]
+                if len(node.args) > 4
+                else node.kwargs.get("variance_size")
+            )
+        elif "rms_norm.default" in target:
+            if len(node.args) < 2:
+                return True
+            x, weight = node.args[0], node.args[1]
+            variance_size = (
+                node.args[3]
+                if len(node.args) > 3
+                else node.kwargs.get("variance_size")
+            )
+        else:
+            continue
+        if variance_size is not None:
+            return False
+        if not isinstance(x, fx.Node) or not isinstance(weight, fx.Node):
+            return True
+        x_dtype = x.meta["val"].dtype
+        weight_dtype = weight.meta["val"].dtype
+        supported = x_dtype in (torch.float16, torch.bfloat16) and weight_dtype in (
+            x_dtype,
+            torch.float32,
+        )
+        if isinstance(residual, fx.Node):
+            supported = supported and residual.meta["val"].dtype == x_dtype
+        return supported
+    return True
+
+
+class MusaAllReduceRMSNormPattern:
+    """Replace allreduce + RMSNorm with a MUSA fused CAR-RMSNorm op."""
+
+    def __init__(
+        self,
+        epsilon: float,
+        dtype: torch.dtype,
+        device: str | None,
+        group_name: str,
+        comm_id: int,
+    ) -> None:
+        self.epsilon = epsilon
+        self.dtype = dtype
+        self.device = device
+        self.group_name = group_name
+        self.comm_id = comm_id
+
+    def empty(self, *args: Any, **kwargs: Any) -> torch.Tensor:
+        return torch.empty(*args, dtype=self.dtype, device=self.device, **kwargs)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        return [self.empty(5, 16), self.empty(16)]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            input: torch.Tensor, weight: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            allreduce_output = torch.ops.vllm.all_reduce.default(
+                input,
+                group_name=self.group_name,
+            )
+            rms = vllm.ir.ops.rms_norm(allreduce_output, weight, self.epsilon)
+            return rms, allreduce_output
+
+        def replacement(
+            input: torch.Tensor, weight: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            rms, allreduce_output = musa_fused_allreduce_rms_norm(
+                input,
+                weight,
+                self.epsilon,
+                self.comm_id,
+            )
+            return rms, allreduce_output
+
+        pm.register_replacement(
+            pattern,
+            replacement,
+            self.get_inputs(),
+            pm.fwd_only,
+            pm_pass,
+            extra_check=_rms_input_weight_supported_dtype,
+        )
+
+
+class MusaAllReduceResidualRMSNormPattern:
+    """Replace custom allreduce + residual add + RMSNorm with fused MUSA op."""
+
+    def __init__(
+        self,
+        epsilon: float,
+        dtype: torch.dtype,
+        device: str | None,
+        jit_comm_id: int,
+        fused_comm_id: int,
+    ) -> None:
+        self.epsilon = epsilon
+        self.dtype = dtype
+        self.device = device
+        self.jit_comm_id = jit_comm_id
+        self.fused_comm_id = fused_comm_id
+
+    def empty(self, *args: Any, **kwargs: Any) -> torch.Tensor:
+        return torch.empty(*args, dtype=self.dtype, device=self.device, **kwargs)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        return [self.empty(5, 16), self.empty(5, 16), self.empty(16)]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            residual: torch.Tensor, input: torch.Tensor, weight: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            allreduce_output = torch.ops.vllm.musa_jit_custom_all_reduce.default(
+                input,
+                self.jit_comm_id,
+            )
+            residual_output = torch.add(allreduce_output, residual)
+            rms = vllm.ir.ops.rms_norm(residual_output, weight, self.epsilon)
+            return rms, residual_output, allreduce_output
+
+        def replacement(
+            residual: torch.Tensor, input: torch.Tensor, weight: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            rms, residual_output, allreduce_output = musa_fused_allreduce_residual_rms_norm(
+                input,
+                residual,
+                weight,
+                self.epsilon,
+                self.fused_comm_id,
+            )
+            return rms, residual_output, allreduce_output
+
+        def replacement_no_raw(
+            residual: torch.Tensor, input: torch.Tensor, weight: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            rms, residual_output = musa_fused_allreduce_residual_rms_norm_no_raw(
+                input,
+                residual,
+                weight,
+                self.epsilon,
+                self.fused_comm_id,
+            )
+            return rms, residual_output
+
+        # Graph fragments that only keep (rms, residual_out) or rms do not need
+        # the raw all-reduce tensor. Register these narrower dropped-output
+        # patterns before the full 3-return pattern; otherwise Inductor can
+        # greedily match the full ABI first and route no-copy candidates through
+        # the raw-car fused op.
+        first_return_only = lambda fn: lambda a, b, c: fn(a, b, c)[0]
+        first_two_returns = lambda fn: lambda a, b, c: fn(a, b, c)[:2]
+        pm.register_replacement(
+            first_two_returns(pattern),  # type: ignore[no-untyped-call]
+            replacement_no_raw,
+            self.get_inputs(),
+            pm.fwd_only,
+            pm_pass,
+            extra_check=_rms_input_weight_supported_dtype,
+        )
+
+        pm.register_replacement(
+            first_return_only(pattern),  # type: ignore[no-untyped-call]
+            first_return_only(lambda a, b, c: replacement_no_raw(a, b, c)),  # type: ignore[no-untyped-call]
+            self.get_inputs(),
+            pm.fwd_only,
+            pm_pass,
+            extra_check=_rms_input_weight_supported_dtype,
+        )
+
+        # Keep the full raw-car ABI last for copy-bearing candidates that still
+        # need the original all-reduced tensor (for example CAR -> copy_).
+        pm.register_replacement(
+            pattern,
+            replacement,
+            self.get_inputs(),
+            pm.fwd_only,
+            pm_pass,
+            extra_check=_rms_input_weight_supported_dtype,
+        )
+
+
+class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
+    """MUSA-specific no-residual CAR-RMSNorm pattern matcher pass."""
+
+    _candidate_count_calls = 0
+    _candidate_total_car = 0
+    _candidate_total_direct = 0
+    _candidate_total_add = 0
+    _candidate_total_fused_add = 0
+
+    def __init__(self, config: VllmConfig) -> None:
+        super().__init__(config)
+        self.disabled = True
+        self.max_token_num: int | None = None
+        self.debug_enabled = (
+            musa_envs.VLLM_MUSA_FUSED_AR_RMSNORM_DEBUG.get()
+        )
+
+        if not current_platform.is_musa():
+            return
+
+        if not musa_envs.VLLM_MUSA_FUSED_AR_RMSNORM.get():
+            return
+
+        self.tp_size = get_tensor_model_parallel_world_size()
+        if self.tp_size <= 1:
+            logger.warning_once(
+                "MUSA allreduce-rmsnorm fusion pass is disabled for tp_size <= 1."
+            )
+            return
+
+        if config.model_config is None:
+            logger.warning_once(
+                "MUSA allreduce-rmsnorm fusion pass is disabled for missing "
+                "model_config."
+            )
+            return
+
+        self.hidden_dim = config.model_config.get_hidden_size()
+        if self.model_dtype not in (torch.float16, torch.bfloat16):
+            logger.warning_once(
+                "MUSA allreduce-rmsnorm fusion only supports fp16/bf16; got %s.",
+                self.model_dtype,
+            )
+            return
+
+        if self.hidden_dim % 8 != 0 or self.hidden_dim > 16384:
+            logger.warning_once(
+                "MUSA allreduce-rmsnorm fusion requires hidden_dim %% 8 == 0 "
+                "and hidden_dim <= 16384; got %d.",
+                self.hidden_dim,
+            )
+            return
+
+        tp_group = get_tp_group()
+        self.group_name = tp_group.unique_name
+        device_comm = getattr(tp_group, "device_communicator", None)
+        ca_comm = getattr(device_comm, "ca_comm", None)
+        if ca_comm is None or getattr(ca_comm, "disabled", False):
+            logger.warning_once(
+                "MUSA allreduce-rmsnorm fusion disabled: missing enabled ca_comm."
+            )
+            return
+
+        jit_comm = getattr(ca_comm, "_jit_comm", None)
+        self.jit_comm_id = getattr(jit_comm, "_comm_id", None)
+        if self.jit_comm_id is None:
+            logger.warning_once(
+                "MUSA allreduce-rmsnorm fusion disabled: missing JIT comm id."
+            )
+            return
+
+        # Reuse the JIT communicator registry that already owns the compiled
+        # custom-allreduce ABI and removes the id during communicator close.
+        self.comm_id = self.jit_comm_id
+        self.patterns = PatternMatcherPass(pass_name="musa_all_reduce_rms_fusion_pass")
+        self.max_token_num = config.scheduler_config.max_num_batched_tokens
+        self.register_patterns()
+        self.dump_patterns(config, self.patterns)
+        logger.warning_once(
+            "MUSA allreduce-rmsnorm fusion pass enabled: group=%s tp_size=%d "
+            "hidden_dim=%d max_token_num=%s comm_id=%d jit_comm_id=%d.",
+            self.group_name,
+            self.tp_size,
+            self.hidden_dim,
+            self.max_token_num,
+            self.comm_id,
+            self.jit_comm_id,
+        )
+
+    @enable_fake_mode
+    def register_patterns(self) -> None:
+        for epsilon in [1e-5, 1e-6]:
+            MusaAllReduceRMSNormPattern(
+                epsilon,
+                self.model_dtype,
+                self.device,
+                self.group_name,
+                self.comm_id,
+            ).register(self.patterns)
+            torch._inductor.pattern_matcher._seen_patterns.clear()
+
+            MusaAllReduceResidualRMSNormPattern(
+                epsilon,
+                self.model_dtype,
+                self.device,
+                self.jit_comm_id,
+                self.comm_id,
+            ).register(self.patterns)
+            # Clear the pattern cache so both eps values can register equivalent
+            # graph shapes.
+            torch._inductor.pattern_matcher._seen_patterns.clear()
+
+        self.disabled = False
+
+    def is_applicable_for_range(self, compile_range: Range) -> bool:
+        if self.disabled:
+            return False
+        if self.max_token_num is None:
+            return True
+        return bool(compile_range.end <= self.max_token_num)
+
+    def uuid(self) -> str:
+        """Include runtime rewrite state in the Inductor disk-cache key."""
+        state: dict[str, Any] = {
+            "source": self.hash_source(
+                self,
+                MusaAllReduceRMSNormPattern,
+                MusaAllReduceResidualRMSNormPattern,
+            ),
+            "enabled": not self.disabled,
+            "max_token_num": self.max_token_num,
+        }
+        if not self.disabled:
+            state.update(
+                {
+                    "comm_id": self.comm_id,
+                    "jit_comm_id": self.jit_comm_id,
+                    "group_name": self.group_name,
+                    "tp_size": self.tp_size,
+                    "hidden_dim": self.hidden_dim,
+                    "model_dtype": str(self.model_dtype),
+                }
+            )
+        return self.hash_dict(state)
+
+    @staticmethod
+    def _target_name(node: fx.Node) -> str:
+        return str(getattr(node, 'target', ''))
+
+    @classmethod
+    def _node_debug(cls, node: fx.Node) -> str:
+        val = node.meta.get('val') if hasattr(node, 'meta') else None
+        shape = getattr(val, 'shape', None)
+        dtype = getattr(val, 'dtype', None)
+        users = [f'{user.name}:{cls._target_name(user)}' for user in node.users]
+        return (
+            f'{node.name}:op={node.op}:target={cls._target_name(node)}:'
+            f'shape={shape}:dtype={dtype}:users={users}'
+        )
+
+    @classmethod
+    def _is_musa_car_node(cls, node: fx.Node) -> bool:
+        return (
+            node.op == 'call_function'
+            and 'musa_jit_custom_all_reduce' in cls._target_name(node)
+        )
+
+    @staticmethod
+    def _car_comm_id(node: fx.Node) -> Any | None:
+        if len(node.args) > 1:
+            return node.args[1]
+        return node.kwargs.get("comm_id")
+
+    def _is_target_musa_car_node(self, node: fx.Node) -> bool:
+        return self._is_musa_car_node(node) and (
+            self._car_comm_id(node) == self.jit_comm_id
+        )
+
+    @classmethod
+    def _is_rms_norm_node(cls, node: fx.Node) -> bool:
+        target = cls._target_name(node)
+        return (
+            node.op == 'call_function'
+            and 'rms_norm.default' in target
+            and 'fused_add_rms_norm.default' not in target
+        )
+
+    @classmethod
+    def _is_fused_add_rms_norm_node(cls, node: fx.Node) -> bool:
+        return (
+            node.op == 'call_function'
+            and 'fused_add_rms_norm.default' in cls._target_name(node)
+        )
+
+    @classmethod
+    def _is_add_node(cls, node: fx.Node) -> bool:
+        return node.op == 'call_function' and 'aten.add' in cls._target_name(node)
+
+    @classmethod
+    def _is_musa_fused_ar_rms_node(cls, node: fx.Node) -> bool:
+        target = cls._target_name(node)
+        return node.op == 'call_function' and (
+            'musa_fused_allreduce_rms_norm' in target
+            or 'musa_fused_allreduce_residual_rms_norm' in target
+        )
+
+    def _collect_candidates(
+        self, graph: fx.Graph
+    ) -> tuple[
+        list[fx.Node],
+        list[fx.Node],
+        list[tuple[fx.Node, fx.Node]],
+        list[tuple[fx.Node, fx.Node, fx.Node]],
+        list[tuple[fx.Node, fx.Node]],
+    ]:
+        direct: list[tuple[fx.Node, fx.Node]] = []
+        add: list[tuple[fx.Node, fx.Node, fx.Node]] = []
+        fused_add: list[tuple[fx.Node, fx.Node]] = []
+        car_nodes = [
+            node for node in graph.nodes if self._is_target_musa_car_node(node)
+        ]
+        fused_nodes = [
+            node for node in graph.nodes if self._is_musa_fused_ar_rms_node(node)
+        ]
+
+        for car in car_nodes:
+            for user in car.users:
+                if self._is_fused_add_rms_norm_node(user):
+                    fused_add.append((car, user))
+                elif self._is_rms_norm_node(user):
+                    direct.append((car, user))
+                elif self._is_add_node(user):
+                    for add_user in user.users:
+                        if self._is_rms_norm_node(add_user):
+                            add.append((car, user, add_user))
+        return car_nodes, fused_nodes, direct, add, fused_add
+
+    def _log_candidate_pattern_counts(
+        self, graph: fx.Graph, *, stage: str, record_totals: bool
+    ) -> None:
+        if not self.debug_enabled:
+            return
+        car_nodes, fused_nodes, direct, add, fused_add = self._collect_candidates(
+            graph
+        )
+
+        cls = type(self)
+        if record_totals:
+            cls._candidate_count_calls += 1
+            cls._candidate_total_car += len(car_nodes)
+            cls._candidate_total_direct += len(direct)
+            cls._candidate_total_add += len(add)
+            cls._candidate_total_fused_add += len(fused_add)
+        pass_id = cls._candidate_count_calls
+
+        examples = [
+            f'{car.name}->{rms.name}' for car, rms in direct[:2]
+        ] + [
+            f'{car.name}->{add_node.name}->{rms.name}'
+            for car, add_node, rms in add[:4]
+        ] + [
+            f'{car.name}->{fused_node.name}'
+            for car, fused_node in fused_add[:4]
+        ]
+        logger.warning(
+            'MUSA CAR-RMSNorm candidates %s fusion pass #%d: '
+            'car=%d fused_ar_rms=%d direct_car_rmsnorm=%d '
+            'add_car_rmsnorm=%d fused_add_car_rmsnorm=%d other_car=%d; '
+            'cumulative_car=%d '
+            'cumulative_direct_car_rmsnorm=%d cumulative_add_car_rmsnorm=%d; '
+            'cumulative_fused_add_car_rmsnorm=%d; '
+            'examples=%s',
+            stage,
+            pass_id,
+            len(car_nodes),
+            len(fused_nodes),
+            len(direct),
+            len(add),
+            len(fused_add),
+            len(car_nodes) - len(direct) - len(add) - len(fused_add),
+            cls._candidate_total_car,
+            cls._candidate_total_direct,
+            cls._candidate_total_add,
+            cls._candidate_total_fused_add,
+            examples,
+        )
+        if not self.debug_enabled:
+            return
+        for idx, fused in enumerate(fused_nodes):
+            logger.warning(
+                'MUSA CAR-RMSNorm fused node %s pass #%d idx=%d fused={%s}',
+                stage,
+                pass_id,
+                idx,
+                self._node_debug(fused),
+            )
+        for idx, (car, rms) in enumerate(direct):
+            logger.warning(
+                'MUSA CAR-RMSNorm direct candidate %s pass #%d idx=%d car={%s} rms={%s}',
+                stage,
+                pass_id,
+                idx,
+                self._node_debug(car),
+                self._node_debug(rms),
+            )
+        for idx, (car, add_node, rms) in enumerate(add):
+            logger.warning(
+                'MUSA CAR-RMSNorm add candidate %s pass #%d idx=%d car={%s} add={%s} rms={%s}',
+                stage,
+                pass_id,
+                idx,
+                self._node_debug(car),
+                self._node_debug(add_node),
+                self._node_debug(rms),
+            )
+        for idx, (car, fused_add_node) in enumerate(fused_add):
+            logger.warning(
+                'MUSA CAR-RMSNorm fused-add candidate %s pass #%d idx=%d '
+                'car={%s} fused_add={%s}',
+                stage,
+                pass_id,
+                idx,
+                self._node_debug(car),
+                self._node_debug(fused_add_node),
+            )
+
+    @staticmethod
+    def _rms_norm_weight(node: fx.Node) -> Any | None:
+        if len(node.args) > 1:
+            return node.args[1]
+        return node.kwargs.get("weight")
+
+    @staticmethod
+    def _rms_norm_eps(node: fx.Node) -> Any | None:
+        if len(node.args) > 2:
+            return node.args[2]
+        return node.kwargs.get("epsilon", node.kwargs.get("eps"))
+
+    @staticmethod
+    def _rms_norm_variance_size(node: fx.Node) -> Any | None:
+        if len(node.args) > 3:
+            return node.args[3]
+        return node.kwargs.get("variance_size")
+
+    @staticmethod
+    def _other_add_arg(add: fx.Node, car: fx.Node) -> Any | None:
+        if len(add.args) < 2:
+            return None
+        lhs, rhs = add.args[0], add.args[1]
+        if lhs is car:
+            return rhs
+        if rhs is car:
+            return lhs
+        return None
+
+    @staticmethod
+    def _fused_add_rms_norm_args(
+        node: fx.Node, car: fx.Node
+    ) -> tuple[Any, Any, Any, Any] | None:
+        """Return residual, weight, epsilon and variance size for vLLM 0.24."""
+        if len(node.args) < 4 or node.args[0] is not car:
+            return None
+        variance_size = (
+            node.args[4] if len(node.args) > 4 else node.kwargs.get("variance_size")
+        )
+        return node.args[1], node.args[2], node.args[3], variance_size
+
+    @staticmethod
+    def _getitem_index(node: fx.Node, parent: fx.Node) -> int | None:
+        if (
+            node.op != "call_function"
+            or node.target is not operator.getitem
+            or len(node.args) < 2
+            or node.args[0] is not parent
+            or not isinstance(node.args[1], int)
+        ):
+            return None
+        return int(node.args[1])
+
+    def _manual_rewrite_residual_musa_jit_car_rmsnorm(
+        self, graph: fx.Graph
+    ) -> tuple[int, int, int, int]:
+        """Rewrite the 0.22 add IR and 0.24 fused-add IR explicitly.
+
+        PatternMatcher can greedily keep matching the full 3-output ABI even when
+        the raw all-reduce value is not used. This rewrite separates the two
+        residual cases from actual graph users:
+        - copy/other CAR users present: keep raw 3-output fused ABI.
+        - only add->RMSNorm needs the CAR result: use the 2-output no-raw ABI.
+        """
+        no_raw_replaced = 0
+        raw_replaced = 0
+        skipped_missing_args = 0
+        skipped_bad_add_args = 0
+
+        for car in list(graph.nodes):
+            if not self._is_target_musa_car_node(car):
+                continue
+            if len(car.args) < 1:
+                skipped_bad_add_args += 1
+                continue
+
+            # vLLM 0.24 lowers add + RMSNorm to a two-output IR node:
+            # fused_add_rms_norm(CAR, residual, weight, eps) -> (rms, residual).
+            # Keep the proven 0.22 SGLang-port raw/no-raw user routing and only
+            # adapt how this combined node's inputs and outputs are accessed.
+            rewrote_fused_add = False
+            fused_add_users = [
+                user
+                for user in list(car.users)
+                if self._is_fused_add_rms_norm_node(user)
+            ]
+            for fused_add in fused_add_users:
+                fused_add_args = self._fused_add_rms_norm_args(fused_add, car)
+                if fused_add_args is None:
+                    skipped_missing_args += 1
+                    continue
+                residual, weight, eps, variance_size = fused_add_args
+                if weight is None or eps is None or variance_size is not None:
+                    skipped_missing_args += 1
+                    continue
+
+                output_users = list(fused_add.users)
+                output_indices = {
+                    user: self._getitem_index(user, fused_add)
+                    for user in output_users
+                }
+                if not output_users or any(
+                    index not in (0, 1) for index in output_indices.values()
+                ):
+                    skipped_missing_args += 1
+                    continue
+
+                raw_users = [
+                    user for user in list(car.users) if user is not fused_add
+                ]
+                use_raw = bool(raw_users)
+
+                with graph.inserting_before(fused_add):
+                    if use_raw:
+                        fused = graph.call_function(
+                            torch.ops.vllm.musa_fused_allreduce_residual_rms_norm.default,
+                            args=(car.args[0], residual, weight, eps, self.comm_id),
+                        )
+                        fused_rms = graph.call_function(
+                            operator.getitem, args=(fused, 0)
+                        )
+                        fused_residual = graph.call_function(
+                            operator.getitem, args=(fused, 1)
+                        )
+                        fused_raw = graph.call_function(
+                            operator.getitem, args=(fused, 2)
+                        )
+                    else:
+                        fused = graph.call_function(
+                            torch.ops.vllm.musa_fused_allreduce_residual_rms_norm_no_raw.default,
+                            args=(car.args[0], residual, weight, eps, self.comm_id),
+                        )
+                        fused_rms = graph.call_function(
+                            operator.getitem, args=(fused, 0)
+                        )
+                        fused_residual = graph.call_function(
+                            operator.getitem, args=(fused, 1)
+                        )
+                        fused_raw = None
+
+                for user, index in output_indices.items():
+                    replacement = fused_rms if index == 0 else fused_residual
+                    user.replace_all_uses_with(replacement)
+                if fused_raw is not None:
+                    for user in raw_users:
+                        user.replace_input_with(car, fused_raw)
+
+                for user in output_users:
+                    if len(user.users) == 0:
+                        graph.erase_node(user)
+                if len(fused_add.users) == 0:
+                    graph.erase_node(fused_add)
+                if len(car.users) == 0:
+                    graph.erase_node(car)
+
+                if use_raw:
+                    raw_replaced += 1
+                else:
+                    no_raw_replaced += 1
+                rewrote_fused_add = True
+                break
+
+            if rewrote_fused_add:
+                continue
+
+            for add in [user for user in list(car.users) if self._is_add_node(user)]:
+                residual = self._other_add_arg(add, car)
+                if residual is None:
+                    skipped_bad_add_args += 1
+                    continue
+
+                rms_users = [
+                    user
+                    for user in list(add.users)
+                    if self._is_rms_norm_node(user)
+                    and len(user.args) >= 1
+                    and user.args[0] is add
+                ]
+                if not rms_users:
+                    continue
+
+                rms = rms_users[0]
+                weight = self._rms_norm_weight(rms)
+                eps = self._rms_norm_eps(rms)
+                variance_size = self._rms_norm_variance_size(rms)
+                if weight is None or eps is None or variance_size is not None:
+                    skipped_missing_args += 1
+                    continue
+
+                raw_users = [user for user in list(car.users) if user is not add]
+                use_raw = bool(raw_users)
+
+                with graph.inserting_before(rms):
+                    if use_raw:
+                        fused = graph.call_function(
+                            torch.ops.vllm.musa_fused_allreduce_residual_rms_norm.default,
+                            args=(car.args[0], residual, weight, eps, self.comm_id),
+                        )
+                        fused_rms = graph.call_function(
+                            operator.getitem, args=(fused, 0)
+                        )
+                        fused_residual = graph.call_function(
+                            operator.getitem, args=(fused, 1)
+                        )
+                        fused_raw = graph.call_function(
+                            operator.getitem, args=(fused, 2)
+                        )
+                    else:
+                        fused = graph.call_function(
+                            torch.ops.vllm.musa_fused_allreduce_residual_rms_norm_no_raw.default,
+                            args=(car.args[0], residual, weight, eps, self.comm_id),
+                        )
+                        fused_rms = graph.call_function(
+                            operator.getitem, args=(fused, 0)
+                        )
+                        fused_residual = graph.call_function(
+                            operator.getitem, args=(fused, 1)
+                        )
+                        fused_raw = None
+
+                rms.replace_all_uses_with(fused_rms)
+                for user in list(add.users):
+                    if user is not rms:
+                        user.replace_input_with(add, fused_residual)
+                if fused_raw is not None:
+                    for user in raw_users:
+                        user.replace_input_with(car, fused_raw)
+
+                graph.erase_node(rms)
+                if len(add.users) == 0:
+                    graph.erase_node(add)
+                if len(car.users) == 0:
+                    graph.erase_node(car)
+
+                if use_raw:
+                    raw_replaced += 1
+                else:
+                    no_raw_replaced += 1
+                break
+
+        replaced = no_raw_replaced + raw_replaced
+        if replaced:
+            graph.lint()
+            graph.eliminate_dead_code()
+
+        logger.warning(
+            "MUSA manual residual CAR-RMSNorm rewrite: no_raw=%d raw=%d "
+            "skipped_missing_args=%d skipped_bad_add_args=%d",
+            no_raw_replaced,
+            raw_replaced,
+            skipped_missing_args,
+            skipped_bad_add_args,
+        )
+        return no_raw_replaced, raw_replaced, skipped_missing_args, skipped_bad_add_args
+
+    @VllmInductorPass.time_and_log
+    def __call__(self, graph: fx.Graph) -> None:
+        if self.disabled:
+            return
+        self._log_candidate_pattern_counts(
+            graph, stage='before', record_totals=True
+        )
+
+        manual_no_raw, manual_raw, _, _ = (
+            self._manual_rewrite_residual_musa_jit_car_rmsnorm(graph)
+        )
+        manual_count = manual_no_raw + manual_raw
+        if manual_count:
+            self.matched_count = manual_count
+            self._log_candidate_pattern_counts(
+                graph, stage='after', record_totals=False
+            )
+            logger.warning(
+                "MUSA allreduce-rmsnorm fusion replaced %s patterns "
+                "(manual_no_raw=%s manual_raw=%s pattern=0)",
+                self.matched_count,
+                manual_no_raw,
+                manual_raw,
+            )
+            return
+
+        self.matched_count = self.patterns.apply(graph)
+        self._log_candidate_pattern_counts(
+            graph, stage='after', record_totals=False
+        )
+        logger.warning(
+            "MUSA allreduce-rmsnorm fusion replaced %s patterns "
+            "(manual_no_raw=0 manual_raw=0 pattern=%s)",
+            self.matched_count,
+            self.matched_count,
+        )

--- a/vllm_musa/_inductor/musa_allreduce_rms_fusion.py
+++ b/vllm_musa/_inductor/musa_allreduce_rms_fusion.py
@@ -426,7 +426,73 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
 
     @classmethod
     def _is_add_node(cls, node: fx.Node) -> bool:
-        return node.op == 'call_function' and 'aten.add' in cls._target_name(node)
+        if (
+            node.op != "call_function"
+            or node.target is not torch.ops.aten.add.Tensor
+            or len(node.args) != 2
+            or any(name != "alpha" for name in node.kwargs)
+        ):
+            return False
+        alpha = node.kwargs.get("alpha", 1)
+        return isinstance(alpha, (int, float, complex)) and alpha == 1
+
+    @staticmethod
+    def _node_tensor_meta(node: Any) -> torch.Tensor | None:
+        if not isinstance(node, fx.Node):
+            return None
+        value = node.meta.get("val")
+        return value if isinstance(value, torch.Tensor) else None
+
+    def _manual_residual_inputs_supported(
+        self, car: fx.Node, residual: Any, weight: Any
+    ) -> bool:
+        """Fail closed unless manual-rewrite inputs satisfy the fused ABI."""
+        if len(car.args) < 1:
+            return False
+
+        input_value = self._node_tensor_meta(car.args[0])
+        car_value = self._node_tensor_meta(car)
+        residual_value = self._node_tensor_meta(residual)
+        weight_value = self._node_tensor_meta(weight)
+        if any(
+            value is None
+            for value in (input_value, car_value, residual_value, weight_value)
+        ):
+            return False
+
+        assert input_value is not None
+        assert car_value is not None
+        assert residual_value is not None
+        assert weight_value is not None
+        try:
+            hidden_size = input_value.shape[-1]
+            return bool(
+                input_value.device.type == "musa"
+                and car_value.device == input_value.device
+                and residual_value.device == input_value.device
+                and weight_value.device == input_value.device
+                and input_value.dim() == 2
+                and car_value.dim() == 2
+                and residual_value.dim() == 2
+                and weight_value.dim() == 1
+                and car_value.shape == input_value.shape
+                and residual_value.shape == input_value.shape
+                and hidden_size == self.hidden_dim
+                and hidden_size > 0
+                and hidden_size % 8 == 0
+                and hidden_size <= 16384
+                and weight_value.numel() == hidden_size
+                and input_value.dtype in (torch.float16, torch.bfloat16)
+                and car_value.dtype == input_value.dtype
+                and residual_value.dtype == input_value.dtype
+                and weight_value.dtype in (input_value.dtype, torch.float32)
+                and input_value.is_contiguous()
+                and car_value.is_contiguous()
+                and residual_value.is_contiguous()
+                and weight_value.is_contiguous()
+            )
+        except (AttributeError, IndexError, RuntimeError, TypeError):
+            return False
 
     @staticmethod
     def _rms_norm_weight(node: fx.Node) -> Any | None:
@@ -518,6 +584,10 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
                 residual, weight, eps, variance_size = fused_add_args
                 if weight is None or eps is None or variance_size is not None:
                     continue
+                if not self._manual_residual_inputs_supported(
+                    car, residual, weight
+                ):
+                    continue
 
                 output_users = list(fused_add.users)
                 output_indices = {
@@ -607,6 +677,10 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
                 eps = self._rms_norm_eps(rms)
                 variance_size = self._rms_norm_variance_size(rms)
                 if weight is None or eps is None or variance_size is not None:
+                    continue
+                if not self._manual_residual_inputs_supported(
+                    car, residual, weight
+                ):
                     continue
 
                 raw_users = [user for user in list(car.users) if user is not add]

--- a/vllm_musa/_inductor/musa_allreduce_rms_fusion.py
+++ b/vllm_musa/_inductor/musa_allreduce_rms_fusion.py
@@ -20,7 +20,6 @@ graphs and residual output for residual graphs.
 
 from __future__ import annotations
 
-import logging
 import operator
 from typing import Any
 
@@ -255,12 +254,6 @@ class MusaAllReduceResidualRMSNormPattern:
 class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
     """MUSA-specific no-residual CAR-RMSNorm pattern matcher pass."""
 
-    _candidate_count_calls = 0
-    _candidate_total_car = 0
-    _candidate_total_direct = 0
-    _candidate_total_add = 0
-    _candidate_total_fused_add = 0
-
     def __init__(self, config: VllmConfig) -> None:
         super().__init__(config)
         self.disabled = True
@@ -398,17 +391,6 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
         return str(getattr(node, 'target', ''))
 
     @classmethod
-    def _node_debug(cls, node: fx.Node) -> str:
-        val = node.meta.get('val') if hasattr(node, 'meta') else None
-        shape = getattr(val, 'shape', None)
-        dtype = getattr(val, 'dtype', None)
-        users = [f'{user.name}:{cls._target_name(user)}' for user in node.users]
-        return (
-            f'{node.name}:op={node.op}:target={cls._target_name(node)}:'
-            f'shape={shape}:dtype={dtype}:users={users}'
-        )
-
-    @classmethod
     def _is_musa_car_node(cls, node: fx.Node) -> bool:
         return (
             node.op == 'call_function'
@@ -445,132 +427,6 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
     @classmethod
     def _is_add_node(cls, node: fx.Node) -> bool:
         return node.op == 'call_function' and 'aten.add' in cls._target_name(node)
-
-    @classmethod
-    def _is_musa_fused_ar_rms_node(cls, node: fx.Node) -> bool:
-        target = cls._target_name(node)
-        return node.op == 'call_function' and (
-            'musa_fused_allreduce_rms_norm' in target
-            or 'musa_fused_allreduce_residual_rms_norm' in target
-        )
-
-    def _collect_candidates(
-        self, graph: fx.Graph
-    ) -> tuple[
-        list[fx.Node],
-        list[fx.Node],
-        list[tuple[fx.Node, fx.Node]],
-        list[tuple[fx.Node, fx.Node, fx.Node]],
-        list[tuple[fx.Node, fx.Node]],
-    ]:
-        direct: list[tuple[fx.Node, fx.Node]] = []
-        add: list[tuple[fx.Node, fx.Node, fx.Node]] = []
-        fused_add: list[tuple[fx.Node, fx.Node]] = []
-        car_nodes = [
-            node for node in graph.nodes if self._is_target_musa_car_node(node)
-        ]
-        fused_nodes = [
-            node for node in graph.nodes if self._is_musa_fused_ar_rms_node(node)
-        ]
-
-        for car in car_nodes:
-            for user in car.users:
-                if self._is_fused_add_rms_norm_node(user):
-                    fused_add.append((car, user))
-                elif self._is_rms_norm_node(user):
-                    direct.append((car, user))
-                elif self._is_add_node(user):
-                    for add_user in user.users:
-                        if self._is_rms_norm_node(add_user):
-                            add.append((car, user, add_user))
-        return car_nodes, fused_nodes, direct, add, fused_add
-
-    def _log_candidate_pattern_counts(
-        self, graph: fx.Graph, *, stage: str, record_totals: bool
-    ) -> None:
-        if not logger.isEnabledFor(logging.DEBUG):
-            return
-        car_nodes, fused_nodes, direct, add, fused_add = self._collect_candidates(
-            graph
-        )
-
-        cls = type(self)
-        if record_totals:
-            cls._candidate_count_calls += 1
-            cls._candidate_total_car += len(car_nodes)
-            cls._candidate_total_direct += len(direct)
-            cls._candidate_total_add += len(add)
-            cls._candidate_total_fused_add += len(fused_add)
-        pass_id = cls._candidate_count_calls
-
-        examples = [
-            f'{car.name}->{rms.name}' for car, rms in direct[:2]
-        ] + [
-            f'{car.name}->{add_node.name}->{rms.name}'
-            for car, add_node, rms in add[:4]
-        ] + [
-            f'{car.name}->{fused_node.name}'
-            for car, fused_node in fused_add[:4]
-        ]
-        logger.debug(
-            'MUSA CAR-RMSNorm candidates %s fusion pass #%d: '
-            'car=%d fused_ar_rms=%d direct_car_rmsnorm=%d '
-            'add_car_rmsnorm=%d fused_add_car_rmsnorm=%d other_car=%d; '
-            'cumulative_car=%d '
-            'cumulative_direct_car_rmsnorm=%d cumulative_add_car_rmsnorm=%d; '
-            'cumulative_fused_add_car_rmsnorm=%d; '
-            'examples=%s',
-            stage,
-            pass_id,
-            len(car_nodes),
-            len(fused_nodes),
-            len(direct),
-            len(add),
-            len(fused_add),
-            len(car_nodes) - len(direct) - len(add) - len(fused_add),
-            cls._candidate_total_car,
-            cls._candidate_total_direct,
-            cls._candidate_total_add,
-            cls._candidate_total_fused_add,
-            examples,
-        )
-        for idx, fused in enumerate(fused_nodes):
-            logger.debug(
-                'MUSA CAR-RMSNorm fused node %s pass #%d idx=%d fused={%s}',
-                stage,
-                pass_id,
-                idx,
-                self._node_debug(fused),
-            )
-        for idx, (car, rms) in enumerate(direct):
-            logger.debug(
-                'MUSA CAR-RMSNorm direct candidate %s pass #%d idx=%d car={%s} rms={%s}',
-                stage,
-                pass_id,
-                idx,
-                self._node_debug(car),
-                self._node_debug(rms),
-            )
-        for idx, (car, add_node, rms) in enumerate(add):
-            logger.debug(
-                'MUSA CAR-RMSNorm add candidate %s pass #%d idx=%d car={%s} add={%s} rms={%s}',
-                stage,
-                pass_id,
-                idx,
-                self._node_debug(car),
-                self._node_debug(add_node),
-                self._node_debug(rms),
-            )
-        for idx, (car, fused_add_node) in enumerate(fused_add):
-            logger.debug(
-                'MUSA CAR-RMSNorm fused-add candidate %s pass #%d idx=%d '
-                'car={%s} fused_add={%s}',
-                stage,
-                pass_id,
-                idx,
-                self._node_debug(car),
-                self._node_debug(fused_add_node),
-            )
 
     @staticmethod
     def _rms_norm_weight(node: fx.Node) -> Any | None:
@@ -627,7 +483,7 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
 
     def _manual_rewrite_residual_musa_jit_car_rmsnorm(
         self, graph: fx.Graph
-    ) -> tuple[int, int, int, int]:
+    ) -> tuple[int, int]:
         """Rewrite the 0.22 add IR and 0.24 fused-add IR explicitly.
 
         PatternMatcher can greedily keep matching the full 3-output ABI even when
@@ -638,14 +494,11 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
         """
         no_raw_replaced = 0
         raw_replaced = 0
-        skipped_missing_args = 0
-        skipped_bad_add_args = 0
 
         for car in list(graph.nodes):
             if not self._is_target_musa_car_node(car):
                 continue
             if len(car.args) < 1:
-                skipped_bad_add_args += 1
                 continue
 
             # vLLM 0.24 lowers add + RMSNorm to a two-output IR node:
@@ -661,11 +514,9 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
             for fused_add in fused_add_users:
                 fused_add_args = self._fused_add_rms_norm_args(fused_add, car)
                 if fused_add_args is None:
-                    skipped_missing_args += 1
                     continue
                 residual, weight, eps, variance_size = fused_add_args
                 if weight is None or eps is None or variance_size is not None:
-                    skipped_missing_args += 1
                     continue
 
                 output_users = list(fused_add.users)
@@ -676,7 +527,6 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
                 if not output_users or any(
                     index not in (0, 1) for index in output_indices.values()
                 ):
-                    skipped_missing_args += 1
                     continue
 
                 raw_users = [
@@ -740,7 +590,6 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
             for add in [user for user in list(car.users) if self._is_add_node(user)]:
                 residual = self._other_add_arg(add, car)
                 if residual is None:
-                    skipped_bad_add_args += 1
                     continue
 
                 rms_users = [
@@ -758,7 +607,6 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
                 eps = self._rms_norm_eps(rms)
                 variance_size = self._rms_norm_variance_size(rms)
                 if weight is None or eps is None or variance_size is not None:
-                    skipped_missing_args += 1
                     continue
 
                 raw_users = [user for user in list(car.users) if user is not add]
@@ -817,49 +665,19 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
             graph.lint()
             graph.eliminate_dead_code()
 
-        logger.warning(
-            "MUSA manual residual CAR-RMSNorm rewrite: no_raw=%d raw=%d "
-            "skipped_missing_args=%d skipped_bad_add_args=%d",
-            no_raw_replaced,
-            raw_replaced,
-            skipped_missing_args,
-            skipped_bad_add_args,
-        )
-        return no_raw_replaced, raw_replaced, skipped_missing_args, skipped_bad_add_args
+        return no_raw_replaced, raw_replaced
 
     @VllmInductorPass.time_and_log
     def __call__(self, graph: fx.Graph) -> None:
         if self.disabled:
             return
-        self._log_candidate_pattern_counts(
-            graph, stage='before', record_totals=True
-        )
 
-        manual_no_raw, manual_raw, _, _ = (
+        manual_no_raw, manual_raw = (
             self._manual_rewrite_residual_musa_jit_car_rmsnorm(graph)
         )
         manual_count = manual_no_raw + manual_raw
         if manual_count:
             self.matched_count = manual_count
-            self._log_candidate_pattern_counts(
-                graph, stage='after', record_totals=False
-            )
-            logger.warning(
-                "MUSA allreduce-rmsnorm fusion replaced %s patterns "
-                "(manual_no_raw=%s manual_raw=%s pattern=0)",
-                self.matched_count,
-                manual_no_raw,
-                manual_raw,
-            )
             return
 
         self.matched_count = self.patterns.apply(graph)
-        self._log_candidate_pattern_counts(
-            graph, stage='after', record_totals=False
-        )
-        logger.warning(
-            "MUSA allreduce-rmsnorm fusion replaced %s patterns "
-            "(manual_no_raw=0 manual_raw=0 pattern=%s)",
-            self.matched_count,
-            self.matched_count,
-        )

--- a/vllm_musa/_inductor/musa_allreduce_rms_fusion.py
+++ b/vllm_musa/_inductor/musa_allreduce_rms_fusion.py
@@ -20,6 +20,7 @@ graphs and residual output for residual graphs.
 
 from __future__ import annotations
 
+import logging
 import operator
 from typing import Any
 
@@ -51,14 +52,13 @@ logger = init_logger(__name__)
 
 
 def _rms_input_weight_supported_dtype(match: pm.Match) -> bool:
-    """Allow RMSNorm weights supported by unfused Qwen3.5/Gemma semantics.
+    """Allow RMSNorm weight dtypes supported by the unfused semantics.
 
     vllm.ir.ops.rms_norm upcasts activations to fp32 and multiplies in the
-    weight dtype before casting the output back to the activation dtype. Qwen3.5
-    uses GemmaRMSNorm, whose native path intentionally passes fp32 weights, so
+    weight dtype before casting the output back to the activation dtype, so
     input/weight dtype equality is not a semantic requirement. Keep this check
-    limited to fused-kernel capability: fp16/bf16 activations with either same
-    dtype or fp32 weights.
+    limited to fused-kernel capability: fp16/bf16 activations with either the
+    same dtype or fp32 weights.
     """
     for node in match.nodes:
         if node.op != "call_function":
@@ -265,10 +265,6 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
         super().__init__(config)
         self.disabled = True
         self.max_token_num: int | None = None
-        self.debug_enabled = (
-            musa_envs.VLLM_MUSA_FUSED_AR_RMSNORM_DEBUG.get()
-        )
-
         if not current_platform.is_musa():
             return
 
@@ -492,7 +488,7 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
     def _log_candidate_pattern_counts(
         self, graph: fx.Graph, *, stage: str, record_totals: bool
     ) -> None:
-        if not self.debug_enabled:
+        if not logger.isEnabledFor(logging.DEBUG):
             return
         car_nodes, fused_nodes, direct, add, fused_add = self._collect_candidates(
             graph
@@ -516,7 +512,7 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
             f'{car.name}->{fused_node.name}'
             for car, fused_node in fused_add[:4]
         ]
-        logger.warning(
+        logger.debug(
             'MUSA CAR-RMSNorm candidates %s fusion pass #%d: '
             'car=%d fused_ar_rms=%d direct_car_rmsnorm=%d '
             'add_car_rmsnorm=%d fused_add_car_rmsnorm=%d other_car=%d; '
@@ -538,10 +534,8 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
             cls._candidate_total_fused_add,
             examples,
         )
-        if not self.debug_enabled:
-            return
         for idx, fused in enumerate(fused_nodes):
-            logger.warning(
+            logger.debug(
                 'MUSA CAR-RMSNorm fused node %s pass #%d idx=%d fused={%s}',
                 stage,
                 pass_id,
@@ -549,7 +543,7 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
                 self._node_debug(fused),
             )
         for idx, (car, rms) in enumerate(direct):
-            logger.warning(
+            logger.debug(
                 'MUSA CAR-RMSNorm direct candidate %s pass #%d idx=%d car={%s} rms={%s}',
                 stage,
                 pass_id,
@@ -558,7 +552,7 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
                 self._node_debug(rms),
             )
         for idx, (car, add_node, rms) in enumerate(add):
-            logger.warning(
+            logger.debug(
                 'MUSA CAR-RMSNorm add candidate %s pass #%d idx=%d car={%s} add={%s} rms={%s}',
                 stage,
                 pass_id,
@@ -568,7 +562,7 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
                 self._node_debug(rms),
             )
         for idx, (car, fused_add_node) in enumerate(fused_add):
-            logger.warning(
+            logger.debug(
                 'MUSA CAR-RMSNorm fused-add candidate %s pass #%d idx=%d '
                 'car={%s} fused_add={%s}',
                 stage,
@@ -656,8 +650,8 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
 
             # vLLM 0.24 lowers add + RMSNorm to a two-output IR node:
             # fused_add_rms_norm(CAR, residual, weight, eps) -> (rms, residual).
-            # Keep the proven 0.22 SGLang-port raw/no-raw user routing and only
-            # adapt how this combined node's inputs and outputs are accessed.
+            # Keep the raw/no-raw user routing and adapt only how this combined
+            # node's inputs and outputs are accessed.
             rewrote_fused_add = False
             fused_add_users = [
                 user

--- a/vllm_musa/_inductor/musa_allreduce_rms_fusion.py
+++ b/vllm_musa/_inductor/musa_allreduce_rms_fusion.py
@@ -258,6 +258,8 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
         super().__init__(config)
         self.disabled = True
         self.max_token_num: int | None = None
+        self.max_tokens_by_comm: int | None = None
+        self.jit_comm_max_size: int | None = None
         if not current_platform.is_musa():
             return
 
@@ -312,23 +314,68 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
             )
             return
 
+        jit_comm_max_size = getattr(jit_comm, "max_size", None)
+        if not isinstance(jit_comm_max_size, int) or jit_comm_max_size <= 0:
+            logger.warning_once(
+                "MUSA allreduce-rmsnorm fusion disabled: invalid JIT comm "
+                "max_size=%r.",
+                jit_comm_max_size,
+            )
+            return
+        element_size = torch.empty((), dtype=self.model_dtype).element_size()
+        max_tokens_by_comm = self._max_fusable_tokens(
+            None, jit_comm_max_size, self.hidden_dim, element_size
+        )
+        if max_tokens_by_comm < 1:
+            logger.warning_once(
+                "MUSA allreduce-rmsnorm fusion disabled: JIT comm max_size=%d "
+                "cannot hold one token for hidden_dim=%d dtype=%s.",
+                jit_comm_max_size,
+                self.hidden_dim,
+                self.model_dtype,
+            )
+            return
+
         # Reuse the JIT communicator registry that already owns the compiled
         # custom-allreduce ABI and removes the id during communicator close.
         self.comm_id = self.jit_comm_id
         self.patterns = PatternMatcherPass(pass_name="musa_all_reduce_rms_fusion_pass")
-        self.max_token_num = config.scheduler_config.max_num_batched_tokens
+        self.jit_comm_max_size = jit_comm_max_size
+        self.max_tokens_by_comm = max_tokens_by_comm
+        self.max_token_num = self._max_fusable_tokens(
+            config.scheduler_config.max_num_batched_tokens,
+            jit_comm_max_size,
+            self.hidden_dim,
+            element_size,
+        )
         self.register_patterns()
         self.dump_patterns(config, self.patterns)
         logger.warning_once(
             "MUSA allreduce-rmsnorm fusion pass enabled: group=%s tp_size=%d "
-            "hidden_dim=%d max_token_num=%s comm_id=%d jit_comm_id=%d.",
+            "hidden_dim=%d max_token_num=%s max_tokens_by_comm=%d comm_id=%d "
+            "jit_comm_id=%d.",
             self.group_name,
             self.tp_size,
             self.hidden_dim,
             self.max_token_num,
+            self.max_tokens_by_comm,
             self.comm_id,
             self.jit_comm_id,
         )
+
+    @staticmethod
+    def _max_fusable_tokens(
+        scheduler_limit: int | None,
+        max_size: int,
+        hidden_dim: int,
+        element_size: int,
+    ) -> int:
+        if max_size <= 0 or hidden_dim <= 0 or element_size <= 0:
+            return 0
+        max_tokens = max_size // (hidden_dim * element_size)
+        if scheduler_limit is None:
+            return max_tokens
+        return min(scheduler_limit, max_tokens)
 
     @enable_fake_mode
     def register_patterns(self) -> None:
@@ -372,6 +419,8 @@ class MusaAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
             ),
             "enabled": not self.disabled,
             "max_token_num": self.max_token_num,
+            "max_tokens_by_comm": self.max_tokens_by_comm,
+            "jit_comm_max_size": self.jit_comm_max_size,
         }
         if not self.disabled:
             state.update(

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -12,6 +12,7 @@ from vllm.logger import init_logger
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_musa.jit_kernel.csrc import allreduce as jit_ar
+from vllm_musa.utils.environ import envs
 
 logger = init_logger(__name__)
 _INT32_MAX = (1 << 31) - 1
@@ -210,14 +211,24 @@ def _register_comm(comm: Any) -> int:
     return comm_id
 
 
-def _musa_jit_custom_all_reduce(input: torch.Tensor, comm_id: int) -> torch.Tensor:
+def get_musa_jit_custom_allreduce_comm(comm_id: int) -> Any:
+    """Return the live JIT communicator referenced by compiled custom ops."""
     comm = _COMM_REGISTRY.get(int(comm_id))
     if comm is None:
-        raise RuntimeError(f"MUSA JIT custom all-reduce communicator {comm_id} is gone")
+        raise RuntimeError(
+            f"MUSA JIT custom all-reduce communicator {comm_id} is gone"
+        )
+    return comm
+
+
+def _musa_jit_custom_all_reduce(input: torch.Tensor, comm_id: int) -> torch.Tensor:
+    comm = get_musa_jit_custom_allreduce_comm(comm_id)
     return comm._custom_all_reduce_impl(input)
 
 
-def _musa_jit_custom_all_reduce_fake(input: torch.Tensor, comm_id: int) -> torch.Tensor:
+def _musa_jit_custom_all_reduce_fake(
+    input: torch.Tensor, comm_id: int
+) -> torch.Tensor:
     return torch.empty_like(input)
 
 
@@ -225,6 +236,95 @@ direct_register_custom_op(
     op_name="musa_jit_custom_all_reduce",
     op_func=_musa_jit_custom_all_reduce,
     fake_impl=_musa_jit_custom_all_reduce_fake,
+)
+
+
+def _musa_jit_fused_allreduce_rmsnorm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    comm = get_musa_jit_custom_allreduce_comm(comm_id)
+    return comm._fused_allreduce_rmsnorm_impl(input, weight, float(eps))
+
+
+def _musa_jit_fused_allreduce_rmsnorm_fake(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    _ = weight, eps, comm_id
+    return torch.empty_like(input), torch.empty_like(input)
+
+
+direct_register_custom_op(
+    op_name="musa_jit_fused_allreduce_rmsnorm",
+    op_func=_musa_jit_fused_allreduce_rmsnorm,
+    fake_impl=_musa_jit_fused_allreduce_rmsnorm_fake,
+)
+
+
+def _musa_jit_fused_allreduce_residual_rmsnorm(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    comm = get_musa_jit_custom_allreduce_comm(comm_id)
+    return comm._fused_allreduce_residual_rmsnorm_impl(
+        input, residual, weight, float(eps)
+    )
+
+
+def _musa_jit_fused_allreduce_residual_rmsnorm_no_raw(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    comm = get_musa_jit_custom_allreduce_comm(comm_id)
+    return comm._fused_allreduce_residual_rmsnorm_no_raw_impl(
+        input, residual, weight, float(eps)
+    )
+
+
+def _musa_jit_fused_allreduce_residual_rmsnorm_fake(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    _ = residual, weight, eps, comm_id
+    return torch.empty_like(input), torch.empty_like(input), torch.empty_like(input)
+
+
+def _musa_jit_fused_allreduce_residual_rmsnorm_no_raw_fake(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    _ = residual, weight, eps, comm_id
+    return torch.empty_like(input), torch.empty_like(input)
+
+
+direct_register_custom_op(
+    op_name="musa_jit_fused_allreduce_residual_rmsnorm",
+    op_func=_musa_jit_fused_allreduce_residual_rmsnorm,
+    fake_impl=_musa_jit_fused_allreduce_residual_rmsnorm_fake,
+)
+
+
+direct_register_custom_op(
+    op_name="musa_jit_fused_allreduce_residual_rmsnorm_no_raw",
+    op_func=_musa_jit_fused_allreduce_residual_rmsnorm_no_raw,
+    fake_impl=_musa_jit_fused_allreduce_residual_rmsnorm_no_raw_fake,
 )
 
 
@@ -307,6 +407,7 @@ def _free_own_shared_buffer(
 class _MusaJitCustomAllreduceImpl:
     _SUPPORTED_WORLD_SIZES = (2, 4, 6, 8)
     _MAX_CAR_SIZE = 512 * 1024 * 1024
+    _GRAPH_REGISTERED_INPUT_MAX_BYTES = 512 * 1024
 
     def __init__(
         self,
@@ -334,6 +435,11 @@ class _MusaJitCustomAllreduceImpl:
         self._graph_peer_bases: dict[tuple[int, bytes], int] = {}
         self._graph_opened_ptrs: list[int] = []
         self._next_graph_slot = 0
+        self._graph_registered_input_enabled = (
+            self._use_graph_registered_inputs
+            and envs.VLLM_MUSA_FUSED_AR_RMSNORM.get()
+            and envs.VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT.get()
+        )
 
         if isinstance(device, int):
             device = torch.device(f"musa:{device}")
@@ -404,6 +510,14 @@ class _MusaJitCustomAllreduceImpl:
                 dtype=torch.int64,
                 device=self.device,
             )
+            if self._graph_registered_input_enabled:
+                logger.info_once(
+                    "MUSA fused CAR-RMSNorm graph registered-input path is enabled "
+                    "(capacity=%d, max_input_bytes=%d). Eager execution and larger "
+                    "graph inputs use the staging path.",
+                    graph_slots,
+                    self._GRAPH_REGISTERED_INPUT_MAX_BYTES,
+                )
         else:
             logger.info_once(
                 "Using fixed-staging MUSA JIT custom all-reduce for "
@@ -419,15 +533,20 @@ class _MusaJitCustomAllreduceImpl:
 
     @contextmanager
     def capture(self):
+        if self._IS_CAPTURING:
+            raise RuntimeError("Nested MUSA custom-allreduce capture is unsupported")
         self._pending_graph_inputs = []
+        capture_succeeded = False
         try:
             self._IS_CAPTURING = True
             yield
+            capture_succeeded = True
         finally:
             try:
-                if self._pending_graph_inputs:
+                if capture_succeeded and self._pending_graph_inputs:
                     self._register_graph_buffers()
             finally:
+                self._pending_graph_inputs = []
                 self._IS_CAPTURING = False
 
     def _graph_pointer_meta(self, tensor: torch.Tensor) -> tuple[bytes, int]:
@@ -509,6 +628,31 @@ class _MusaJitCustomAllreduceImpl:
         self._pending_graph_inputs = []
         self._next_graph_slot = end
 
+    def _graph_rank_data_for_input(self, tensor: torch.Tensor) -> torch.Tensor:
+        assert self.graph_rank_data is not None
+        slot = self._next_graph_slot + len(self._pending_graph_inputs)
+        if slot >= self.graph_rank_data.shape[0]:
+            raise RuntimeError(
+                "MUSA custom AR graph rank-data buffer is full: "
+                f"slot={slot}, capacity={self.graph_rank_data.shape[0]}"
+            )
+        self._pending_graph_inputs.append(tensor)
+        return self.graph_rank_data[slot]
+
+    def _graph_registered_input_eligible(self, tensor: torch.Tensor) -> bool:
+        return (
+            self._graph_registered_input_enabled
+            and tensor.numel() * tensor.element_size()
+            <= self._GRAPH_REGISTERED_INPUT_MAX_BYTES
+        )
+
+    def _use_registered_graph_input(self, tensor: torch.Tensor) -> bool:
+        return (
+            self._graph_registered_input_eligible(tensor)
+            and self._IS_CAPTURING
+            and self._is_current_stream_capturing()
+        )
+
     def should_custom_ar(self, inp: torch.Tensor) -> bool:
         if self.disabled:
             return False
@@ -567,10 +711,75 @@ class _MusaJitCustomAllreduceImpl:
         except Exception:
             return False
 
+    def _reject_fused_allreduce_rmsnorm_reason(
+        self, inp: torch.Tensor, weight: torch.Tensor
+    ) -> str | None:
+        if not envs.VLLM_MUSA_FUSED_AR_RMSNORM.get():
+            return "VLLM_MUSA_FUSED_AR_RMSNORM is disabled"
+        if self.disabled:
+            return "communicator is disabled"
+        if inp.device.type != "musa" or weight.device.type != "musa":
+            return f"device mismatch: input={inp.device} weight={weight.device}"
+        if inp.dim() != 2 or weight.dim() != 1:
+            return f"dim mismatch: input_dim={inp.dim()} weight_dim={weight.dim()}"
+        hidden_size = inp.shape[-1]
+        if hidden_size <= 0 or hidden_size != weight.numel():
+            return f"hidden/weight mismatch: hidden={hidden_size} weight_numel={weight.numel()}"
+        if hidden_size % 8 != 0 or hidden_size > 32768:
+            return f"unsupported hidden size: hidden={hidden_size}"
+        if inp.dtype not in (torch.float16, torch.bfloat16):
+            return f"unsupported input dtype: {inp.dtype}"
+        if weight.dtype not in (inp.dtype, torch.float32):
+            return (
+                "unsupported weight dtype for fused RMSNorm: "
+                f"input={inp.dtype} weight={weight.dtype}"
+            )
+        if not inp.is_contiguous() or not weight.is_contiguous():
+            return (
+                "non-contiguous input/weight: "
+                f"input_stride={inp.stride()} weight_stride={weight.stride()}"
+            )
+        inp_size = inp.numel() * inp.element_size()
+        if inp_size % 16 != 0 or inp_size > self.max_size:
+            return f"unsupported byte size: bytes={inp_size} max_size={self.max_size}"
+        return None
+
+    def should_fused_allreduce_rmsnorm(
+        self, inp: torch.Tensor, weight: torch.Tensor
+    ) -> bool:
+        return self._reject_fused_allreduce_rmsnorm_reason(inp, weight) is None
+
+    def _reject_fused_allreduce_residual_rmsnorm_reason(
+        self, inp: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor
+    ) -> str | None:
+        base_reason = self._reject_fused_allreduce_rmsnorm_reason(inp, weight)
+        if base_reason is not None:
+            return base_reason
+        if residual.device.type != "musa":
+            return f"residual device mismatch: residual={residual.device}"
+        if residual.dim() != 2 or residual.shape != inp.shape:
+            return (
+                "residual shape mismatch: "
+                f"input_shape={tuple(inp.shape)} residual_shape={tuple(residual.shape)}"
+            )
+        if residual.dtype != inp.dtype:
+            return f"residual dtype mismatch: input={inp.dtype} residual={residual.dtype}"
+        if not residual.is_contiguous():
+            return f"non-contiguous residual: residual_stride={residual.stride()}"
+        return None
+
+    def should_fused_allreduce_residual_rmsnorm(
+        self, inp: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor
+    ) -> bool:
+        return (
+            self._reject_fused_allreduce_residual_rmsnorm_reason(inp, residual, weight)
+            is None
+        )
+
     @staticmethod
     def _is_current_stream_capturing() -> bool:
         try:
-            return bool(torch.cuda.is_current_stream_capturing())
+            return bool(torch.get_device_module().is_current_stream_capturing())
         except Exception:
             return False
 
@@ -637,15 +846,11 @@ class _MusaJitCustomAllreduceImpl:
         return out
 
     def _graph_custom_all_reduce_impl(self, input: torch.Tensor) -> torch.Tensor:
-        assert self.graph_rank_data is not None
         assert self.signal_ptrs_cpu is not None
-        slot = self._next_graph_slot + len(self._pending_graph_inputs)
-        if slot >= self.graph_rank_data.shape[0]:
-            raise RuntimeError("MUSA custom AR graph rank-data buffer is full")
+        rank_data = self._graph_rank_data_for_input(input)
         out = torch.empty_like(input)
-        self._pending_graph_inputs.append(input)
         jit_ar.launch_graph_registered(
-            self.graph_rank_data[slot],
+            rank_data,
             self.signal_ptrs_cpu,
             input,
             out,
@@ -699,6 +904,194 @@ class _MusaJitCustomAllreduceImpl:
             self.world_size,
         )
         return out
+
+    def _fused_allreduce_rmsnorm_custom_op(
+        self, input: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self._comm_id is not None
+        return torch.ops.vllm.musa_jit_fused_allreduce_rmsnorm(
+            input, weight, float(eps), self._comm_id
+        )
+
+    def fused_allreduce_rmsnorm(
+        self, input: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if not self.should_fused_allreduce_rmsnorm(input, weight):
+            return None
+        if self._IS_CAPTURING:
+            if not self._is_current_stream_capturing():
+                return torch.empty_like(input), torch.empty_like(input)
+            return self._fused_allreduce_rmsnorm_custom_op(input, weight, eps)
+        if self._is_torch_compiling():
+            return self._fused_allreduce_rmsnorm_custom_op(input, weight, eps)
+        return self._fused_allreduce_rmsnorm_impl(input, weight, eps)
+
+    def _fused_allreduce_rmsnorm_impl(
+        self, input: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self.buffer_rank_data is not None
+        norm_out = torch.empty_like(input)
+        reduced = torch.empty_like(input)
+        shot = jit_ar.preferred_shot(
+            self.world_size, input.numel() * input.element_size()
+        )
+        use_registered = self._use_registered_graph_input(input)
+        rank_data = (
+            self._graph_rank_data_for_input(input)
+            if use_registered
+            else self.buffer_rank_data
+        )
+        launcher = (
+            jit_ar.launch_fused_allreduce_rmsnorm_registered
+            if use_registered
+            else jit_ar.launch_fused_allreduce_rmsnorm_unregistered
+        )
+        launcher(
+            rank_data,
+            self.signal_ptrs_cpu,
+            input,
+            weight,
+            norm_out,
+            reduced,
+            self.meta_ptrs[self.rank],
+            self.buffer_ptrs[self.rank],
+            self.max_size,
+            self.rank,
+            self.world_size,
+            shot,
+            float(eps),
+        )
+        return norm_out, reduced
+
+    def _fused_allreduce_residual_rmsnorm_custom_op(
+        self, input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert self._comm_id is not None
+        return torch.ops.vllm.musa_jit_fused_allreduce_residual_rmsnorm(
+            input, residual, weight, float(eps), self._comm_id
+        )
+
+    def _fused_allreduce_residual_rmsnorm_no_raw_custom_op(
+        self, input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self._comm_id is not None
+        return torch.ops.vllm.musa_jit_fused_allreduce_residual_rmsnorm_no_raw(
+            input, residual, weight, float(eps), self._comm_id
+        )
+
+    def fused_allreduce_residual_rmsnorm(
+        self, input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+        if not self.should_fused_allreduce_residual_rmsnorm(input, residual, weight):
+            return None
+        if self._IS_CAPTURING:
+            if not self._is_current_stream_capturing():
+                return torch.empty_like(input), torch.empty_like(input), torch.empty_like(input)
+            return self._fused_allreduce_residual_rmsnorm_custom_op(
+                input, residual, weight, eps
+            )
+        if self._is_torch_compiling():
+            return self._fused_allreduce_residual_rmsnorm_custom_op(
+                input, residual, weight, eps
+            )
+        return self._fused_allreduce_residual_rmsnorm_impl(input, residual, weight, eps)
+
+    def fused_allreduce_residual_rmsnorm_no_raw(
+        self, input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if not self.should_fused_allreduce_residual_rmsnorm(input, residual, weight):
+            return None
+        if self._IS_CAPTURING:
+            if not self._is_current_stream_capturing():
+                return torch.empty_like(input), torch.empty_like(input)
+            return self._fused_allreduce_residual_rmsnorm_no_raw_custom_op(
+                input, residual, weight, eps
+            )
+        if self._is_torch_compiling():
+            return self._fused_allreduce_residual_rmsnorm_no_raw_custom_op(
+                input, residual, weight, eps
+            )
+        return self._fused_allreduce_residual_rmsnorm_no_raw_impl(
+            input, residual, weight, eps
+        )
+
+    def _fused_allreduce_residual_rmsnorm_impl(
+        self, input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert self.buffer_rank_data is not None
+        norm_out = torch.empty_like(input)
+        residual_out = torch.empty_like(input)
+        reduced = torch.empty_like(input)
+        shot = jit_ar.preferred_shot(
+            self.world_size, input.numel() * input.element_size()
+        )
+        use_registered = self._use_registered_graph_input(input)
+        rank_data = (
+            self._graph_rank_data_for_input(input)
+            if use_registered
+            else self.buffer_rank_data
+        )
+        launcher = (
+            jit_ar.launch_fused_allreduce_residual_rmsnorm_registered
+            if use_registered
+            else jit_ar.launch_fused_allreduce_residual_rmsnorm_unregistered
+        )
+        launcher(
+            rank_data,
+            self.signal_ptrs_cpu,
+            input,
+            residual,
+            weight,
+            norm_out,
+            residual_out,
+            reduced,
+            self.meta_ptrs[self.rank],
+            self.buffer_ptrs[self.rank],
+            self.max_size,
+            self.rank,
+            self.world_size,
+            shot,
+            float(eps),
+        )
+        return norm_out, residual_out, reduced
+
+    def _fused_allreduce_residual_rmsnorm_no_raw_impl(
+        self, input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self.buffer_rank_data is not None
+        norm_out = torch.empty_like(input)
+        residual_out = torch.empty_like(input)
+        shot = jit_ar.preferred_shot(
+            self.world_size, input.numel() * input.element_size()
+        )
+        use_registered = self._use_registered_graph_input(input)
+        rank_data = (
+            self._graph_rank_data_for_input(input)
+            if use_registered
+            else self.buffer_rank_data
+        )
+        launcher = (
+            jit_ar.launch_fused_allreduce_residual_rmsnorm_no_raw_registered
+            if use_registered
+            else jit_ar.launch_fused_allreduce_residual_rmsnorm_no_raw_unregistered
+        )
+        launcher(
+            rank_data,
+            self.signal_ptrs_cpu,
+            input,
+            residual,
+            weight,
+            norm_out,
+            residual_out,
+            self.meta_ptrs[self.rank],
+            self.buffer_ptrs[self.rank],
+            self.max_size,
+            self.rank,
+            self.world_size,
+            shot,
+            float(eps),
+        )
+        return norm_out, residual_out
 
     def close(self) -> None:
         if self.meta_opened_ipc_ptrs:
@@ -809,6 +1202,23 @@ class MusaJitCustomAllreduce:
     def should_custom_ar(self, inp: torch.Tensor) -> bool:
         return self._jit_available and self._jit_comm.should_custom_ar(inp)
 
+    def should_fused_allreduce_rmsnorm(
+        self, inp: torch.Tensor, weight: torch.Tensor
+    ) -> bool:
+        return self._jit_available and self._jit_comm.should_fused_allreduce_rmsnorm(
+            inp, weight
+        )
+
+    def should_fused_allreduce_residual_rmsnorm(
+        self, inp: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor
+    ) -> bool:
+        return (
+            self._jit_available
+            and self._jit_comm.should_fused_allreduce_residual_rmsnorm(
+                inp, residual, weight
+            )
+        )
+
     def custom_all_reduce(self, input: torch.Tensor) -> torch.Tensor | None:
         if self._jit_available and self._jit_comm.should_custom_ar(input):
             return self._jit_comm.custom_all_reduce(input)
@@ -824,6 +1234,67 @@ class MusaJitCustomAllreduce:
             input, dim, output_dtype
         ):
             return self._jit_comm.custom_all_gather(input, dim, output_dtype)
+        return None
+
+    def fused_allreduce_rmsnorm(
+        self, input: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if self._jit_available and self._jit_comm.should_fused_allreduce_rmsnorm(
+            input, weight
+        ):
+            return self._jit_comm.fused_allreduce_rmsnorm(input, weight, eps)
+        return None
+
+    def reject_fused_allreduce_residual_rmsnorm_reason(
+        self, inp: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor
+    ) -> str | None:
+        if not self._jit_available:
+            return "JIT communicator is unavailable"
+        return self._jit_comm._reject_fused_allreduce_residual_rmsnorm_reason(
+            inp, residual, weight
+        )
+
+    def fused_allreduce_residual_rmsnorm(
+        self, input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+        if (
+            self._jit_available
+            and self._jit_comm.should_fused_allreduce_residual_rmsnorm(
+                input, residual, weight
+            )
+        ):
+            return self._jit_comm.fused_allreduce_residual_rmsnorm(
+                input, residual, weight, eps
+            )
+        if self._jit_available:
+            logger.warning_once(
+                "MUSA JIT fused allreduce-residual-rmsnorm rejected tensor: %s",
+                self._jit_comm._reject_fused_allreduce_residual_rmsnorm_reason(
+                    input, residual, weight
+                ),
+            )
+        return None
+
+
+    def fused_allreduce_residual_rmsnorm_no_raw(
+        self, input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if (
+            self._jit_available
+            and self._jit_comm.should_fused_allreduce_residual_rmsnorm(
+                input, residual, weight
+            )
+        ):
+            return self._jit_comm.fused_allreduce_residual_rmsnorm_no_raw(
+                input, residual, weight, eps
+            )
+        if self._jit_available:
+            logger.warning_once(
+                "MUSA JIT fused allreduce-residual-rmsnorm no-raw rejected tensor: %s",
+                self._jit_comm._reject_fused_allreduce_residual_rmsnorm_reason(
+                    input, residual, weight
+                ),
+            )
         return None
 
     def close(self) -> None:

--- a/vllm_musa/fused_allreduce_rmsnorm_ops.py
+++ b/vllm_musa/fused_allreduce_rmsnorm_ops.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA CAR-RMSNorm fused-op bring-up helpers.
+
+This module exposes opaque custom ops to Inductor and routes runtime execution
+to the MUSA JIT fused custom-allreduce + RMSNorm implementations. The graph-level
+ABIs return both the RMSNorm output and the tensor preserved for downstream graph
+users: all-reduced tensor for the no-residual path; residual output plus raw
+all-reduced tensor for the residual path.
+"""
+
+from __future__ import annotations
+
+import torch
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from vllm.logger import init_logger
+from vllm_musa.distributed.device_communicators.musa_jit_custom_all_reduce import (
+    get_musa_jit_custom_allreduce_comm,
+)
+
+logger = init_logger(__name__)
+
+
+def _musa_fused_allreduce_rms_norm_impl(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Runtime implementation: use the registered MUSA JIT fused kernel."""
+    comm = get_musa_jit_custom_allreduce_comm(comm_id)
+    result = comm.fused_allreduce_rmsnorm(input, weight, float(eps))
+    if result is None:
+        raise RuntimeError(
+            "MUSA fused allreduce-rmsnorm requires the registered communicator "
+            "to accept this tensor for fused custom all-reduce + RMSNorm"
+        )
+    return result
+
+
+def _musa_fused_allreduce_rms_norm_fake(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del weight, eps, comm_id
+    return torch.empty_like(input), torch.empty_like(input)
+
+
+def _musa_fused_allreduce_residual_rms_norm_impl(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Runtime implementation: use the registered MUSA JIT residual fused kernel."""
+    comm = get_musa_jit_custom_allreduce_comm(comm_id)
+    result = comm.fused_allreduce_residual_rmsnorm(
+        input, residual, weight, float(eps)
+    )
+    if result is None:
+        reason_fn = getattr(comm, "reject_fused_allreduce_residual_rmsnorm_reason", None)
+        reason = (
+            reason_fn(input, residual, weight)
+            if callable(reason_fn)
+            else "registered communicator did not provide a rejection reason"
+        )
+        raise RuntimeError(
+            "MUSA fused allreduce-residual-rmsnorm requires the registered "
+            "communicator to accept these tensors for fused custom all-reduce + "
+            f"residual + RMSNorm; rejection reason: {reason}"
+        )
+    return result
+
+
+def _musa_fused_allreduce_residual_rms_norm_no_raw_impl(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Runtime implementation for residual fused kernel without raw CAR output."""
+    comm = get_musa_jit_custom_allreduce_comm(comm_id)
+    result = comm.fused_allreduce_residual_rmsnorm_no_raw(
+        input, residual, weight, float(eps)
+    )
+    if result is None:
+        reason_fn = getattr(comm, "reject_fused_allreduce_residual_rmsnorm_reason", None)
+        reason = (
+            reason_fn(input, residual, weight)
+            if callable(reason_fn)
+            else "registered communicator did not provide a rejection reason"
+        )
+        raise RuntimeError(
+            "MUSA fused allreduce-residual-rmsnorm no-raw requires the registered "
+            "communicator to accept these tensors for fused custom all-reduce + "
+            f"residual + RMSNorm; rejection reason: {reason}"
+        )
+    return result
+
+
+def _musa_fused_allreduce_residual_rms_norm_fake(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    del residual, weight, eps, comm_id
+    return torch.empty_like(input), torch.empty_like(input), torch.empty_like(input)
+
+
+def _musa_fused_allreduce_residual_rms_norm_no_raw_fake(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del residual, weight, eps, comm_id
+    return torch.empty_like(input), torch.empty_like(input)
+
+
+try:
+    direct_register_custom_op(
+        op_name="musa_fused_allreduce_rms_norm",
+        op_func=_musa_fused_allreduce_rms_norm_impl,
+        fake_impl=_musa_fused_allreduce_rms_norm_fake,
+    )
+except RuntimeError as exc:
+    # The module can be imported more than once in plugin-heavy processes.
+    if "musa_fused_allreduce_rms_norm" not in str(exc):
+        raise
+    logger.debug("MUSA fused allreduce-rmsnorm custom op already registered")
+
+
+try:
+    direct_register_custom_op(
+        op_name="musa_fused_allreduce_residual_rms_norm",
+        op_func=_musa_fused_allreduce_residual_rms_norm_impl,
+        fake_impl=_musa_fused_allreduce_residual_rms_norm_fake,
+    )
+except RuntimeError as exc:
+    # The module can be imported more than once in plugin-heavy processes.
+    if "musa_fused_allreduce_residual_rms_norm" not in str(exc):
+        raise
+    logger.debug(
+        "MUSA fused allreduce-residual-rmsnorm custom op already registered"
+    )
+
+
+try:
+    direct_register_custom_op(
+        op_name="musa_fused_allreduce_residual_rms_norm_no_raw",
+        op_func=_musa_fused_allreduce_residual_rms_norm_no_raw_impl,
+        fake_impl=_musa_fused_allreduce_residual_rms_norm_no_raw_fake,
+    )
+except RuntimeError as exc:
+    # The module can be imported more than once in plugin-heavy processes.
+    if "musa_fused_allreduce_residual_rms_norm_no_raw" not in str(exc):
+        raise
+    logger.debug(
+        "MUSA fused allreduce-residual-rmsnorm no-raw custom op already registered"
+    )
+
+
+def musa_fused_allreduce_rms_norm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.vllm.musa_fused_allreduce_rms_norm(
+        input,
+        weight,
+        eps,
+        comm_id,
+    )
+
+
+def musa_fused_allreduce_residual_rms_norm(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return torch.ops.vllm.musa_fused_allreduce_residual_rms_norm(
+        input,
+        residual,
+        weight,
+        eps,
+        comm_id,
+    )
+
+
+def musa_fused_allreduce_residual_rms_norm_no_raw(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    comm_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.vllm.musa_fused_allreduce_residual_rms_norm_no_raw(
+        input,
+        residual,
+        weight,
+        eps,
+        comm_id,
+    )

--- a/vllm_musa/fused_allreduce_rmsnorm_ops.py
+++ b/vllm_musa/fused_allreduce_rmsnorm_ops.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""MUSA CAR-RMSNorm fused-op bring-up helpers.
+"""MUSA CAR-RMSNorm fused custom-op bindings.
 
 This module exposes opaque custom ops to Inductor and routes runtime execution
 to the MUSA JIT fused custom-allreduce + RMSNorm implementations. The graph-level

--- a/vllm_musa/jit_kernel/csrc/allreduce.py
+++ b/vllm_musa/jit_kernel/csrc/allreduce.py
@@ -161,3 +161,227 @@ def launch_graph_registered(
         int(world_size),
         int(shot),
     )
+
+
+def launch_fused_allreduce_rmsnorm_unregistered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    weight: torch.Tensor,
+    norm_out: torch.Tensor,
+    reduced: torch.Tensor,
+    self_signal_ptr: int,
+    self_buffer_ptr: int,
+    max_size_bytes: int,
+    rank: int,
+    world_size: int,
+    shot: int,
+    eps: float,
+) -> None:
+    _custom_ar_module(int(world_size)).vllm_musa_fused_ar_rmsnorm_launch_unregistered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        weight,
+        norm_out,
+        reduced,
+        int(self_signal_ptr),
+        int(self_buffer_ptr),
+        int(max_size_bytes),
+        int(rank),
+        int(world_size),
+        int(shot),
+        float(eps),
+    )
+
+
+def launch_fused_allreduce_residual_rmsnorm_unregistered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    norm_out: torch.Tensor,
+    residual_out: torch.Tensor,
+    reduced: torch.Tensor,
+    self_signal_ptr: int,
+    self_buffer_ptr: int,
+    max_size_bytes: int,
+    rank: int,
+    world_size: int,
+    shot: int,
+    eps: float,
+) -> None:
+    _custom_ar_module(
+        int(world_size)
+    ).vllm_musa_fused_ar_residual_rmsnorm_launch_unregistered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        residual,
+        weight,
+        norm_out,
+        residual_out,
+        reduced,
+        int(self_signal_ptr),
+        int(self_buffer_ptr),
+        int(max_size_bytes),
+        int(rank),
+        int(world_size),
+        int(shot),
+        float(eps),
+    )
+
+
+def launch_fused_allreduce_residual_rmsnorm_no_raw_unregistered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    norm_out: torch.Tensor,
+    residual_out: torch.Tensor,
+    self_signal_ptr: int,
+    self_buffer_ptr: int,
+    max_size_bytes: int,
+    rank: int,
+    world_size: int,
+    shot: int,
+    eps: float,
+) -> None:
+    _custom_ar_module(
+        int(world_size)
+    ).vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        residual,
+        weight,
+        norm_out,
+        residual_out,
+        int(self_signal_ptr),
+        int(self_buffer_ptr),
+        int(max_size_bytes),
+        int(rank),
+        int(world_size),
+        int(shot),
+        float(eps),
+    )
+
+
+def _check_registered_rank_data(rank_data: torch.Tensor) -> None:
+    if rank_data.device.type == "cpu":
+        raise ValueError(
+            "registered MUSA custom-allreduce rank_data must be a device tensor"
+        )
+
+
+def launch_fused_allreduce_rmsnorm_registered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    weight: torch.Tensor,
+    norm_out: torch.Tensor,
+    reduced: torch.Tensor,
+    self_signal_ptr: int,
+    self_buffer_ptr: int,
+    max_size_bytes: int,
+    rank: int,
+    world_size: int,
+    shot: int,
+    eps: float,
+) -> None:
+    """Launch fused AR-RMSNorm from device-resident peer input pointers.
+
+    The FFI entry is shared with the staging launcher. CPU rank_data selects
+    the existing staging copy; MUSA rank_data selects the registered-input
+    path and skips that copy.
+    """
+    _check_registered_rank_data(rank_data)
+    launch_fused_allreduce_rmsnorm_unregistered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        weight,
+        norm_out,
+        reduced,
+        self_signal_ptr,
+        self_buffer_ptr,
+        max_size_bytes,
+        rank,
+        world_size,
+        shot,
+        eps,
+    )
+
+
+def launch_fused_allreduce_residual_rmsnorm_registered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    norm_out: torch.Tensor,
+    residual_out: torch.Tensor,
+    reduced: torch.Tensor,
+    self_signal_ptr: int,
+    self_buffer_ptr: int,
+    max_size_bytes: int,
+    rank: int,
+    world_size: int,
+    shot: int,
+    eps: float,
+) -> None:
+    _check_registered_rank_data(rank_data)
+    launch_fused_allreduce_residual_rmsnorm_unregistered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        residual,
+        weight,
+        norm_out,
+        residual_out,
+        reduced,
+        self_signal_ptr,
+        self_buffer_ptr,
+        max_size_bytes,
+        rank,
+        world_size,
+        shot,
+        eps,
+    )
+
+
+def launch_fused_allreduce_residual_rmsnorm_no_raw_registered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    norm_out: torch.Tensor,
+    residual_out: torch.Tensor,
+    self_signal_ptr: int,
+    self_buffer_ptr: int,
+    max_size_bytes: int,
+    rank: int,
+    world_size: int,
+    shot: int,
+    eps: float,
+) -> None:
+    _check_registered_rank_data(rank_data)
+    launch_fused_allreduce_residual_rmsnorm_no_raw_unregistered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        residual,
+        weight,
+        norm_out,
+        residual_out,
+        self_signal_ptr,
+        self_buffer_ptr,
+        max_size_bytes,
+        rank,
+        world_size,
+        shot,
+        eps,
+    )

--- a/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
+++ b/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
@@ -32,31 +32,15 @@ namespace {
 #define SGL_CUSTOM_AR_MAX_BLOCKS 120
 #endif
 
-// SGLang MR413 TP2 fast paths, adapted to the vLLM raw/no-raw ABI.
-#ifndef VLLM_MUSA_FUSED_AR_TP2_REGCACHE
-#define VLLM_MUSA_FUSED_AR_TP2_REGCACHE 1
-#endif
-
-#ifndef VLLM_MUSA_FUSED_AR_TP2_VEC2RANK
-#define VLLM_MUSA_FUSED_AR_TP2_VEC2RANK 1
-#endif
-
 // Limit the TP4 rows=64, hidden=2048 fused two-shot grid to 32 blocks. The
 // grid-stride loops still cover all rows while halving block-indexed cross-rank
 // synchronization groups relative to the generic 64-block launch.
-#ifndef VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP
-#define VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP 32
-#endif
-
 constexpr int kMaxBlocks = SGL_CUSTOM_AR_MAX_BLOCKS;
 constexpr int kMaxThreadsPerBlock = 1024;
 constexpr int kDefaultThreads = SGL_CUSTOM_AR_THREADS;
 constexpr int kDefaultBlockLimit = SGL_CUSTOM_AR_BLOCKS;
+constexpr int kTp4Rows64TwoShotBlockLimit = 32;
 constexpr int kMaxRanks = 8;
-static_assert(
-    VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP == 32 ||
-        VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP == 64,
-    "TP4 BS64 fused two-shot block cap must be 32 or 64");
 using FlagType = uint32_t;
 
 template <int nranks>
@@ -64,10 +48,7 @@ inline int fused_ar_rmsnorm_2shot_blocks(int rows, int hidden) {
   int blocks = std::min(rows, kMaxBlocks);
   if constexpr (nranks == 4) {
     if (rows == 64 && hidden == 2048) {
-      blocks = std::min(
-          blocks,
-          static_cast<int>(
-              VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP));
+      blocks = std::min(blocks, kTp4Rows64TwoShotBlockLimit);
     }
   }
   return blocks;
@@ -546,17 +527,17 @@ __device__ __forceinline__ float load_weight_scalar<float>(const float* weight, 
   return weight[idx];
 }
 
-// Direct TP2 one-stage kernel adapted from SGLang MR413.  It keeps the reduced
-// or residual value in registers across the RMS reduction, avoiding the
-// second global read in the generic vLLM kernel.  MR413 compiles one vec8 lane
-// per thread for both TP2 h2048 vec2rank and non-power-of-two h5120 regcache.
+// Direct TP2 one-stage kernel. It keeps the reduced or residual value in
+// registers across the RMS reduction, avoiding the second global read in the
+// generic vLLM kernel. The specialized path uses one vec8 lane per thread for
+// both TP2 h2048 vector-rank and non-power-of-two h5120 register-cache cases.
 template <
     typename T,
     typename WT,
     bool HasResidual,
     bool WriteReduced>
 __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
-fused_ar_rmsnorm_tp2_mr413_kernel(
+fused_ar_rmsnorm_tp2_specialized_kernel(
     RankData data,
     const RankData* device_data,
     RankSignals sg,
@@ -574,7 +555,7 @@ fused_ar_rmsnorm_tp2_mr413_kernel(
     data = *device_data;
   }
   using P = typename packed_t<T>::P;
-  static_assert(P::size == 8, "MR413 TP2 fused path expects 8 values per pack");
+  static_assert(P::size == 8, "specialized TP2 fused path expects 8 values per pack");
   extern __shared__ float warp_sums[];
   const int tid = static_cast<int>(threadIdx.x);
   const int packed_hidden = hidden / P::size;
@@ -645,7 +626,7 @@ fused_ar_rmsnorm_tp2_mr413_kernel(
 }
 
 template <typename T, typename WT, bool HasResidual, bool WriteReduced>
-bool launch_fused_ar_rmsnorm_tp2_mr413(
+bool launch_fused_ar_rmsnorm_tp2_specialized(
     RankData data,
     const RankData* device_data,
     RankSignals sg,
@@ -664,37 +645,33 @@ bool launch_fused_ar_rmsnorm_tp2_mr413(
     return false;
   }
 
-#if VLLM_MUSA_FUSED_AR_TP2_VEC2RANK
   if (hidden == 2048 && rows <= 128) {
-    // Match MR413's TP2 h2048 compile config: one vec8 lane per thread
-    // (2048 / 8 == 256 threads), not the generic 512-thread module.
+    // Use one vec8 lane per thread (2048 / 8 == 256 threads), rather than the
+    // generic 512-thread module.
     constexpr int threads = 2048 / 8;
     const int blocks = std::min(kMaxBlocks, rows);
     const size_t smem_bytes =
         static_cast<size_t>((threads + 31) / 32) * sizeof(float);
-    fused_ar_rmsnorm_tp2_mr413_kernel<
+    fused_ar_rmsnorm_tp2_specialized_kernel<
         T, WT, HasResidual, WriteReduced>
         <<<blocks, threads, smem_bytes, stream>>>(
             data, device_data, sg, self_sg, residual, weight, norm_out,
             residual_out, reduced, rank, rows, hidden, eps);
     return true;
   }
-#endif
 
-#if VLLM_MUSA_FUSED_AR_TP2_REGCACHE
   if (hidden == 5120 && rows <= 128) {
     constexpr int threads = 5120 / 8;
     const int blocks = std::min(kMaxBlocks, rows);
     const size_t smem_bytes =
         static_cast<size_t>((threads + 31) / 32) * sizeof(float);
-    fused_ar_rmsnorm_tp2_mr413_kernel<
+    fused_ar_rmsnorm_tp2_specialized_kernel<
         T, WT, HasResidual, WriteReduced>
         <<<blocks, threads, smem_bytes, stream>>>(
             data, device_data, sg, self_sg, residual, weight, norm_out,
             residual_out, reduced, rank, rows, hidden, eps);
     return true;
   }
-#endif
 
   return false;
 }
@@ -1356,7 +1333,7 @@ void launch_fused_ar_rmsnorm(
   TVM_FFI_ICHECK_LE(packed_size64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
   if (shot == 1) {
     if constexpr (nranks == 2) {
-      if (launch_fused_ar_rmsnorm_tp2_mr413<T, WT, false, true>(
+      if (launch_fused_ar_rmsnorm_tp2_specialized<T, WT, false, true>(
               data,
               device_data,
               sg,
@@ -1467,7 +1444,7 @@ void launch_fused_ar_residual_rmsnorm(
   TVM_FFI_ICHECK_LE(packed_size64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
   if (shot == 1) {
     if constexpr (nranks == 2) {
-      if (launch_fused_ar_rmsnorm_tp2_mr413<T, WT, true, true>(
+      if (launch_fused_ar_rmsnorm_tp2_specialized<T, WT, true, true>(
               data,
               device_data,
               sg,
@@ -1579,7 +1556,7 @@ void launch_fused_ar_residual_rmsnorm_no_raw(
   TVM_FFI_ICHECK_LE(packed_size64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
   if (shot == 1) {
     if constexpr (nranks == 2) {
-      if (launch_fused_ar_rmsnorm_tp2_mr413<T, WT, true, false>(
+      if (launch_fused_ar_rmsnorm_tp2_specialized<T, WT, true, false>(
               data,
               device_data,
               sg,

--- a/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
+++ b/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
@@ -32,12 +32,46 @@ namespace {
 #define SGL_CUSTOM_AR_MAX_BLOCKS 120
 #endif
 
+// SGLang MR413 TP2 fast paths, adapted to the vLLM raw/no-raw ABI.
+#ifndef VLLM_MUSA_FUSED_AR_TP2_REGCACHE
+#define VLLM_MUSA_FUSED_AR_TP2_REGCACHE 1
+#endif
+
+#ifndef VLLM_MUSA_FUSED_AR_TP2_VEC2RANK
+#define VLLM_MUSA_FUSED_AR_TP2_VEC2RANK 1
+#endif
+
+// Limit the TP4 rows=64, hidden=2048 fused two-shot grid to 32 blocks. The
+// grid-stride loops still cover all rows while halving block-indexed cross-rank
+// synchronization groups relative to the generic 64-block launch.
+#ifndef VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP
+#define VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP 32
+#endif
+
 constexpr int kMaxBlocks = SGL_CUSTOM_AR_MAX_BLOCKS;
 constexpr int kMaxThreadsPerBlock = 1024;
 constexpr int kDefaultThreads = SGL_CUSTOM_AR_THREADS;
 constexpr int kDefaultBlockLimit = SGL_CUSTOM_AR_BLOCKS;
 constexpr int kMaxRanks = 8;
+static_assert(
+    VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP == 32 ||
+        VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP == 64,
+    "TP4 BS64 fused two-shot block cap must be 32 or 64");
 using FlagType = uint32_t;
+
+template <int nranks>
+inline int fused_ar_rmsnorm_2shot_blocks(int rows, int hidden) {
+  int blocks = std::min(rows, kMaxBlocks);
+  if constexpr (nranks == 4) {
+    if (rows == 64 && hidden == 2048) {
+      blocks = std::min(
+          blocks,
+          static_cast<int>(
+              VLLM_MUSA_FUSED_AR_TP4_BS64_2SHOT_BLOCK_CAP));
+    }
+  }
+  return blocks;
+}
 
 struct alignas(128) Signal {
   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
@@ -330,7 +364,6 @@ __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) custom_all_reduce_2sho
     idx_base += stride;
   } while (idx_base < size);
 }
-
 template <typename InputT, typename OutputT, int nranks>
 __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
     cross_device_all_gather_last_dim(RankData data, OutputT* __restrict__ out,
@@ -437,6 +470,1200 @@ void launch_all_gather_last_dim(RankData data, RankSignals sg,
       <<<1, nranks, 0, stream>>>(sg, self_sg, rank);
 }
 
+__device__ __forceinline__ float fused_ar_fast_rsqrt(float value) {
+#if ((defined __MUSA_ARCH__) && (__MUSA_ARCH__ == 310))
+  const float half_value = 0.5f * value;
+  float y = __frsqrt_rn(value);
+  y = y * (1.5f - half_value * y * y);
+  return y;
+#else
+  return rsqrtf(value);
+#endif
+}
+
+__device__ __forceinline__ float fused_ar_block_sum(float value, float* warp_sums) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int num_warps = (static_cast<int>(blockDim.x) + 31) >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = tid < num_warps ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+    if (lane == 0) {
+      warp_sums[0] = value;
+    }
+  }
+  __syncthreads_lm();
+  return warp_sums[0];
+}
+
+inline int fused_ar_vec8_block_threads(int hidden) {
+  const int vec_count = hidden / 8;
+  const int rounded = ((vec_count + 31) / 32) * 32;
+  return rounded < 1024 ? rounded : 1024;
+}
+
+inline int fused_ar_vec8_2shot_block_threads(int hidden) {
+  // MP31 schedules four 32-thread shuffle warps as one 128-thread warp squad.
+  // Keep the 2-shot block aligned to that squad while retaining 32-lane shuffles.
+  const int vec_count = hidden / 8;
+  const int rounded = ((vec_count + 127) / 128) * 128;
+  return rounded < kMaxThreadsPerBlock ? rounded : kMaxThreadsPerBlock;
+}
+
+template <int nranks>
+__device__ __forceinline__ int fused_ar_2shot_owner(int vec_idx, int generic_part) {
+  if constexpr ((nranks & (nranks - 1)) == 0) {
+    return (vec_idx >> 3) & (nranks - 1);
+  } else {
+    if (generic_part == 0 || vec_idx >= generic_part * nranks) {
+      return nranks - 1;
+    }
+    return vec_idx / generic_part;
+  }
+}
+
+template <typename WT>
+__device__ __forceinline__ float load_weight_scalar(const WT* weight, int idx) {
+  return to_float(weight[idx]);
+}
+
+template <>
+__device__ __forceinline__ float load_weight_scalar<float>(const float* weight, int idx) {
+  return weight[idx];
+}
+
+// Direct TP2 one-stage kernel adapted from SGLang MR413.  It keeps the reduced
+// or residual value in registers across the RMS reduction, avoiding the
+// second global read in the generic vLLM kernel.  MR413 compiles one vec8 lane
+// per thread for both TP2 h2048 vec2rank and non-power-of-two h5120 regcache.
+template <
+    typename T,
+    typename WT,
+    bool HasResidual,
+    bool WriteReduced>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+fused_ar_rmsnorm_tp2_mr413_kernel(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual,
+    const WT* __restrict__ weight,
+    T* __restrict__ norm_out,
+    T* __restrict__ residual_out,
+    T* __restrict__ reduced,
+    int rank,
+    int rows,
+    int hidden,
+    float eps) {
+  if (device_data != nullptr) {
+    data = *device_data;
+  }
+  using P = typename packed_t<T>::P;
+  static_assert(P::size == 8, "MR413 TP2 fused path expects 8 values per pack");
+  extern __shared__ float warp_sums[];
+  const int tid = static_cast<int>(threadIdx.x);
+  const int packed_hidden = hidden / P::size;
+  const int packed_col = tid;
+
+  multi_rank_barrier<2, true>(sg, self_sg, rank);
+
+  for (int row = static_cast<int>(blockIdx.x);
+       row < rows;
+       row += static_cast<int>(gridDim.x)) {
+    float values[P::size] = {0.0f};
+    float square_sum = 0.0f;
+    int pack_idx = 0;
+
+    if (row < rows) {
+      pack_idx = row * packed_hidden + packed_col;
+      const P local_pack =
+          reinterpret_cast<const P*>(data.ptrs[rank])[pack_idx];
+      const P peer_pack =
+          reinterpret_cast<const P*>(data.ptrs[rank ^ 1])[pack_idx];
+      P reduced_pack;
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        reduced_pack.data[i] = from_float<T>(
+            to_float(local_pack.data[i]) + to_float(peer_pack.data[i]));
+      }
+      if constexpr (WriteReduced) {
+        reinterpret_cast<P*>(reduced)[pack_idx] = reduced_pack;
+      }
+
+      P norm_input_pack = reduced_pack;
+      if constexpr (HasResidual) {
+        const P residual_pack =
+            reinterpret_cast<const P*>(residual)[pack_idx];
+#pragma unroll
+        for (int i = 0; i < P::size; ++i) {
+          norm_input_pack.data[i] = from_float<T>(
+              to_float(reduced_pack.data[i]) +
+              to_float(residual_pack.data[i]));
+        }
+        reinterpret_cast<P*>(residual_out)[pack_idx] = norm_input_pack;
+      }
+
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        values[i] = to_float(norm_input_pack.data[i]);
+        square_sum += values[i] * values[i];
+      }
+    }
+
+    const float row_square_sum = fused_ar_block_sum(square_sum, warp_sums);
+    const float scale = fused_ar_fast_rsqrt(
+        row_square_sum / static_cast<float>(hidden) + eps);
+
+    if (row < rows) {
+      const int col = packed_col * P::size;
+      P out_pack;
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        const float gamma = load_weight_scalar<WT>(weight, col + i);
+        out_pack.data[i] = from_float<T>(values[i] * scale * gamma);
+      }
+      reinterpret_cast<P*>(norm_out)[pack_idx] = out_pack;
+    }
+  }
+
+  multi_rank_barrier<2, false>(sg, self_sg, rank);
+}
+
+template <typename T, typename WT, bool HasResidual, bool WriteReduced>
+bool launch_fused_ar_rmsnorm_tp2_mr413(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual,
+    const WT* weight,
+    T* norm_out,
+    T* residual_out,
+    T* reduced,
+    int rank,
+    int rows,
+    int hidden,
+    float eps,
+    musaStream_t stream) {
+  if (rows <= 0) {
+    return false;
+  }
+
+#if VLLM_MUSA_FUSED_AR_TP2_VEC2RANK
+  if (hidden == 2048 && rows <= 128) {
+    // Match MR413's TP2 h2048 compile config: one vec8 lane per thread
+    // (2048 / 8 == 256 threads), not the generic 512-thread module.
+    constexpr int threads = 2048 / 8;
+    const int blocks = std::min(kMaxBlocks, rows);
+    const size_t smem_bytes =
+        static_cast<size_t>((threads + 31) / 32) * sizeof(float);
+    fused_ar_rmsnorm_tp2_mr413_kernel<
+        T, WT, HasResidual, WriteReduced>
+        <<<blocks, threads, smem_bytes, stream>>>(
+            data, device_data, sg, self_sg, residual, weight, norm_out,
+            residual_out, reduced, rank, rows, hidden, eps);
+    return true;
+  }
+#endif
+
+#if VLLM_MUSA_FUSED_AR_TP2_REGCACHE
+  if (hidden == 5120 && rows <= 128) {
+    constexpr int threads = 5120 / 8;
+    const int blocks = std::min(kMaxBlocks, rows);
+    const size_t smem_bytes =
+        static_cast<size_t>((threads + 31) / 32) * sizeof(float);
+    fused_ar_rmsnorm_tp2_mr413_kernel<
+        T, WT, HasResidual, WriteReduced>
+        <<<blocks, threads, smem_bytes, stream>>>(
+            data, device_data, sg, self_sg, residual, weight, norm_out,
+            residual_out, reduced, rank, rows, hidden, eps);
+    return true;
+  }
+#endif
+
+  return false;
+}
+
+template <typename T, typename WT, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) fused_ar_rmsnorm_1stage_kernel(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const WT* __restrict__ weight,
+    T* __restrict__ norm_out,
+    T* __restrict__ reduced,
+    int rank,
+    int rows,
+    int hidden,
+    float eps) {
+  if (device_data != nullptr) {
+    data = *device_data;
+  }
+  using P = typename packed_t<T>::P;
+  static_assert(P::size == 8, "fused AR-RMSNorm currently expects 8 values per 16B pack");
+  extern __shared__ float warp_sums[];
+  const int tid = static_cast<int>(threadIdx.x);
+  const int vec_count = hidden / P::size;
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  for (int row = static_cast<int>(blockIdx.x); row < rows; row += static_cast<int>(gridDim.x)) {
+    const int row_pack_base = row * vec_count;
+    float square_sum = 0.0f;
+
+    for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+      const int pack_idx = row_pack_base + vec_idx;
+      float acc[P::size];
+      const P first = reinterpret_cast<const P*>(data.ptrs[0])[pack_idx];
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        acc[i] = to_float(first.data[i]);
+      }
+#pragma unroll
+      for (int r = 1; r < nranks; ++r) {
+        const P peer = reinterpret_cast<const P*>(data.ptrs[r])[pack_idx];
+#pragma unroll
+        for (int i = 0; i < P::size; ++i) {
+          acc[i] += to_float(peer.data[i]);
+        }
+      }
+
+      P reduced_pack;
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        reduced_pack.data[i] = from_float<T>(acc[i]);
+        const float x = to_float(reduced_pack.data[i]);
+        square_sum += x * x;
+      }
+      reinterpret_cast<P*>(reduced)[pack_idx] = reduced_pack;
+    }
+
+    square_sum = fused_ar_block_sum(square_sum, warp_sums);
+    const float scale = fused_ar_fast_rsqrt(square_sum / static_cast<float>(hidden) + eps);
+
+    for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+      const int pack_idx = row_pack_base + vec_idx;
+      const int col = vec_idx * P::size;
+      const P reduced_pack = reinterpret_cast<const P*>(reduced)[pack_idx];
+      P out_pack;
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        const float x = to_float(reduced_pack.data[i]);
+        const float w = load_weight_scalar<WT>(weight, col + i);
+        out_pack.data[i] = from_float<T>(x * scale * w);
+      }
+      reinterpret_cast<P*>(norm_out)[pack_idx] = out_pack;
+    }
+  }
+
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) fused_ar_rmsnorm_reduce_scatter_store_kernel(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    int rank,
+    int rows,
+    int hidden) {
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  static_assert(P::size == 8, "fused AR-RMSNorm currently expects 8 values per 16B pack");
+  const int tid = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  const int stride = static_cast<int>(gridDim.x * blockDim.x);
+  const int vec_count = hidden / P::size;
+  const int packed_size = rows * vec_count;
+  const int part = packed_size / nranks;
+  const int start = rank * part;
+  const int end = rank == nranks - 1 ? packed_size : start + part;
+  const P* ptrs[nranks];
+  P* tmps[nranks];
+#pragma unroll
+  for (int i = 0; i < nranks; ++i) {
+    ptrs[i] = reinterpret_cast<const P*>(data.ptrs[i]);
+    tmps[i] = get_tmp_buf<P>(sg.signals[i]);
+  }
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  for (int idx = start + tid; idx < end; idx += stride) {
+    const P reduced_pack = packed_reduce<P, nranks, A>(ptrs, idx);
+#pragma unroll
+    for (int dst = 0; dst < nranks; ++dst) {
+      tmps[dst][idx] = reduced_pack;
+    }
+  }
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (threadIdx.x == 0) {
+    __threadfence_system_noflush();
+  }
+  multi_rank_barrier<nranks, false, true>(sg, self_sg, rank);
+}
+
+template <typename T, typename WT>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) fused_ar_rmsnorm_local_tmp_kernel(
+    RankSignals sg,
+    const WT* __restrict__ weight,
+    T* __restrict__ norm_out,
+    T* __restrict__ reduced,
+    int rank,
+    int rows,
+    int hidden,
+    float eps) {
+  using P = typename packed_t<T>::P;
+  static_assert(P::size == 8, "fused AR-RMSNorm currently expects 8 values per 16B pack");
+  extern __shared__ float warp_sums[];
+  const int row = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  const int vec_count = hidden / P::size;
+  const int row_pack_base = row * vec_count;
+  const P* tmps = get_tmp_buf<P>(sg.signals[rank]);
+  float square_sum = 0.0f;
+
+  for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+    const int pack_idx = row_pack_base + vec_idx;
+    const P reduced_pack = tmps[pack_idx];
+    reinterpret_cast<P*>(reduced)[pack_idx] = reduced_pack;
+#pragma unroll
+    for (int i = 0; i < P::size; ++i) {
+      const float x = to_float(reduced_pack.data[i]);
+      square_sum += x * x;
+    }
+  }
+
+  square_sum = fused_ar_block_sum(square_sum, warp_sums);
+  const float scale = fused_ar_fast_rsqrt(square_sum / static_cast<float>(hidden) + eps);
+
+  for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+    const int pack_idx = row_pack_base + vec_idx;
+    const int col = vec_idx * P::size;
+    const P reduced_pack = reinterpret_cast<const P*>(reduced)[pack_idx];
+      P out_pack;
+#pragma unroll
+    for (int i = 0; i < P::size; ++i) {
+      const float x = to_float(reduced_pack.data[i]);
+      const float w = load_weight_scalar<WT>(weight, col + i);
+      out_pack.data[i] = from_float<T>(x * scale * w);
+    }
+    reinterpret_cast<P*>(norm_out)[pack_idx] = out_pack;
+  }
+}
+
+template <typename T, typename WT, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) fused_ar_residual_rmsnorm_1stage_kernel(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual,
+    const WT* __restrict__ weight,
+    T* __restrict__ norm_out,
+    T* __restrict__ residual_out,
+    T* __restrict__ reduced,
+    int rank,
+    int rows,
+    int hidden,
+    float eps) {
+  if (device_data != nullptr) {
+    data = *device_data;
+  }
+  using P = typename packed_t<T>::P;
+  static_assert(P::size == 8, "fused AR-residual-RMSNorm currently expects 8 values per 16B pack");
+  extern __shared__ float warp_sums[];
+  const int tid = static_cast<int>(threadIdx.x);
+  const int vec_count = hidden / P::size;
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  for (int row = static_cast<int>(blockIdx.x); row < rows; row += static_cast<int>(gridDim.x)) {
+    const int row_pack_base = row * vec_count;
+    float square_sum = 0.0f;
+
+    for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+      const int pack_idx = row_pack_base + vec_idx;
+      float acc[P::size];
+      const P first = reinterpret_cast<const P*>(data.ptrs[0])[pack_idx];
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        acc[i] = to_float(first.data[i]);
+      }
+#pragma unroll
+      for (int r = 1; r < nranks; ++r) {
+        const P peer = reinterpret_cast<const P*>(data.ptrs[r])[pack_idx];
+#pragma unroll
+        for (int i = 0; i < P::size; ++i) {
+          acc[i] += to_float(peer.data[i]);
+        }
+      }
+
+      P reduced_pack;
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        reduced_pack.data[i] = from_float<T>(acc[i]);
+      }
+      reinterpret_cast<P*>(reduced)[pack_idx] = reduced_pack;
+      const P residual_pack = reinterpret_cast<const P*>(residual)[pack_idx];
+      P residual_out_pack;
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        const float x = to_float(reduced_pack.data[i]) + to_float(residual_pack.data[i]);
+        residual_out_pack.data[i] = from_float<T>(x);
+        const float stored = to_float(residual_out_pack.data[i]);
+        square_sum += stored * stored;
+      }
+      reinterpret_cast<P*>(residual_out)[pack_idx] = residual_out_pack;
+    }
+
+    square_sum = fused_ar_block_sum(square_sum, warp_sums);
+    const float scale = fused_ar_fast_rsqrt(square_sum / static_cast<float>(hidden) + eps);
+
+    for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+      const int pack_idx = row_pack_base + vec_idx;
+      const int col = vec_idx * P::size;
+      const P residual_out_pack = reinterpret_cast<const P*>(residual_out)[pack_idx];
+      P out_pack;
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        const float x = to_float(residual_out_pack.data[i]);
+        const float w = load_weight_scalar<WT>(weight, col + i);
+        out_pack.data[i] = from_float<T>(x * scale * w);
+      }
+      reinterpret_cast<P*>(norm_out)[pack_idx] = out_pack;
+    }
+  }
+
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, typename WT>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) fused_ar_residual_rmsnorm_local_tmp_kernel(
+    RankSignals sg,
+    const T* __restrict__ residual,
+    const WT* __restrict__ weight,
+    T* __restrict__ norm_out,
+    T* __restrict__ residual_out,
+    T* __restrict__ reduced,
+    int rank,
+    int rows,
+    int hidden,
+    float eps) {
+  using P = typename packed_t<T>::P;
+  static_assert(P::size == 8, "fused AR-residual-RMSNorm currently expects 8 values per 16B pack");
+  extern __shared__ float warp_sums[];
+  const int row = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  const int vec_count = hidden / P::size;
+  const int row_pack_base = row * vec_count;
+  const P* tmps = get_tmp_buf<P>(sg.signals[rank]);
+  float square_sum = 0.0f;
+
+  for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+    const int pack_idx = row_pack_base + vec_idx;
+    const P reduced_pack = tmps[pack_idx];
+    reinterpret_cast<P*>(reduced)[pack_idx] = reduced_pack;
+    const P residual_pack = reinterpret_cast<const P*>(residual)[pack_idx];
+    P residual_out_pack;
+#pragma unroll
+    for (int i = 0; i < P::size; ++i) {
+      const float x = to_float(reduced_pack.data[i]) + to_float(residual_pack.data[i]);
+      residual_out_pack.data[i] = from_float<T>(x);
+      const float stored = to_float(residual_out_pack.data[i]);
+      square_sum += stored * stored;
+    }
+    reinterpret_cast<P*>(residual_out)[pack_idx] = residual_out_pack;
+  }
+
+  square_sum = fused_ar_block_sum(square_sum, warp_sums);
+  const float scale = fused_ar_fast_rsqrt(square_sum / static_cast<float>(hidden) + eps);
+
+  for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+    const int pack_idx = row_pack_base + vec_idx;
+    const int col = vec_idx * P::size;
+    const P residual_out_pack = reinterpret_cast<const P*>(residual_out)[pack_idx];
+    P out_pack;
+#pragma unroll
+    for (int i = 0; i < P::size; ++i) {
+      const float x = to_float(residual_out_pack.data[i]);
+      const float w = load_weight_scalar<WT>(weight, col + i);
+      out_pack.data[i] = from_float<T>(x * scale * w);
+    }
+    reinterpret_cast<P*>(norm_out)[pack_idx] = out_pack;
+  }
+}
+
+template <typename T, typename WT, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) fused_ar_residual_rmsnorm_no_raw_1stage_kernel(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual,
+    const WT* __restrict__ weight,
+    T* __restrict__ norm_out,
+    T* __restrict__ residual_out,
+    int rank,
+    int rows,
+    int hidden,
+    float eps) {
+  if (device_data != nullptr) {
+    data = *device_data;
+  }
+  using P = typename packed_t<T>::P;
+  static_assert(P::size == 8, "fused AR-residual-RMSNorm no-raw currently expects 8 values per 16B pack");
+  extern __shared__ float warp_sums[];
+  const int tid = static_cast<int>(threadIdx.x);
+  const int vec_count = hidden / P::size;
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  for (int row = static_cast<int>(blockIdx.x); row < rows; row += static_cast<int>(gridDim.x)) {
+    const int row_pack_base = row * vec_count;
+    float square_sum = 0.0f;
+
+    for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+      const int pack_idx = row_pack_base + vec_idx;
+      float acc[P::size];
+      const P first = reinterpret_cast<const P*>(data.ptrs[0])[pack_idx];
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        acc[i] = to_float(first.data[i]);
+      }
+#pragma unroll
+      for (int r = 1; r < nranks; ++r) {
+        const P peer = reinterpret_cast<const P*>(data.ptrs[r])[pack_idx];
+#pragma unroll
+        for (int i = 0; i < P::size; ++i) {
+          acc[i] += to_float(peer.data[i]);
+        }
+      }
+
+      const P residual_pack = reinterpret_cast<const P*>(residual)[pack_idx];
+      P residual_out_pack;
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        // Match the raw-output ABI: the all-reduce result is first rounded to
+        // the model dtype, then the residual is added and rounded again.
+        const T reduced_value = from_float<T>(acc[i]);
+        const float x =
+            to_float(reduced_value) + to_float(residual_pack.data[i]);
+        residual_out_pack.data[i] = from_float<T>(x);
+        const float stored = to_float(residual_out_pack.data[i]);
+        square_sum += stored * stored;
+      }
+      reinterpret_cast<P*>(residual_out)[pack_idx] = residual_out_pack;
+    }
+
+    square_sum = fused_ar_block_sum(square_sum, warp_sums);
+    const float scale = fused_ar_fast_rsqrt(square_sum / static_cast<float>(hidden) + eps);
+
+    for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+      const int pack_idx = row_pack_base + vec_idx;
+      const int col = vec_idx * P::size;
+      const P residual_out_pack = reinterpret_cast<const P*>(residual_out)[pack_idx];
+      P out_pack;
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        const float x = to_float(residual_out_pack.data[i]);
+        const float w = load_weight_scalar<WT>(weight, col + i);
+        out_pack.data[i] = from_float<T>(x * scale * w);
+      }
+      reinterpret_cast<P*>(norm_out)[pack_idx] = out_pack;
+    }
+  }
+
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, typename WT>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) fused_ar_residual_rmsnorm_no_raw_local_tmp_kernel(
+    RankSignals sg,
+    const T* __restrict__ residual,
+    const WT* __restrict__ weight,
+    T* __restrict__ norm_out,
+    T* __restrict__ residual_out,
+    int rank,
+    int rows,
+    int hidden,
+    float eps) {
+  using P = typename packed_t<T>::P;
+  static_assert(P::size == 8, "fused AR-residual-RMSNorm no-raw currently expects 8 values per 16B pack");
+  extern __shared__ float warp_sums[];
+  const int row = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  const int vec_count = hidden / P::size;
+  const int row_pack_base = row * vec_count;
+  const P* tmps = get_tmp_buf<P>(sg.signals[rank]);
+  float square_sum = 0.0f;
+
+  for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+    const int pack_idx = row_pack_base + vec_idx;
+    const P reduced_pack = tmps[pack_idx];
+    const P residual_pack = reinterpret_cast<const P*>(residual)[pack_idx];
+    P residual_out_pack;
+#pragma unroll
+    for (int i = 0; i < P::size; ++i) {
+      const float x = to_float(reduced_pack.data[i]) + to_float(residual_pack.data[i]);
+      residual_out_pack.data[i] = from_float<T>(x);
+      const float stored = to_float(residual_out_pack.data[i]);
+      square_sum += stored * stored;
+    }
+    reinterpret_cast<P*>(residual_out)[pack_idx] = residual_out_pack;
+  }
+
+  square_sum = fused_ar_block_sum(square_sum, warp_sums);
+  const float scale = fused_ar_fast_rsqrt(square_sum / static_cast<float>(hidden) + eps);
+
+  for (int vec_idx = tid; vec_idx < vec_count; vec_idx += static_cast<int>(blockDim.x)) {
+    const int pack_idx = row_pack_base + vec_idx;
+    const int col = vec_idx * P::size;
+    const P residual_out_pack = reinterpret_cast<const P*>(residual_out)[pack_idx];
+    P out_pack;
+#pragma unroll
+    for (int i = 0; i < P::size; ++i) {
+      const float x = to_float(residual_out_pack.data[i]);
+      const float w = load_weight_scalar<WT>(weight, col + i);
+      out_pack.data[i] = from_float<T>(x * scale * w);
+    }
+    reinterpret_cast<P*>(norm_out)[pack_idx] = out_pack;
+  }
+}
+
+template <typename T, typename WT, int nranks, bool HasResidual, bool WriteReduced>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) fused_ar_rmsnorm_2shot_kernel(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual,
+    const WT* __restrict__ weight,
+    T* __restrict__ norm_out,
+    T* __restrict__ residual_out,
+    T* __restrict__ reduced,
+    int rank,
+    int rows,
+    int hidden,
+    float eps) {
+  if (device_data != nullptr) {
+    data = *device_data;
+  }
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  static_assert(P::size == 8, "fused 2-shot AR-RMSNorm expects 8 values per 16B pack");
+
+  extern __shared__ float warp_sums[];
+  __shared__ float rank8_smem[nranks == 8 ? (kMaxThreadsPerBlock << 1) : 1];
+  const int tid = static_cast<int>(threadIdx.x);
+  const int vec_count = hidden / P::size;
+  const int generic_part = vec_count / nranks;
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  if constexpr ((nranks & (nranks - 1)) == 0) {
+    // This is the native MUSA 2-shot mapping used by custom_all_reduce_2shot.
+    // A 32-lane shuffle group reduces rank inputs; MP31 warp-squad alignment is
+    // handled by the launch block size.
+    constexpr int nranks_sft = (nranks >> 1) - (nranks >> 3);
+    constexpr int coalesce_num = 8;
+    constexpr int coalesce_sft = 3;
+    constexpr int group_stride_sft = nranks_sft + coalesce_sft;
+    constexpr int vlen = P::size;
+    const int lane = tid & 31;
+    const int warp = tid >> 5;
+    const int target_rank = (tid >> coalesce_sft) & (nranks - 1);
+    const int group_id = tid >> group_stride_sft;
+    const int coalesce_tid = tid & (coalesce_num - 1);
+    const int idx_in_row =
+        coalesce_tid + (rank << coalesce_sft) + (group_id << group_stride_sft);
+    using Vec = int16_t __attribute__((vector_size(16)));
+    const Vec* target_ptr = reinterpret_cast<const Vec*>(data.ptrs[target_rank]);
+    Vec* self_tmp = get_tmp_buf<Vec>(sg.signals[rank]);
+
+    for (int row = static_cast<int>(blockIdx.x); row < rows;
+         row += static_cast<int>(gridDim.x)) {
+      const int row_vec_base = row * vec_count;
+      int idx_base = 0;
+      do {
+        const int vec_idx = idx_in_row + idx_base;
+        float acc[vlen] = {0.0f};
+        if (vec_idx < vec_count) {
+#if SGL_CUSTOM_AR_VECTOR_LOAD
+          const Vec raw = target_ptr[row_vec_base + vec_idx];
+          const T* src = reinterpret_cast<const T*>(&raw);
+#else
+          const T* src =
+              reinterpret_cast<const T*>(&target_ptr[row_vec_base + vec_idx]);
+#endif
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            acc[i] = to_float(src[i]);
+          }
+        }
+        shfl_reduce<T, nranks, vlen>(acc);
+        if constexpr (nranks == 8) {
+          if (lane < coalesce_num) {
+#pragma unroll
+            for (int i = 0; i < vlen; ++i) {
+              rank8_smem[warp * vlen * coalesce_num + coalesce_tid * vlen + i] =
+                  acc[i];
+            }
+          }
+          __syncthreads_lm();
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            acc[i] +=
+                rank8_smem[(warp ^ 1) * vlen * coalesce_num + coalesce_tid * vlen + i];
+          }
+        }
+        if (rank == target_rank && vec_idx < vec_count) {
+          Vec result;
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            reinterpret_cast<T*>(&result)[i] = downcast_s<T>(acc[i]);
+          }
+          self_tmp[row_vec_base + vec_idx] = result;
+        }
+        if constexpr (nranks == 8) {
+          // Do not let the next iteration overwrite LDS while another squad is
+          // still consuming the current rank-pair reduction.
+          __syncthreads_lm();
+        }
+        idx_base += static_cast<int>(blockDim.x);
+      } while (idx_base < vec_count);
+    }
+  } else {
+    // TP6 keeps the generic MUSA two-stage reduction because the shuffle
+    // target-rank mapping requires a power-of-two rank count.
+    const int vec_start = rank * generic_part;
+    const int vec_end = rank == nranks - 1 ? vec_count : vec_start + generic_part;
+    const P* ptrs[nranks];
+#pragma unroll
+    for (int r = 0; r < nranks; ++r) {
+      ptrs[r] = reinterpret_cast<const P*>(data.ptrs[r]);
+    }
+    P* self_tmp = get_tmp_buf<P>(sg.signals[rank]);
+    for (int row = static_cast<int>(blockIdx.x); row < rows;
+         row += static_cast<int>(gridDim.x)) {
+      const int row_pack_base = row * vec_count;
+      for (int vec_idx = vec_start + tid; vec_idx < vec_end;
+           vec_idx += static_cast<int>(blockDim.x)) {
+        const int pack_idx = row_pack_base + vec_idx;
+        self_tmp[pack_idx] = packed_reduce<P, nranks, A>(ptrs, pack_idx);
+      }
+    }
+  }
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  multi_rank_barrier<nranks, false, true>(sg, self_sg, rank);
+
+  for (int row = static_cast<int>(blockIdx.x); row < rows;
+       row += static_cast<int>(gridDim.x)) {
+    const int row_pack_base = row * vec_count;
+    float square_sum = 0.0f;
+
+    for (int vec_idx = tid; vec_idx < vec_count;
+         vec_idx += static_cast<int>(blockDim.x)) {
+      const int pack_idx = row_pack_base + vec_idx;
+      const int owner = fused_ar_2shot_owner<nranks>(vec_idx, generic_part);
+      const P reduced_pack = get_tmp_buf<P>(sg.signals[owner])[pack_idx];
+      P norm_input_pack = reduced_pack;
+      if constexpr (WriteReduced) {
+        reinterpret_cast<P*>(reduced)[pack_idx] = reduced_pack;
+      }
+      if constexpr (HasResidual) {
+        const P residual_pack = reinterpret_cast<const P*>(residual)[pack_idx];
+#pragma unroll
+        for (int i = 0; i < P::size; ++i) {
+          norm_input_pack.data[i] = downcast_s<T>(
+              to_float(reduced_pack.data[i]) + to_float(residual_pack.data[i]));
+        }
+        reinterpret_cast<P*>(residual_out)[pack_idx] = norm_input_pack;
+      }
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        const float x = to_float(norm_input_pack.data[i]);
+        square_sum += x * x;
+      }
+    }
+
+    square_sum = fused_ar_block_sum(square_sum, warp_sums);
+    const float scale = fused_ar_fast_rsqrt(square_sum / static_cast<float>(hidden) + eps);
+
+    for (int vec_idx = tid; vec_idx < vec_count;
+         vec_idx += static_cast<int>(blockDim.x)) {
+      const int pack_idx = row_pack_base + vec_idx;
+      const int col = vec_idx * P::size;
+      P norm_input_pack;
+      if constexpr (HasResidual) {
+        norm_input_pack = reinterpret_cast<const P*>(residual_out)[pack_idx];
+      } else {
+        norm_input_pack = reinterpret_cast<const P*>(reduced)[pack_idx];
+      }
+      P out_pack;
+#pragma unroll
+      for (int i = 0; i < P::size; ++i) {
+        const float x = to_float(norm_input_pack.data[i]);
+        const float w = load_weight_scalar<WT>(weight, col + i);
+        out_pack.data[i] = from_float<T>(x * scale * w);
+      }
+      reinterpret_cast<P*>(norm_out)[pack_idx] = out_pack;
+    }
+  }
+}
+
+template <typename T, typename WT, int nranks>
+void launch_fused_ar_rmsnorm(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const WT* weight,
+    T* norm_out,
+    T* reduced,
+    int rank,
+    int rows,
+    int hidden,
+    int shot,
+    float eps,
+    musaStream_t stream) {
+  constexpr int pack = packed_t<T>::P::size;
+  TVM_FFI_ICHECK_EQ(pack, 8);
+  TVM_FFI_ICHECK_EQ(hidden % pack, 0);
+  TVM_FFI_ICHECK_GT(rows, 0);
+  TVM_FFI_ICHECK_GT(hidden, 0);
+  TVM_FFI_ICHECK(shot == 1 || shot == 2) << "shot must be 1 or 2";
+  const int64_t packed_size64 = static_cast<int64_t>(rows) * static_cast<int64_t>(hidden / pack);
+  TVM_FFI_ICHECK_LE(packed_size64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  if (shot == 1) {
+    if constexpr (nranks == 2) {
+      if (launch_fused_ar_rmsnorm_tp2_mr413<T, WT, false, true>(
+              data,
+              device_data,
+              sg,
+              self_sg,
+              static_cast<const T*>(nullptr),
+              weight,
+              norm_out,
+              static_cast<T*>(nullptr),
+              reduced,
+              rank,
+              rows,
+              hidden,
+              eps,
+              stream)) {
+        return;
+      }
+    }
+  }
+  const int rms_threads = fused_ar_vec8_block_threads(hidden);
+  const int rms_smem = ((rms_threads + 31) / 32) * static_cast<int>(sizeof(float));
+  const int two_shot_threads = fused_ar_vec8_2shot_block_threads(hidden);
+  const int two_shot_smem = ((two_shot_threads + 31) / 32) * static_cast<int>(sizeof(float));
+
+  if (shot == 1) {
+    const int blocks = std::min(rows, kMaxBlocks);
+    fused_ar_rmsnorm_1stage_kernel<T, WT, nranks><<<blocks, rms_threads, rms_smem, stream>>>(
+        data, device_data, sg, self_sg, weight, norm_out, reduced, rank, rows, hidden, eps);
+  } else if (shot == 2) {
+    const int blocks = fused_ar_rmsnorm_2shot_blocks<nranks>(rows, hidden);
+    fused_ar_rmsnorm_2shot_kernel<T, WT, nranks, false, true>
+        <<<blocks, two_shot_threads, two_shot_smem, stream>>>(
+            data,
+            device_data,
+            sg,
+            self_sg,
+            static_cast<const T*>(nullptr),
+            weight,
+            norm_out,
+            static_cast<T*>(nullptr),
+            reduced,
+            rank,
+            rows,
+            hidden,
+            eps);
+  } else {
+    TVM_FFI_THROW(ValueError) << "shot must be 1 or 2";
+  }
+}
+
+template <typename T, typename WT>
+void dispatch_fused_world_size(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const WT* weight,
+    T* norm_out,
+    T* reduced,
+    int rank,
+    int world_size,
+    int rows,
+    int hidden,
+    int shot,
+    float eps,
+    musaStream_t stream) {
+  switch (world_size) {
+    case 2:
+      launch_fused_ar_rmsnorm<T, WT, 2>(data, device_data, sg, self_sg, weight, norm_out, reduced, rank, rows, hidden, shot, eps, stream);
+      break;
+    case 4:
+      launch_fused_ar_rmsnorm<T, WT, 4>(data, device_data, sg, self_sg, weight, norm_out, reduced, rank, rows, hidden, shot, eps, stream);
+      break;
+    case 6:
+      launch_fused_ar_rmsnorm<T, WT, 6>(data, device_data, sg, self_sg, weight, norm_out, reduced, rank, rows, hidden, shot, eps, stream);
+      break;
+    case 8:
+      launch_fused_ar_rmsnorm<T, WT, 8>(data, device_data, sg, self_sg, weight, norm_out, reduced, rank, rows, hidden, shot, eps, stream);
+      break;
+    default:
+      TVM_FFI_THROW(ValueError) << "world_size must be one of 2/4/6/8";
+  }
+}
+
+template <typename T, typename WT, int nranks>
+void launch_fused_ar_residual_rmsnorm(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual,
+    const WT* weight,
+    T* norm_out,
+    T* residual_out,
+    T* reduced,
+    int rank,
+    int rows,
+    int hidden,
+    int shot,
+    float eps,
+    musaStream_t stream) {
+  constexpr int pack = packed_t<T>::P::size;
+  TVM_FFI_ICHECK_EQ(pack, 8);
+  TVM_FFI_ICHECK_EQ(hidden % pack, 0);
+  TVM_FFI_ICHECK_GT(rows, 0);
+  TVM_FFI_ICHECK_GT(hidden, 0);
+  TVM_FFI_ICHECK(shot == 1 || shot == 2) << "shot must be 1 or 2";
+  const int64_t packed_size64 = static_cast<int64_t>(rows) * static_cast<int64_t>(hidden / pack);
+  TVM_FFI_ICHECK_LE(packed_size64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  if (shot == 1) {
+    if constexpr (nranks == 2) {
+      if (launch_fused_ar_rmsnorm_tp2_mr413<T, WT, true, true>(
+              data,
+              device_data,
+              sg,
+              self_sg,
+              residual,
+              weight,
+              norm_out,
+              residual_out,
+              reduced,
+              rank,
+              rows,
+              hidden,
+              eps,
+              stream)) {
+        return;
+      }
+    }
+  }
+  const int rms_threads = fused_ar_vec8_block_threads(hidden);
+  const int rms_smem = ((rms_threads + 31) / 32) * static_cast<int>(sizeof(float));
+  const int two_shot_threads = fused_ar_vec8_2shot_block_threads(hidden);
+  const int two_shot_smem = ((two_shot_threads + 31) / 32) * static_cast<int>(sizeof(float));
+
+  if (shot == 1) {
+    const int blocks = std::min(rows, kMaxBlocks);
+    fused_ar_residual_rmsnorm_1stage_kernel<T, WT, nranks><<<blocks, rms_threads, rms_smem, stream>>>(
+        data, device_data, sg, self_sg, residual, weight, norm_out, residual_out, reduced, rank, rows, hidden, eps);
+  } else if (shot == 2) {
+    const int blocks = fused_ar_rmsnorm_2shot_blocks<nranks>(rows, hidden);
+    fused_ar_rmsnorm_2shot_kernel<T, WT, nranks, true, true>
+        <<<blocks, two_shot_threads, two_shot_smem, stream>>>(
+            data,
+            device_data,
+            sg,
+            self_sg,
+            residual,
+            weight,
+            norm_out,
+            residual_out,
+            reduced,
+            rank,
+            rows,
+            hidden,
+            eps);
+  } else {
+    TVM_FFI_THROW(ValueError) << "shot must be 1 or 2";
+  }
+}
+
+template <typename T, typename WT>
+void dispatch_fused_residual_world_size(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual,
+    const WT* weight,
+    T* norm_out,
+    T* residual_out,
+    T* reduced,
+    int rank,
+    int world_size,
+    int rows,
+    int hidden,
+    int shot,
+    float eps,
+    musaStream_t stream) {
+  switch (world_size) {
+    case 2:
+      launch_fused_ar_residual_rmsnorm<T, WT, 2>(data, device_data, sg, self_sg, residual, weight, norm_out, residual_out, reduced, rank, rows, hidden, shot, eps, stream);
+      break;
+    case 4:
+      launch_fused_ar_residual_rmsnorm<T, WT, 4>(data, device_data, sg, self_sg, residual, weight, norm_out, residual_out, reduced, rank, rows, hidden, shot, eps, stream);
+      break;
+    case 6:
+      launch_fused_ar_residual_rmsnorm<T, WT, 6>(data, device_data, sg, self_sg, residual, weight, norm_out, residual_out, reduced, rank, rows, hidden, shot, eps, stream);
+      break;
+    case 8:
+      launch_fused_ar_residual_rmsnorm<T, WT, 8>(data, device_data, sg, self_sg, residual, weight, norm_out, residual_out, reduced, rank, rows, hidden, shot, eps, stream);
+      break;
+    default:
+      TVM_FFI_THROW(ValueError) << "world_size must be one of 2/4/6/8";
+  }
+}
+
+template <typename T, typename WT, int nranks>
+void launch_fused_ar_residual_rmsnorm_no_raw(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual,
+    const WT* weight,
+    T* norm_out,
+    T* residual_out,
+    int rank,
+    int rows,
+    int hidden,
+    int shot,
+    float eps,
+    musaStream_t stream) {
+  constexpr int pack = packed_t<T>::P::size;
+  TVM_FFI_ICHECK_EQ(pack, 8);
+  TVM_FFI_ICHECK_EQ(hidden % pack, 0);
+  TVM_FFI_ICHECK_GT(rows, 0);
+  TVM_FFI_ICHECK_GT(hidden, 0);
+  TVM_FFI_ICHECK(shot == 1 || shot == 2) << "shot must be 1 or 2";
+  const int64_t packed_size64 = static_cast<int64_t>(rows) * static_cast<int64_t>(hidden / pack);
+  TVM_FFI_ICHECK_LE(packed_size64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  if (shot == 1) {
+    if constexpr (nranks == 2) {
+      if (launch_fused_ar_rmsnorm_tp2_mr413<T, WT, true, false>(
+              data,
+              device_data,
+              sg,
+              self_sg,
+              residual,
+              weight,
+              norm_out,
+              residual_out,
+              static_cast<T*>(nullptr),
+              rank,
+              rows,
+              hidden,
+              eps,
+              stream)) {
+        return;
+      }
+    }
+  }
+  const int rms_threads = fused_ar_vec8_block_threads(hidden);
+  const int rms_smem = ((rms_threads + 31) / 32) * static_cast<int>(sizeof(float));
+  const int two_shot_threads = fused_ar_vec8_2shot_block_threads(hidden);
+  const int two_shot_smem = ((two_shot_threads + 31) / 32) * static_cast<int>(sizeof(float));
+
+  if (shot == 1) {
+    const int blocks = std::min(rows, kMaxBlocks);
+    fused_ar_residual_rmsnorm_no_raw_1stage_kernel<T, WT, nranks><<<blocks, rms_threads, rms_smem, stream>>>(
+        data, device_data, sg, self_sg, residual, weight, norm_out, residual_out, rank, rows, hidden, eps);
+  } else if (shot == 2) {
+    const int blocks = fused_ar_rmsnorm_2shot_blocks<nranks>(rows, hidden);
+    fused_ar_rmsnorm_2shot_kernel<T, WT, nranks, true, false>
+        <<<blocks, two_shot_threads, two_shot_smem, stream>>>(
+            data,
+            device_data,
+            sg,
+            self_sg,
+            residual,
+            weight,
+            norm_out,
+            residual_out,
+            static_cast<T*>(nullptr),
+            rank,
+            rows,
+            hidden,
+            eps);
+  } else {
+    TVM_FFI_THROW(ValueError) << "shot must be 1 or 2";
+  }
+}
+
+template <typename T, typename WT>
+void dispatch_fused_residual_no_raw_world_size(
+    RankData data,
+    const RankData* device_data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual,
+    const WT* weight,
+    T* norm_out,
+    T* residual_out,
+    int rank,
+    int world_size,
+    int rows,
+    int hidden,
+    int shot,
+    float eps,
+    musaStream_t stream) {
+  switch (world_size) {
+    case 2:
+      launch_fused_ar_residual_rmsnorm_no_raw<T, WT, 2>(data, device_data, sg, self_sg, residual, weight, norm_out, residual_out, rank, rows, hidden, shot, eps, stream);
+      break;
+    case 4:
+      launch_fused_ar_residual_rmsnorm_no_raw<T, WT, 4>(data, device_data, sg, self_sg, residual, weight, norm_out, residual_out, rank, rows, hidden, shot, eps, stream);
+      break;
+    case 6:
+      launch_fused_ar_residual_rmsnorm_no_raw<T, WT, 6>(data, device_data, sg, self_sg, residual, weight, norm_out, residual_out, rank, rows, hidden, shot, eps, stream);
+      break;
+    case 8:
+      launch_fused_ar_residual_rmsnorm_no_raw<T, WT, 8>(data, device_data, sg, self_sg, residual, weight, norm_out, residual_out, rank, rows, hidden, shot, eps, stream);
+      break;
+    default:
+      TVM_FFI_THROW(ValueError) << "world_size must be one of 2/4/6/8";
+  }
+}
+
 template <typename T, int nranks, bool indirect>
 void launch_ar(RankData data, const RankData* data_ptr, RankSignals sg, Signal* self_sg, T* out, int rank, int size, int shot, musaStream_t stream) {
   const int pack = packed_t<T>::P::size;
@@ -521,6 +1748,13 @@ void dispatch_all_gather_world_size(RankData data, RankSignals sg,
     default:
       TVM_FFI_THROW(ValueError) << "all-gather world_size must be one of 2/4/8";
   }
+}
+inline void validate_world_size(int64_t world_size) {
+  TVM_FFI_ICHECK(
+      world_size == 2 || world_size == 4 || world_size == 6 ||
+      world_size == 8)
+      << "world_size must be one of 2/4/6/8";
+  TVM_FFI_ICHECK_LE(world_size, kMaxRanks);
 }
 
 }  // namespace
@@ -792,9 +2026,423 @@ void vllm_musa_custom_ar_launch_graph_registered(
   TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA custom AR kernel failed: " << musaGetErrorString(err);
 }
 
+void vllm_musa_fused_ar_rmsnorm_launch_unregistered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView weight,
+    ffi::TensorView norm_out,
+    ffi::TensorView reduced,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t max_size_bytes,
+    int64_t rank,
+    int64_t world_size,
+    int64_t shot,
+    double eps) {
+  validate_world_size(world_size);
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(weight);
+  CHECK_MUSA_CONTIGUOUS(norm_out);
+  CHECK_MUSA_CONTIGUOUS(reduced);
+  const bool rank_data_on_cpu = rank_data.device().device_type == kDLCPU;
+  const bool rank_data_on_musa =
+      rank_data.device().device_type == inp.device().device_type;
+  TVM_FFI_ICHECK(rank_data_on_cpu || rank_data_on_musa);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+  TVM_FFI_ICHECK_EQ(inp.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(norm_out.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(reduced.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(weight.ndim(), 1);
+  TVM_FFI_ICHECK_EQ(inp.size(0), norm_out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), norm_out.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(0), reduced.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), reduced.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(1), weight.size(0));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), norm_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), reduced.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), weight.dtype()) || dtype_equal(weight.dtype(), dl_float32));
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, weight.device().device_id);
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, norm_out.device().device_id);
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, reduced.device().device_id);
+
+  const int64_t rows64 = inp.size(0);
+  const int64_t hidden64 = inp.size(1);
+  TVM_FFI_ICHECK_GT(rows64, 0);
+  TVM_FFI_ICHECK_GT(hidden64, 0);
+  TVM_FFI_ICHECK_EQ(hidden64 % 8, 0);
+  TVM_FFI_ICHECK_LE(rows64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  TVM_FFI_ICHECK_LE(hidden64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  TVM_FFI_ICHECK_LE(rows64 * hidden64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+
+  RankSignals sg{};
+  const auto* ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(ptrs[i]);
+  }
+  RankData data{};
+  const RankData* device_data = nullptr;
+  if (rank_data_on_cpu) {
+    const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+    for (int i = 0; i < kMaxRanks; ++i) {
+      data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+    }
+  } else {
+    TVM_FFI_ICHECK_EQ(rank_data.device().device_id, inp.device().device_id);
+    device_data = reinterpret_cast<const RankData*>(rank_data.data_ptr());
+  }
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(norm_out.device());
+  const int64_t numel64 = tensor_numel(inp);
+  const int64_t nbytes = numel64 * ((static_cast<int64_t>(inp.dtype().bits) * inp.dtype().lanes + 7) / 8);
+  TVM_FFI_ICHECK_LE(nbytes, max_size_bytes);
+  if (rank_data_on_cpu) {
+    const musaError_t copy_err = musaMemcpyAsync(
+        reinterpret_cast<void*>(self_buffer_ptr),
+        inp.data_ptr(),
+        static_cast<size_t>(nbytes),
+        musaMemcpyDeviceToDevice,
+        stream);
+    TVM_FFI_ICHECK_EQ(copy_err, musaSuccess)
+        << "MUSA fused AR-RMSNorm input copy failed: "
+        << musaGetErrorString(copy_err);
+  }
+
+  const int rows = static_cast<int>(rows64);
+  const int hidden = static_cast<int>(hidden64);
+  if (dtype_equal(inp.dtype(), dl_float16)) {
+    if (dtype_equal(weight.dtype(), dl_float32)) {
+      dispatch_fused_world_size<half, float>(
+          data, device_data, sg, self_sg, static_cast<const float*>(weight.data_ptr()),
+          static_cast<half*>(norm_out.data_ptr()), static_cast<half*>(reduced.data_ptr()),
+          static_cast<int>(rank), static_cast<int>(world_size), rows, hidden,
+          static_cast<int>(shot), static_cast<float>(eps), stream);
+    } else {
+      dispatch_fused_world_size<half, half>(
+          data, device_data, sg, self_sg, static_cast<const half*>(weight.data_ptr()),
+          static_cast<half*>(norm_out.data_ptr()), static_cast<half*>(reduced.data_ptr()),
+          static_cast<int>(rank), static_cast<int>(world_size), rows, hidden,
+          static_cast<int>(shot), static_cast<float>(eps), stream);
+    }
+  } else if (dtype_equal(inp.dtype(), dl_bfloat16)) {
+    if (dtype_equal(weight.dtype(), dl_float32)) {
+      dispatch_fused_world_size<__mt_bfloat16, float>(
+          data, device_data, sg, self_sg, static_cast<const float*>(weight.data_ptr()),
+          static_cast<__mt_bfloat16*>(norm_out.data_ptr()), static_cast<__mt_bfloat16*>(reduced.data_ptr()),
+          static_cast<int>(rank), static_cast<int>(world_size), rows, hidden,
+          static_cast<int>(shot), static_cast<float>(eps), stream);
+    } else {
+      dispatch_fused_world_size<__mt_bfloat16, __mt_bfloat16>(
+          data, device_data, sg, self_sg, static_cast<const __mt_bfloat16*>(weight.data_ptr()),
+          static_cast<__mt_bfloat16*>(norm_out.data_ptr()), static_cast<__mt_bfloat16*>(reduced.data_ptr()),
+          static_cast<int>(rank), static_cast<int>(world_size), rows, hidden,
+          static_cast<int>(shot), static_cast<float>(eps), stream);
+    }
+  } else {
+    TVM_FFI_THROW(ValueError) << "fused AR-RMSNorm only supports fp16/bf16";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA fused AR-RMSNorm kernel failed: " << musaGetErrorString(err);
+}
+
+void vllm_musa_fused_ar_residual_rmsnorm_launch_unregistered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView residual,
+    ffi::TensorView weight,
+    ffi::TensorView norm_out,
+    ffi::TensorView residual_out,
+    ffi::TensorView reduced,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t max_size_bytes,
+    int64_t rank,
+    int64_t world_size,
+    int64_t shot,
+    double eps) {
+  validate_world_size(world_size);
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(residual);
+  CHECK_MUSA_CONTIGUOUS(weight);
+  CHECK_MUSA_CONTIGUOUS(norm_out);
+  CHECK_MUSA_CONTIGUOUS(residual_out);
+  CHECK_MUSA_CONTIGUOUS(reduced);
+  const bool rank_data_on_cpu = rank_data.device().device_type == kDLCPU;
+  const bool rank_data_on_musa =
+      rank_data.device().device_type == inp.device().device_type;
+  TVM_FFI_ICHECK(rank_data_on_cpu || rank_data_on_musa);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+  TVM_FFI_ICHECK_EQ(inp.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(residual.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(norm_out.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(residual_out.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(reduced.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(weight.ndim(), 1);
+  TVM_FFI_ICHECK_EQ(inp.size(0), residual.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), residual.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(0), norm_out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), norm_out.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(0), residual_out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), residual_out.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(0), reduced.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), reduced.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(1), weight.size(0));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), residual.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), norm_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), residual_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), reduced.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), weight.dtype()) || dtype_equal(weight.dtype(), dl_float32));
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, residual.device().device_id);
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, weight.device().device_id);
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, norm_out.device().device_id);
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, residual_out.device().device_id);
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, reduced.device().device_id);
+
+  const int64_t rows64 = inp.size(0);
+  const int64_t hidden64 = inp.size(1);
+  TVM_FFI_ICHECK_GT(rows64, 0);
+  TVM_FFI_ICHECK_GT(hidden64, 0);
+  TVM_FFI_ICHECK_EQ(hidden64 % 8, 0);
+  TVM_FFI_ICHECK_LE(rows64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  TVM_FFI_ICHECK_LE(hidden64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  TVM_FFI_ICHECK_LE(rows64 * hidden64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+
+  RankSignals sg{};
+  const auto* ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(ptrs[i]);
+  }
+  RankData data{};
+  const RankData* device_data = nullptr;
+  if (rank_data_on_cpu) {
+    const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+    for (int i = 0; i < kMaxRanks; ++i) {
+      data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+    }
+  } else {
+    TVM_FFI_ICHECK_EQ(rank_data.device().device_id, inp.device().device_id);
+    device_data = reinterpret_cast<const RankData*>(rank_data.data_ptr());
+  }
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(norm_out.device());
+  const int64_t numel64 = tensor_numel(inp);
+  const int64_t nbytes = numel64 * ((static_cast<int64_t>(inp.dtype().bits) * inp.dtype().lanes + 7) / 8);
+  TVM_FFI_ICHECK_LE(nbytes, max_size_bytes);
+  if (rank_data_on_cpu) {
+    const musaError_t copy_err = musaMemcpyAsync(
+        reinterpret_cast<void*>(self_buffer_ptr),
+        inp.data_ptr(),
+        static_cast<size_t>(nbytes),
+        musaMemcpyDeviceToDevice,
+        stream);
+    TVM_FFI_ICHECK_EQ(copy_err, musaSuccess)
+        << "MUSA fused AR-residual-RMSNorm input copy failed: "
+        << musaGetErrorString(copy_err);
+  }
+
+  const int rows = static_cast<int>(rows64);
+  const int hidden = static_cast<int>(hidden64);
+  if (dtype_equal(inp.dtype(), dl_float16)) {
+    if (dtype_equal(weight.dtype(), dl_float32)) {
+      dispatch_fused_residual_world_size<half, float>(
+          data, device_data, sg, self_sg, static_cast<const half*>(residual.data_ptr()),
+          static_cast<const float*>(weight.data_ptr()), static_cast<half*>(norm_out.data_ptr()),
+          static_cast<half*>(residual_out.data_ptr()), static_cast<half*>(reduced.data_ptr()),
+          static_cast<int>(rank),
+          static_cast<int>(world_size), rows, hidden, static_cast<int>(shot),
+          static_cast<float>(eps), stream);
+    } else {
+      dispatch_fused_residual_world_size<half, half>(
+          data, device_data, sg, self_sg, static_cast<const half*>(residual.data_ptr()),
+          static_cast<const half*>(weight.data_ptr()), static_cast<half*>(norm_out.data_ptr()),
+          static_cast<half*>(residual_out.data_ptr()), static_cast<half*>(reduced.data_ptr()),
+          static_cast<int>(rank),
+          static_cast<int>(world_size), rows, hidden, static_cast<int>(shot),
+          static_cast<float>(eps), stream);
+    }
+  } else if (dtype_equal(inp.dtype(), dl_bfloat16)) {
+    if (dtype_equal(weight.dtype(), dl_float32)) {
+      dispatch_fused_residual_world_size<__mt_bfloat16, float>(
+          data, device_data, sg, self_sg, static_cast<const __mt_bfloat16*>(residual.data_ptr()),
+          static_cast<const float*>(weight.data_ptr()), static_cast<__mt_bfloat16*>(norm_out.data_ptr()),
+          static_cast<__mt_bfloat16*>(residual_out.data_ptr()), static_cast<__mt_bfloat16*>(reduced.data_ptr()),
+          static_cast<int>(rank),
+          static_cast<int>(world_size), rows, hidden, static_cast<int>(shot),
+          static_cast<float>(eps), stream);
+    } else {
+      dispatch_fused_residual_world_size<__mt_bfloat16, __mt_bfloat16>(
+          data, device_data, sg, self_sg, static_cast<const __mt_bfloat16*>(residual.data_ptr()),
+          static_cast<const __mt_bfloat16*>(weight.data_ptr()), static_cast<__mt_bfloat16*>(norm_out.data_ptr()),
+          static_cast<__mt_bfloat16*>(residual_out.data_ptr()), static_cast<__mt_bfloat16*>(reduced.data_ptr()),
+          static_cast<int>(rank),
+          static_cast<int>(world_size), rows, hidden, static_cast<int>(shot),
+          static_cast<float>(eps), stream);
+    }
+  } else {
+    TVM_FFI_THROW(ValueError) << "fused AR-residual-RMSNorm only supports fp16/bf16";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA fused AR-residual-RMSNorm kernel failed: " << musaGetErrorString(err);
+}
+
+void vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView residual,
+    ffi::TensorView weight,
+    ffi::TensorView norm_out,
+    ffi::TensorView residual_out,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t max_size_bytes,
+    int64_t rank,
+    int64_t world_size,
+    int64_t shot,
+    double eps) {
+  validate_world_size(world_size);
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(residual);
+  CHECK_MUSA_CONTIGUOUS(weight);
+  CHECK_MUSA_CONTIGUOUS(norm_out);
+  CHECK_MUSA_CONTIGUOUS(residual_out);
+  const bool rank_data_on_cpu = rank_data.device().device_type == kDLCPU;
+  const bool rank_data_on_musa =
+      rank_data.device().device_type == inp.device().device_type;
+  TVM_FFI_ICHECK(rank_data_on_cpu || rank_data_on_musa);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+  TVM_FFI_ICHECK_EQ(inp.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(residual.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(norm_out.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(residual_out.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(weight.ndim(), 1);
+  TVM_FFI_ICHECK_EQ(inp.size(0), residual.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), residual.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(0), norm_out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), norm_out.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(0), residual_out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), residual_out.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(1), weight.size(0));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), residual.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), norm_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), residual_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), weight.dtype()) || dtype_equal(weight.dtype(), dl_float32));
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, residual.device().device_id);
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, weight.device().device_id);
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, norm_out.device().device_id);
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, residual_out.device().device_id);
+
+  const int64_t rows64 = inp.size(0);
+  const int64_t hidden64 = inp.size(1);
+  TVM_FFI_ICHECK_GT(rows64, 0);
+  TVM_FFI_ICHECK_GT(hidden64, 0);
+  TVM_FFI_ICHECK_EQ(hidden64 % 8, 0);
+  TVM_FFI_ICHECK_LE(rows64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  TVM_FFI_ICHECK_LE(hidden64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  TVM_FFI_ICHECK_LE(rows64 * hidden64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+
+  RankSignals sg{};
+  const auto* ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(ptrs[i]);
+  }
+  RankData data{};
+  const RankData* device_data = nullptr;
+  if (rank_data_on_cpu) {
+    const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+    for (int i = 0; i < kMaxRanks; ++i) {
+      data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+    }
+  } else {
+    TVM_FFI_ICHECK_EQ(rank_data.device().device_id, inp.device().device_id);
+    device_data = reinterpret_cast<const RankData*>(rank_data.data_ptr());
+  }
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(norm_out.device());
+  const int64_t numel64 = tensor_numel(inp);
+  const int64_t nbytes = numel64 * ((static_cast<int64_t>(inp.dtype().bits) * inp.dtype().lanes + 7) / 8);
+  TVM_FFI_ICHECK_LE(nbytes, max_size_bytes);
+  if (rank_data_on_cpu) {
+    const musaError_t copy_err = musaMemcpyAsync(
+        reinterpret_cast<void*>(self_buffer_ptr),
+        inp.data_ptr(),
+        static_cast<size_t>(nbytes),
+        musaMemcpyDeviceToDevice,
+        stream);
+    TVM_FFI_ICHECK_EQ(copy_err, musaSuccess)
+        << "MUSA fused AR-residual-RMSNorm no-raw input copy failed: "
+        << musaGetErrorString(copy_err);
+  }
+
+  const int rows = static_cast<int>(rows64);
+  const int hidden = static_cast<int>(hidden64);
+  if (dtype_equal(inp.dtype(), dl_float16)) {
+    if (dtype_equal(weight.dtype(), dl_float32)) {
+      dispatch_fused_residual_no_raw_world_size<half, float>(
+          data, device_data, sg, self_sg, static_cast<const half*>(residual.data_ptr()),
+          static_cast<const float*>(weight.data_ptr()), static_cast<half*>(norm_out.data_ptr()),
+          static_cast<half*>(residual_out.data_ptr()), static_cast<int>(rank),
+          static_cast<int>(world_size), rows, hidden, static_cast<int>(shot),
+          static_cast<float>(eps), stream);
+    } else {
+      dispatch_fused_residual_no_raw_world_size<half, half>(
+          data, device_data, sg, self_sg, static_cast<const half*>(residual.data_ptr()),
+          static_cast<const half*>(weight.data_ptr()), static_cast<half*>(norm_out.data_ptr()),
+          static_cast<half*>(residual_out.data_ptr()), static_cast<int>(rank),
+          static_cast<int>(world_size), rows, hidden, static_cast<int>(shot),
+          static_cast<float>(eps), stream);
+    }
+  } else if (dtype_equal(inp.dtype(), dl_bfloat16)) {
+    if (dtype_equal(weight.dtype(), dl_float32)) {
+      dispatch_fused_residual_no_raw_world_size<__mt_bfloat16, float>(
+          data, device_data, sg, self_sg, static_cast<const __mt_bfloat16*>(residual.data_ptr()),
+          static_cast<const float*>(weight.data_ptr()), static_cast<__mt_bfloat16*>(norm_out.data_ptr()),
+          static_cast<__mt_bfloat16*>(residual_out.data_ptr()), static_cast<int>(rank),
+          static_cast<int>(world_size), rows, hidden, static_cast<int>(shot),
+          static_cast<float>(eps), stream);
+    } else {
+      dispatch_fused_residual_no_raw_world_size<__mt_bfloat16, __mt_bfloat16>(
+          data, device_data, sg, self_sg, static_cast<const __mt_bfloat16*>(residual.data_ptr()),
+          static_cast<const __mt_bfloat16*>(weight.data_ptr()), static_cast<__mt_bfloat16*>(norm_out.data_ptr()),
+          static_cast<__mt_bfloat16*>(residual_out.data_ptr()), static_cast<int>(rank),
+          static_cast<int>(world_size), rows, hidden, static_cast<int>(shot),
+          static_cast<float>(eps), stream);
+    }
+  } else {
+    TVM_FFI_THROW(ValueError) << "fused AR-residual-RMSNorm no-raw only supports fp16/bf16";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA fused AR-residual-RMSNorm no-raw kernel failed: " << musaGetErrorString(err);
+}
+
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_meta_size, vllm_musa_custom_ar_meta_size);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_unregistered, vllm_musa_custom_ar_launch_unregistered);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_all_gather,
                               vllm_musa_custom_ar_launch_all_gather);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_registered, vllm_musa_custom_ar_launch_registered);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_graph_registered, vllm_musa_custom_ar_launch_graph_registered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_fused_ar_rmsnorm_launch_unregistered, vllm_musa_fused_ar_rmsnorm_launch_unregistered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_fused_ar_residual_rmsnorm_launch_unregistered, vllm_musa_fused_ar_residual_rmsnorm_launch_unregistered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered, vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered);

--- a/vllm_musa/patches/series/0003-MUSA-vllm.compilation.passes.pass_manager.patch
+++ b/vllm_musa/patches/series/0003-MUSA-vllm.compilation.passes.pass_manager.patch
@@ -4,14 +4,14 @@ Date: Wed, 3 Jun 2026 11:47:35 +0000
 Subject: [PATCH] MUSA: vllm.compilation.passes.pass_manager
 
 ---
- vllm/compilation/passes/pass_manager.py | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ vllm/compilation/passes/pass_manager.py | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
 
 diff --git a/vllm/compilation/passes/pass_manager.py b/vllm/compilation/passes/pass_manager.py
-index 4b98ac577..5a4bbcb26 100644
+index 4b98ac577..3033e46f4 100644
 --- a/vllm/compilation/passes/pass_manager.py
 +++ b/vllm/compilation/passes/pass_manager.py
-@@ -43,7 +43,7 @@ if current_platform.is_cuda_alike():
+@@ -43,10 +43,15 @@ if current_platform.is_cuda_alike():
      from .utility.scatter_split_replace import ScatterSplitReplacementPass
      from .utility.split_coalescing import SplitCoalescingPass
  
@@ -20,3 +20,24 @@ index 4b98ac577..5a4bbcb26 100644
      from .fusion.allreduce_rms_fusion import AllReduceFusionPass
      from .fusion.collective_fusion import AsyncTPPass
  
++if current_platform.is_musa():
++    from vllm_musa._inductor.musa_allreduce_rms_fusion import (
++        MusaAllReduceRMSNormFusionPass,
++    )
++
+ if current_platform.is_xpu():
+     from .fusion.act_quant_fusion import ActivationQuantFusionPass
+     from .fusion.rms_quant_fusion import RMSNormQuantFusionPass
+@@ -151,8 +156,11 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
+             if self.pass_config.fuse_act_padding and rocm_aiter_ops.is_enabled():
+                 # Run the more specific RMSNorm+router-pad fusion before
+                 # AR+RMS, since both consume fused_add_rms_norm.
+                 self.passes += [RocmAiterTritonAddRMSNormPadFusionPass(config)]
+-
++
++            if current_platform.is_musa():
++                self.passes += [MusaAllReduceRMSNormFusionPass(config)]
++
+             if self.pass_config.fuse_allreduce_rms:
+                 if rocm_aiter_ops.is_enabled():
+                     self.passes += [RocmAiterAllReduceFusionPass(config)]

--- a/vllm_musa/patches/series/0003-MUSA-vllm.compilation.passes.pass_manager.patch
+++ b/vllm_musa/patches/series/0003-MUSA-vllm.compilation.passes.pass_manager.patch
@@ -35,7 +35,7 @@ index 4b98ac577..3033e46f4 100644
                  self.passes += [RocmAiterTritonAddRMSNormPadFusionPass(config)]
 -
 +
-+            if current_platform.is_musa():
++            if current_platform.is_musa() and self.pass_config.fuse_allreduce_rms:
 +                self.passes += [MusaAllReduceRMSNormFusionPass(config)]
 +
              if self.pass_config.fuse_allreduce_rms:

--- a/vllm_musa/patches/series/0003-MUSA-vllm.compilation.passes.pass_manager.patch
+++ b/vllm_musa/patches/series/0003-MUSA-vllm.compilation.passes.pass_manager.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: musa <musa@local>
+From: Elon Gao <elon.gao@mthread.com>
 Date: Wed, 3 Jun 2026 11:47:35 +0000
 Subject: [PATCH] MUSA: vllm.compilation.passes.pass_manager
 

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -86,27 +86,14 @@ class EnvBool(EnvField):
         raise ValueError(f'"{value}" is not a valid boolean value')
 
 
-class EnvInt(EnvField):
-    def parse(self, value: str) -> int:
-        return int(value)
-
-
 class Envs:
     VLLM_MUSA_CUSTOM_OP_USE_NATIVE = EnvBool(False)
     VLLM_MUSA_FUSED_ADD_RMSNORM = EnvBool(True)
-    # Enable the MUSA CAR-RMSNorm graph rewrite and fused runtime path.
-    VLLM_MUSA_FUSED_AR_RMSNORM = EnvBool(False)
-    # Opt in to exchanging Graph-input IPC handles. Eager execution and the
-    # default Graph path keep using the fixed staging buffer.
-    VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT = EnvBool(False)
-    # Direct graph-input IPC was faster through 512 KiB and regressed at
-    # 640/960 KiB in paired TP2 tests; larger inputs keep the staging path.
-    VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT_MAX_BYTES = EnvInt(
-        512 * 1024
-    )
-    # Opt-in detailed graph-candidate diagnostics for CAR-RMSNorm fusion.
-    # Keep disabled by default so normal inference has no per-node log volume.
-    VLLM_MUSA_FUSED_AR_RMSNORM_DEBUG = EnvBool(False)
+    # Enable the MUSA custom all-reduce and RMSNorm fused path.
+    VLLM_MUSA_FUSED_AR_RMSNORM = EnvBool(True)
+    # Use registered graph inputs when eligible. Explicitly disabling this
+    # option keeps the fused path and uses the staging-buffer fallback.
+    VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT = EnvBool(True)
     VLLM_MUSA_ENABLE_JIT_TOPK = EnvBool(True)
     VLLM_MUSA_SEEDED_MULTINOMIAL = EnvBool(True)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -86,9 +86,27 @@ class EnvBool(EnvField):
         raise ValueError(f'"{value}" is not a valid boolean value')
 
 
+class EnvInt(EnvField):
+    def parse(self, value: str) -> int:
+        return int(value)
+
+
 class Envs:
     VLLM_MUSA_CUSTOM_OP_USE_NATIVE = EnvBool(False)
     VLLM_MUSA_FUSED_ADD_RMSNORM = EnvBool(True)
+    # Enable the MUSA CAR-RMSNorm graph rewrite and fused runtime path.
+    VLLM_MUSA_FUSED_AR_RMSNORM = EnvBool(False)
+    # Opt in to exchanging Graph-input IPC handles. Eager execution and the
+    # default Graph path keep using the fixed staging buffer.
+    VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT = EnvBool(False)
+    # Direct graph-input IPC was faster through 512 KiB and regressed at
+    # 640/960 KiB in paired TP2 tests; larger inputs keep the staging path.
+    VLLM_MUSA_FUSED_AR_RMSNORM_GRAPH_REGISTERED_INPUT_MAX_BYTES = EnvInt(
+        512 * 1024
+    )
+    # Opt-in detailed graph-candidate diagnostics for CAR-RMSNorm fusion.
+    # Keep disabled by default so normal inference has no per-node log volume.
+    VLLM_MUSA_FUSED_AR_RMSNORM_DEBUG = EnvBool(False)
     VLLM_MUSA_ENABLE_JIT_TOPK = EnvBool(True)
     VLLM_MUSA_SEEDED_MULTINOMIAL = EnvBool(True)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)


### PR DESCRIPTION
# Optimize MUSA custom allreduce RMSNorm fusion

## Summary

This PR adds and wires the MUSA JIT custom allreduce + RMSNorm fused path for
the supported tensor-parallel world sizes (TP2/TP4/TP8). It includes
graph-safe registered-input handling and keeps the existing behavior as the
fallback when the feature is disabled or a shape is not eligible. The
included serving matrix covers TP2 and TP4.

Key changes:

- Add the MUSA JIT fused custom allreduce + RMSNorm kernels and Python launch
  bindings, including residual-output variants.
- Integrate fused dispatch with the lifecycle-managed communicator registry.
- Keep eager/prefill on fixed staging with the D2D fallback, while eligible
  captured graphs use registered input pointers without a per-replay copy.
- Add graph-capture registration and recapture handling so registered pointers
  cannot become stale or remain placeholder data.
- Add Inductor graph rewrites and environment-controlled opt-in/fallback paths.
- Limit the TP4 `rows=64` two-shot kernel to 32 blocks to reduce
  synchronization overhead.
- Add source-level coverage for graph registration, fusion, and safety guards.

test:

Serving performance used Qwen3.5-35B-A3B BF16/FP8 with TP4 and
Qwen3.5-27B BF16/FP8 with TP2 on S5000. This PR reports only 4096→1024;
batch sizes are 1/4/16/64. Baseline is the paired mean of two disabled control
runs; Fused is the enabled run. Throughput `+` is better; TTFT/TPOT/E2E `-`
is better.

Source contract test:

```bash
pytest -q tests/test_fused_ar_registered_graph_source.py
```

Serving command used for each control/fused run:

```bash
vllm bench serve --backend openai-chat --base-url http://127.0.0.1:<PORT> \
  --endpoint /v1/chat/completions --model <SERVED_MODEL> --tokenizer <MODEL> \
  --dataset-name random --random-input-len 4096 --random-output-len 1024 \
  --num-prompts <BS> --max-concurrency <BS> --request-rate inf \
  --temperature 0 --seed 0 --ignore-eos --trust-remote-code \
  --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 50,90,95,99
```

The three runs use the disabled/fused/disabled feature settings. The server
uses TP4 for 35B or TP2 for 27B, `max_model_len=5184`, `max_num_seqs=64`,
`FLASH_ATTN`, normal graph capture, and no eager or compile-disabling flags.

| Model | Precision | Input→Output | BS | TP | Baseline output (tok/s) | Fused output (tok/s) | Throughput Δ | TTFT Δ | TPOT Δ | E2E Δ | Reps/leg |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Qwen3.5-35B-A3B | BF16 | 4096→1024 | 1 | 4 | 55.47 | 55.82 | +0.634% | -2.309% | -0.617% | -0.630% | 5 |
| Qwen3.5-35B-A3B | BF16 | 4096→1024 | 4 | 4 | 229.75 | 231.77 | +0.880% | -2.031% | -0.851% | -0.874% | 5 |
| Qwen3.5-35B-A3B | BF16 | 4096→1024 | 16 | 4 | 690.80 | 692.86 | +0.298% | -1.757% | -0.250% | -0.319% | 5 |
| Qwen3.5-35B-A3B | BF16 | 4096→1024 | 64 | 4 | 1729.47 | 1730.60 | +0.065% | -1.904% | +0.116% | -0.110% | 5 |
| Qwen3.5-35B-A3B-FP8 | FP8 | 4096→1024 | 1 | 4 | 58.00 | 58.64 | +1.097% | -1.922% | -1.078% | -1.085% | 5 |
| Qwen3.5-35B-A3B-FP8 | FP8 | 4096→1024 | 4 | 4 | 211.93 | 213.48 | +0.731% | -2.286% | -0.697% | -0.726% | 5 |
| Qwen3.5-35B-A3B-FP8 | FP8 | 4096→1024 | 16 | 4 | 642.71 | 645.41 | +0.419% | -0.860% | -0.398% | -0.419% | 5 |
| Qwen3.5-35B-A3B-FP8 | FP8 | 4096→1024 | 64 | 4 | 1442.36 | 1447.94 | +0.387% | -2.177% | -0.157% | -0.362% | 5 |
| Qwen3.5-27B | BF16 | 4096→1024 | 1 | 2 | 29.51 | 30.46 | +3.215% | -3.008% | -3.116% | -3.115% | 5 |
| Qwen3.5-27B | BF16 | 4096→1024 | 4 | 2 | 103.11 | 105.24 | +2.071% | -2.910% | -1.997% | -2.028% | 5 |
| Qwen3.5-27B | BF16 | 4096→1024 | 16 | 2 | 296.47 | 300.78 | +1.454% | -2.662% | -1.320% | -1.432% | 5 |
| Qwen3.5-27B | BF16 | 4096→1024 | 64 | 2 | 582.10 | 588.20 | +1.047% | -2.489% | -0.762% | -1.041% | 5 |
| Qwen3.5-27B-FP8 | FP8 | 4096→1024 | 1 | 2 | 38.98 | 40.31 | +3.425% | -3.869% | -3.302% | -3.312% | 5 |
| Qwen3.5-27B-FP8 | FP8 | 4096→1024 | 4 | 2 | 131.22 | 134.45 | +2.461% | -3.908% | -2.344% | -2.403% | 5 |
| Qwen3.5-27B-FP8 | FP8 | 4096→1024 | 16 | 2 | 360.95 | 367.30 | +1.760% | -3.470% | -1.562% | -1.728% | 5 |
| Qwen3.5-27B-FP8 | FP8 | 4096→1024 | 64 | 2 | 669.85 | 678.56 | +1.300% | -3.339% | -0.895% | -1.285% | 5 |

Focused repeated validation:

- Qwen3.5-35B-A3B BF16, TP4, 4096→1024, BS64 used 10 formal repetitions per leg: 30/30 samples, 1,920 completed requests, 0 failures.
- Output throughput: `1729.47 → 1730.60 tok/s` (`+0.065%`).
- TTFT: `4168.08 → 4088.73 ms` (`-1.904%`).
- TPOT: `32.313 → 32.351 ms` (`+0.116%`).
- E2E: `37224.35 → 37183.33 ms` (`-0.110%`).
- The earlier apparent regression did not reproduce in this repeated run.

Functional and source validation:

- `PASS`: all three semantic smoke requests returned the expected response.
- `PASS`: all 8 changed feature-file hashes match the candidate commit.
- `PASS`: candidate commit `b4a2e8b94f10c92ff1e04bd19dda664e7f8b035d` has tree `2b1b12a1eef9f2c0166d563bb8ba32987ff593bc`, identical to the tested tree.
- `PASS`: no textual merge conflict against `v0.24.0-dev@6c7ef2f8d4939de2f76f17990419258663456e2c`.

Evidence boundary:

- The focused 35B BF16 4096→1024 BS64 row is the clean-source repeated run.
- The remaining 15 rows are historical comparison context whose source commit was not recorded; they are not relabeled as clean-SHA results.
- The table contains mean deltas and does not claim that every delta is statistically significant.
