### PR TITLE
Update MUSA dependency pins and Pymtml

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,7 +1,7 @@
 # Runtime Python dependencies that are portable across MUSA images.
 # 0.1.76 ports nested torch/cuda.h includes to torch/musa.h during builds.
 torchada>=0.1.76
-mthreads-ml-py>=2.2.11
+mthreads-ml-py>=2.4.1
 numpy==1.26
 openai>=2.24.0
 transformers==5.5.3

--- a/requirements/musa_private.txt
+++ b/requirements/musa_private.txt
@@ -12,10 +12,10 @@
 # projects on public PyPI, so they must resolve from the Moore Threads index
 # only. Versions below track the MUSA release_5.2.0 Python Wheel guide.
 
-torch==2.9.1.post1+musa5.2.0s5000
-torch_musa==2.9.1.post1+musa5.2.0s5000
-torchvision==0.24.1.post1+musa5.2.0s5000
-torchaudio==2.9.1+musa5.2.0s5000
+torch==2.9.1.post1+musa5.2.0
+torch_musa==2.9.1.post1+musa5.2.0
+torchvision==0.24.1.post1+musa5.2.0
+torchaudio==2.9.1+musa5.2.0
 mate==0.2.4
 flash_attn_3==0.2.4
 flash_mla==0.2.4


### PR DESCRIPTION
 ## Summary
 - Bump `mthreads-ml-py` to `>=2.4.1`, because `2.4.1` can be installed directly via `pip install`.
 - Update MUSA wheel pins to match the current PyPI naming in the MUSA index, where the `s5000` suffix has been removed
