### PR TITLE
Perf/musa3508 deepseek v4 c4 compressor

### DIFF
--- a/csrc/musa/attention/deepseek_v4_c4_indexer_compressor.mu
+++ b/csrc/musa/attention/deepseek_v4_c4_indexer_compressor.mu
@@ -1,0 +1,458 @@
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+
+#include <musa_bf16.h>
+#include <musa_fp8.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+namespace {
+
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kRopeDim = 64;
+constexpr int64_t kNopeDim = kHeadDim - kRopeDim;
+constexpr int64_t kStateWidth = 2 * kHeadDim;
+constexpr int64_t kStateRowWidth = 2 * kStateWidth;
+constexpr int64_t kStateBlockSize = 4;
+constexpr int64_t kCompressRatio = 4;
+constexpr int64_t kCompressRows = 2 * kCompressRatio;
+constexpr int64_t kTokenValueBytes = kHeadDim;
+constexpr int64_t kTokenScaleBytes = sizeof(float);
+constexpr int64_t kWarpsPerBlock = 4;
+constexpr int64_t kThreadsPerBlock = 32 * kWarpsPerBlock;
+constexpr int64_t kMaxDecodeRows = 128;
+constexpr float kFp8Max = 448.0f;
+constexpr float kLog2E = 1.4426950408889634f;
+
+constexpr int kIndexInt32 = 1;
+constexpr int kIndexInt64 = 2;
+
+__device__ __forceinline__ int64_t load_index(const void* ptr, int kind,
+                                              int64_t idx) {
+  if (kind == kIndexInt32) {
+    return static_cast<int64_t>(static_cast<const int32_t*>(ptr)[idx]);
+  }
+  return static_cast<const int64_t*>(ptr)[idx];
+}
+
+__device__ __forceinline__ float warp_reduce_sum(float value) {
+  value += __shfl_xor_sync(0xffffffffu, value, 16);
+  value += __shfl_xor_sync(0xffffffffu, value, 8);
+  value += __shfl_xor_sync(0xffffffffu, value, 4);
+  value += __shfl_xor_sync(0xffffffffu, value, 2);
+  value += __shfl_xor_sync(0xffffffffu, value, 1);
+  return value;
+}
+
+__device__ __forceinline__ uint32_t warp_reduce_max_u32(uint32_t value) {
+  uint32_t peer = __shfl_xor_sync(0xffffffffu, value, 16);
+  value = value > peer ? value : peer;
+  peer = __shfl_xor_sync(0xffffffffu, value, 8);
+  value = value > peer ? value : peer;
+  peer = __shfl_xor_sync(0xffffffffu, value, 4);
+  value = value > peer ? value : peer;
+  peer = __shfl_xor_sync(0xffffffffu, value, 2);
+  value = value > peer ? value : peer;
+  peer = __shfl_xor_sync(0xffffffffu, value, 1);
+  return value > peer ? value : peer;
+}
+
+__device__ __forceinline__ float weight_to_float(float value) { return value; }
+
+__device__ __forceinline__ float weight_to_float(__mt_bfloat16 value) {
+  return __bfloat162float(value);
+}
+
+__device__ __forceinline__ float clamp_fp8(float value) {
+  return fminf(fmaxf(value, -kFp8Max), kFp8Max);
+}
+
+template <typename WeightT, int kKvBlockSize>
+__global__ __launch_bounds__(kThreadsPerBlock, 4)
+void deepseek_v4_c4_indexer_compressor_kernel(
+    const float* __restrict__ state_cache, int64_t state_stride0,
+    int64_t state_stride1, const void* __restrict__ token_to_req_indices,
+    int token_to_req_kind, const void* __restrict__ positions,
+    int position_kind, const void* __restrict__ state_slot_mapping,
+    int state_slot_kind, const void* __restrict__ block_table,
+    int block_table_kind, int64_t block_table_stride,
+    const WeightT* __restrict__ rms_norm_weight,
+    const float* __restrict__ cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache, int64_t kv_cache_stride0,
+    const void* __restrict__ kv_slot_mapping, int kv_slot_kind, float rms_eps,
+    int64_t num_tokens, int64_t num_state_blocks, int64_t num_reqs,
+    int64_t max_blocks_per_req, int64_t num_kv_blocks) {
+  const int warp = threadIdx.x >> 5;
+  const int lane = threadIdx.x & 31;
+  const int64_t token =
+      static_cast<int64_t>(blockIdx.x) * kWarpsPerBlock + warp;
+  if (token >= num_tokens) {
+    return;
+  }
+
+  // Preserve the Triton PAD and compression-boundary semantics. Every lane in
+  // a warp observes the same branch, so early returns do not break reductions.
+  const int64_t state_slot =
+      load_index(state_slot_mapping, state_slot_kind, token);
+  if (state_slot < 0 ||
+      state_slot >= num_state_blocks * kStateBlockSize) {
+    return;
+  }
+  const int64_t position = load_index(positions, position_kind, token);
+  if (position < kCompressRatio - 1 ||
+      (position + 1) % kCompressRatio != 0) {
+    return;
+  }
+  const int64_t req_idx =
+      load_index(token_to_req_indices, token_to_req_kind, token);
+  if (req_idx < 0 || req_idx >= num_reqs) {
+    return;
+  }
+
+  // One lane owns four adjacent head dimensions. The eight C4 rows are kept
+  // in registers; unlike the Triton program this packs four logical programs
+  // into a single 128-thread block without using shared memory or barriers.
+  float kv[kCompressRows][4];
+  float score[kCompressRows][4];
+  const int64_t first_position = position - kCompressRows + 1;
+
+#pragma unroll
+  for (int row = 0; row < kCompressRows; ++row) {
+    const int64_t source_position = first_position + row;
+    bool valid = source_position >= 0;
+    int64_t physical_block = 0;
+    const int64_t logical_block = source_position / kStateBlockSize;
+    if (valid) {
+      valid = logical_block >= 0 && logical_block < max_blocks_per_req;
+    }
+    if (valid) {
+      physical_block = load_index(
+          block_table, block_table_kind,
+          req_idx * block_table_stride + logical_block);
+      valid = physical_block >= 0 && physical_block < num_state_blocks;
+    }
+
+    float4 kv_vec = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 score_vec =
+        make_float4(-FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX);
+    if (valid) {
+      const int64_t block_offset = source_position % kStateBlockSize;
+      const int64_t head_offset = row >= kCompressRatio ? kHeadDim : 0;
+      const float* row_ptr = state_cache + physical_block * state_stride0 +
+                             block_offset * state_stride1 + head_offset +
+                             lane * 4;
+      kv_vec = *reinterpret_cast<const float4*>(row_ptr);
+      score_vec = *reinterpret_cast<const float4*>(row_ptr + kStateWidth);
+    }
+    kv[row][0] = kv_vec.x;
+    kv[row][1] = kv_vec.y;
+    kv[row][2] = kv_vec.z;
+    kv[row][3] = kv_vec.w;
+    score[row][0] = score_vec.x;
+    score[row][1] = score_vec.y;
+    score[row][2] = score_vec.z;
+    score[row][3] = score_vec.w;
+  }
+
+  // Stable per-dimension softmax and weighted reduction. The exp2 form follows
+  // the optimized SGLang C4 kernel and matches the fast-math lowering used by
+  // MUSA Triton for exp.
+  float max0 = score[0][0];
+  float max1 = score[0][1];
+  float max2 = score[0][2];
+  float max3 = score[0][3];
+#pragma unroll
+  for (int row = 1; row < kCompressRows; ++row) {
+    max0 = fmaxf(max0, score[row][0]);
+    max1 = fmaxf(max1, score[row][1]);
+    max2 = fmaxf(max2, score[row][2]);
+    max3 = fmaxf(max3, score[row][3]);
+  }
+  float denominator0 = 0.0f;
+  float denominator1 = 0.0f;
+  float denominator2 = 0.0f;
+  float denominator3 = 0.0f;
+  float numerator0 = 0.0f;
+  float numerator1 = 0.0f;
+  float numerator2 = 0.0f;
+  float numerator3 = 0.0f;
+#pragma unroll
+  for (int row = 0; row < kCompressRows; ++row) {
+    const float exp0 = exp2f((score[row][0] - max0) * kLog2E);
+    const float exp1 = exp2f((score[row][1] - max1) * kLog2E);
+    const float exp2 = exp2f((score[row][2] - max2) * kLog2E);
+    const float exp3 = exp2f((score[row][3] - max3) * kLog2E);
+    numerator0 += kv[row][0] * exp0;
+    numerator1 += kv[row][1] * exp1;
+    numerator2 += kv[row][2] * exp2;
+    numerator3 += kv[row][3] * exp3;
+    denominator0 += exp0;
+    denominator1 += exp1;
+    denominator2 += exp2;
+    denominator3 += exp3;
+  }
+  float compressed[4] = {
+      numerator0 / denominator0,
+      numerator1 / denominator1,
+      numerator2 / denominator2,
+      numerator3 / denominator3,
+  };
+
+  float sum_of_squares = 0.0f;
+#pragma unroll
+  for (int elem = 0; elem < 4; ++elem) {
+    sum_of_squares += compressed[elem] * compressed[elem];
+  }
+  sum_of_squares = warp_reduce_sum(sum_of_squares);
+  const float norm_factor =
+      rsqrtf(sum_of_squares / static_cast<float>(kHeadDim) + rms_eps);
+
+  float output[4];
+#pragma unroll
+  for (int elem = 0; elem < 4; ++elem) {
+    output[elem] = compressed[elem] * norm_factor *
+                   weight_to_float(rms_norm_weight[lane * 4 + elem]);
+  }
+
+  // vLLM's indexer cache contract applies GPT-J interleaved RoPE to the final
+  // 64 dimensions. Do not import SGLang's subsequent Hadamard transform: its
+  // query/indexer contract differs and vLLM's eager reference has no Hadamard.
+  if (lane >= kNopeDim / 4) {
+    const int64_t pair_base = (lane - kNopeDim / 4) * 2;
+    const int64_t compressed_position =
+        (position / kCompressRatio) * kCompressRatio;
+    const float* cos_ptr =
+        cos_sin_cache + compressed_position * cos_sin_stride;
+    const float* sin_ptr = cos_ptr + kRopeDim / 2;
+
+    const float even0 = output[0];
+    const float odd0 = output[1];
+    const float even1 = output[2];
+    const float odd1 = output[3];
+    const float cos0 = cos_ptr[pair_base];
+    const float sin0 = sin_ptr[pair_base];
+    const float cos1 = cos_ptr[pair_base + 1];
+    const float sin1 = sin_ptr[pair_base + 1];
+    output[0] = even0 * cos0 - odd0 * sin0;
+    output[1] = odd0 * cos0 + even0 * sin0;
+    output[2] = even1 * cos1 - odd1 * sin1;
+    output[3] = odd1 * cos1 + even1 * sin1;
+  }
+
+  // Match the existing kernel's one bf16 rounding point before absmax/FP8.
+#pragma unroll
+  for (int elem = 0; elem < 4; ++elem) {
+    output[elem] = __bfloat162float(__float2bfloat16(output[elem]));
+  }
+
+  // Positive finite float bit patterns preserve numeric ordering. The latest
+  // SGLang C4 decode path uses this integer max to reduce the absmax latency.
+  uint32_t local_absmax_bits =
+      __float_as_uint(output[0]) & 0x7fffffffu;
+#pragma unroll
+  for (int elem = 1; elem < 4; ++elem) {
+    const uint32_t abs_bits = __float_as_uint(output[elem]) & 0x7fffffffu;
+    local_absmax_bits =
+        local_absmax_bits > abs_bits ? local_absmax_bits : abs_bits;
+  }
+  const float absmax = fmaxf(
+      1.0e-4f, __uint_as_float(warp_reduce_max_u32(local_absmax_bits)));
+  const int exponent = static_cast<int>(ceilf(log2f(absmax / kFp8Max)));
+  const float scale = exp2f(static_cast<float>(exponent));
+  const float inv_scale = exp2f(static_cast<float>(-exponent));
+
+  const int64_t kv_slot = load_index(kv_slot_mapping, kv_slot_kind, token);
+  if (kv_slot < 0 || kv_slot >= num_kv_blocks * kKvBlockSize) {
+    return;
+  }
+  const int64_t kv_block_idx = kv_slot / kKvBlockSize;
+  const int64_t kv_pos_in_block = kv_slot % kKvBlockSize;
+  uint8_t* cache_block = kv_cache + kv_block_idx * kv_cache_stride0;
+  uint8_t* value_ptr =
+      cache_block + kv_pos_in_block * kTokenValueBytes;
+  uint8_t* scale_ptr = cache_block + kKvBlockSize * kTokenValueBytes +
+                       kv_pos_in_block * kTokenScaleBytes;
+
+  const float4 quant_input =
+      make_float4(clamp_fp8(output[0] * inv_scale),
+                  clamp_fp8(output[1] * inv_scale),
+                  clamp_fp8(output[2] * inv_scale),
+                  clamp_fp8(output[3] * inv_scale));
+  const __mt_fp8x4_e4m3 packed(quant_input);
+  reinterpret_cast<uint32_t*>(value_ptr)[lane] =
+      static_cast<uint32_t>(packed.__x);
+  if (lane == 0) {
+    *reinterpret_cast<float*>(scale_ptr) = scale;
+  }
+}
+
+int index_kind(const torch::Tensor& tensor, const char* name) {
+  if (tensor.scalar_type() == torch::kInt32) {
+    return kIndexInt32;
+  }
+  if (tensor.scalar_type() == torch::kInt64) {
+    return kIndexInt64;
+  }
+  TORCH_CHECK(false, name, " must be int32 or int64");
+}
+
+void check_same_device(const torch::Tensor& reference,
+                       const torch::Tensor& tensor, const char* name) {
+  TORCH_CHECK(tensor.device() == reference.device(), name,
+              " must be on the same device as state_cache");
+}
+
+template <typename WeightT, int kKvBlockSize>
+void launch_c4_indexer_compressor(
+    const torch::Tensor& state_cache,
+    const torch::Tensor& token_to_req_indices,
+    const torch::Tensor& positions,
+    const torch::Tensor& state_slot_mapping,
+    const torch::Tensor& block_table,
+    const torch::Tensor& rms_norm_weight,
+    const torch::Tensor& cos_sin_cache, torch::Tensor& kv_cache,
+    const torch::Tensor& kv_slot_mapping, float rms_eps,
+    musaStream_t stream) {
+  const int64_t num_tokens = state_slot_mapping.numel();
+  const dim3 block(kThreadsPerBlock);
+  const dim3 grid(static_cast<unsigned int>(
+      (num_tokens + kWarpsPerBlock - 1) / kWarpsPerBlock));
+  deepseek_v4_c4_indexer_compressor_kernel<WeightT, kKvBlockSize>
+      <<<grid, block, 0, stream>>>(
+          static_cast<const float*>(state_cache.data_ptr()),
+          state_cache.stride(0), state_cache.stride(1),
+          token_to_req_indices.data_ptr(),
+          index_kind(token_to_req_indices, "token_to_req_indices"),
+          positions.data_ptr(), index_kind(positions, "positions"),
+          state_slot_mapping.data_ptr(),
+          index_kind(state_slot_mapping, "state_slot_mapping"),
+          block_table.data_ptr(), index_kind(block_table, "block_table"),
+          block_table.stride(0),
+          static_cast<const WeightT*>(rms_norm_weight.data_ptr()),
+          static_cast<const float*>(cos_sin_cache.data_ptr()),
+          cos_sin_cache.stride(0), static_cast<uint8_t*>(kv_cache.data_ptr()),
+          kv_cache.stride(0), kv_slot_mapping.data_ptr(),
+          index_kind(kv_slot_mapping, "kv_slot_mapping"), rms_eps, num_tokens,
+          state_cache.size(0), block_table.size(0), block_table.size(1),
+          kv_cache.size(0));
+}
+
+}  // namespace
+
+void deepseek_v4_c4_indexer_compress_cache(
+    const torch::Tensor& state_cache,
+    const torch::Tensor& token_to_req_indices,
+    const torch::Tensor& positions,
+    const torch::Tensor& state_slot_mapping,
+    const torch::Tensor& block_table,
+    const torch::Tensor& rms_norm_weight,
+    const torch::Tensor& cos_sin_cache, torch::Tensor& kv_cache,
+    const torch::Tensor& kv_slot_mapping, double rms_eps,
+    int64_t state_block_size, int64_t state_width,
+    int64_t kv_block_size) {
+  TORCH_CHECK(state_cache.scalar_type() == torch::kFloat32,
+              "state_cache must be float32");
+  TORCH_CHECK(state_cache.dim() == 3 &&
+                  state_cache.size(1) == kStateBlockSize &&
+                  state_cache.size(2) == kStateRowWidth,
+              "state_cache must have shape [num_blocks, 4, 512]");
+  TORCH_CHECK(state_cache.stride(2) == 1 &&
+                  state_cache.stride(1) % 4 == 0 &&
+                  state_cache.stride(0) % 4 == 0,
+              "state_cache rows must support aligned float4 loads");
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(state_cache.data_ptr()) % 16 == 0,
+              "state_cache must be 16-byte aligned");
+  TORCH_CHECK(state_block_size == kStateBlockSize,
+              "C4 indexer compressor requires state block size 4");
+  TORCH_CHECK(state_width == kStateWidth,
+              "C4 indexer compressor requires state width 256");
+  TORCH_CHECK(state_slot_mapping.numel() > 0 &&
+                  state_slot_mapping.numel() <= kMaxDecodeRows,
+              "C4 native path supports 1..128 decode rows");
+
+  const int64_t num_tokens = state_slot_mapping.numel();
+  TORCH_CHECK(token_to_req_indices.numel() >= num_tokens,
+              "token_to_req_indices does not cover every decode row");
+  TORCH_CHECK(positions.numel() >= num_tokens,
+              "positions does not cover every decode row");
+  TORCH_CHECK(kv_slot_mapping.numel() >= num_tokens,
+              "kv_slot_mapping does not cover every decode row");
+  TORCH_CHECK(token_to_req_indices.is_contiguous() &&
+                  positions.is_contiguous() &&
+                  state_slot_mapping.is_contiguous() &&
+                  kv_slot_mapping.is_contiguous(),
+              "index tensors must be contiguous");
+  TORCH_CHECK(block_table.dim() == 2 && block_table.stride(1) == 1 &&
+                  block_table.size(0) > 0 && block_table.size(1) > 0,
+              "block_table must be a non-empty row-contiguous 2D tensor");
+
+  TORCH_CHECK(rms_norm_weight.dim() == 1 &&
+                  rms_norm_weight.numel() == kHeadDim &&
+                  rms_norm_weight.is_contiguous(),
+              "rms_norm_weight must be contiguous with shape [128]");
+  TORCH_CHECK(rms_norm_weight.scalar_type() == torch::kFloat32 ||
+                  rms_norm_weight.scalar_type() == torch::kBFloat16,
+              "rms_norm_weight must be float32 or bfloat16");
+  TORCH_CHECK(cos_sin_cache.scalar_type() == torch::kFloat32 &&
+                  cos_sin_cache.dim() == 2 &&
+                  cos_sin_cache.size(1) == kRopeDim &&
+                  cos_sin_cache.stride(1) == 1,
+              "cos_sin_cache must be float32 [max_position, 64]");
+  TORCH_CHECK(kv_cache.scalar_type() == torch::kUInt8 && kv_cache.dim() >= 2 &&
+                  kv_cache.size(0) > 0 && kv_cache.size(1) == kv_block_size &&
+                  kv_cache.stride(-1) == 1,
+              "kv_cache must be a uint8 paged cache with the requested block size");
+  TORCH_CHECK(kv_block_size == 64 || kv_block_size == 256,
+              "C4 native path supports KV block size 64 or 256");
+  TORCH_CHECK(kv_cache.stride(0) >=
+                  kv_block_size * (kTokenValueBytes + kTokenScaleBytes),
+              "kv_cache page stride is smaller than the 132-byte token layout");
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(kv_cache.data_ptr()) % 4 == 0 &&
+                  kv_cache.stride(0) % 4 == 0,
+              "kv_cache must support aligned fp8x4 and float scale stores");
+
+  check_same_device(state_cache, token_to_req_indices,
+                    "token_to_req_indices");
+  check_same_device(state_cache, positions, "positions");
+  check_same_device(state_cache, state_slot_mapping, "state_slot_mapping");
+  check_same_device(state_cache, block_table, "block_table");
+  check_same_device(state_cache, rms_norm_weight, "rms_norm_weight");
+  check_same_device(state_cache, cos_sin_cache, "cos_sin_cache");
+  check_same_device(state_cache, kv_cache, "kv_cache");
+  check_same_device(state_cache, kv_slot_mapping, "kv_slot_mapping");
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(state_cache));
+  musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+#define LAUNCH_C4_INDEXER(WEIGHT_T, PAGE_SIZE)                                \
+  launch_c4_indexer_compressor<WEIGHT_T, PAGE_SIZE>(                          \
+      state_cache, token_to_req_indices, positions, state_slot_mapping,       \
+      block_table, rms_norm_weight, cos_sin_cache, kv_cache, kv_slot_mapping, \
+      static_cast<float>(rms_eps), stream)
+
+  if (rms_norm_weight.scalar_type() == torch::kFloat32) {
+    if (kv_block_size == 64) {
+      LAUNCH_C4_INDEXER(float, 64);
+    } else {
+      LAUNCH_C4_INDEXER(float, 256);
+    }
+  } else {
+    if (kv_block_size == 64) {
+      LAUNCH_C4_INDEXER(__mt_bfloat16, 64);
+    } else {
+      LAUNCH_C4_INDEXER(__mt_bfloat16, 256);
+    }
+  }
+
+#undef LAUNCH_C4_INDEXER
+
+  const auto err = musaGetLastError();
+  TORCH_CHECK(err == musaSuccess,
+              "deepseek_v4_c4_indexer_compress_cache launch failed: ",
+              musaGetErrorString(err));
+}

--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -115,6 +115,20 @@ void deepseek_v4_qnorm_rope_kv_insert(
     const torch::Tensor& cos_sin_cache,
     double eps,
     int64_t cache_block_size);
+void deepseek_v4_c4_indexer_compress_cache(
+    const torch::Tensor& state_cache,
+    const torch::Tensor& token_to_req_indices,
+    const torch::Tensor& positions,
+    const torch::Tensor& state_slot_mapping,
+    const torch::Tensor& block_table,
+    const torch::Tensor& rms_norm_weight,
+    const torch::Tensor& cos_sin_cache,
+    torch::Tensor& kv_cache,
+    const torch::Tensor& kv_slot_mapping,
+    double rms_eps,
+    int64_t state_block_size,
+    int64_t state_width,
+    int64_t kv_block_size);
 std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_q_kv_rmsnorm(
     const torch::Tensor& q,
     const torch::Tensor& kv,

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -107,6 +107,15 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
                 &deepseek_v4_qnorm_rope_kv_insert);
 
   musa_ops.def(
+      "deepseek_v4_c4_indexer_compress_cache(Tensor state_cache, Tensor "
+      "token_to_req_indices, Tensor positions, Tensor state_slot_mapping, "
+      "Tensor block_table, Tensor rms_norm_weight, Tensor cos_sin_cache, "
+      "Tensor! kv_cache, Tensor kv_slot_mapping, float rms_eps, int "
+      "state_block_size, int state_width, int kv_block_size) -> ()");
+  musa_ops.impl("deepseek_v4_c4_indexer_compress_cache", torch::kMUSA,
+                &deepseek_v4_c4_indexer_compress_cache);
+
+  musa_ops.def(
       "deepseek_v4_fused_q_kv_rmsnorm(Tensor q, Tensor kv, Tensor q_weight, "
       "Tensor kv_weight, float eps) -> (Tensor, Tensor)");
   musa_ops.impl("deepseek_v4_fused_q_kv_rmsnorm", torch::kMUSA,

--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,7 @@ VLLM_MUSA_CSRC_SOURCES = [
     "csrc/musa/fused_add_rmsnorm.mu",
     "csrc/musa/cache_kernels.mu",
     "csrc/musa/attention/deepseek_v4_cache_store.mu",
+    "csrc/musa/attention/deepseek_v4_c4_indexer_compressor.mu",
     "csrc/musa/attention/deepseek_v4_fused_qkv_rmsnorm.mu",
     "csrc/musa/attention/deepseek_v4_cache_utils.mu",
     "csrc/musa/attention/deepseek_v4_indexer_topk.mu",

--- a/tests/deepseek_v4_c4_indexer_compressor_ab.py
+++ b/tests/deepseek_v4_c4_indexer_compressor_ab.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA correctness and eager event-time A/B for the C4 indexer compressor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import torch
+
+from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
+    _fused_kv_compress_norm_rope_insert_indexer_attn,
+)
+from vllm_musa import _custom_ops as musa_ops
+
+HEAD_DIM = 128
+ROPE_DIM = 64
+STATE_BLOCK_SIZE = 4
+STATE_WIDTH = 256
+COMPRESS_RATIO = 4
+KV_TOKEN_BYTES = 132
+
+
+def make_inputs(
+    capture_rows: int,
+    active_rows: int,
+    kv_block_size: int,
+    weight_dtype: torch.dtype,
+) -> tuple[torch.Tensor, ...]:
+    if not 0 < active_rows <= capture_rows <= 128:
+        raise ValueError("expected 0 < active_rows <= capture_rows <= 128")
+    torch.manual_seed(20260727)
+    device = torch.device("musa")
+    max_position = 4 * (active_rows + 16) - 1
+    logical_state_blocks = (max_position + 1) // STATE_BLOCK_SIZE
+    num_state_blocks = capture_rows * logical_state_blocks
+
+    state_cache = torch.randn(
+        (num_state_blocks, STATE_BLOCK_SIZE, 2 * STATE_WIDTH),
+        dtype=torch.float32,
+        device=device,
+    )
+    block_table = torch.arange(
+        num_state_blocks, dtype=torch.int32, device=device
+    ).reshape(capture_rows, logical_state_blocks)
+    token_to_req = torch.arange(capture_rows, dtype=torch.int32, device=device)
+    positions = torch.full((capture_rows,), 3, dtype=torch.int64, device=device)
+    positions[:active_rows] = (
+        torch.arange(active_rows, dtype=torch.int64, device=device) * 4 + 31
+    )
+
+    state_slots = torch.full(
+        (capture_rows,), -1, dtype=torch.int64, device=device
+    )
+    active_positions = positions[:active_rows]
+    active_pages = block_table[
+        torch.arange(active_rows, device=device),
+        active_positions // STATE_BLOCK_SIZE,
+    ].to(torch.int64)
+    state_slots[:active_rows] = (
+        active_pages * STATE_BLOCK_SIZE + active_positions % STATE_BLOCK_SIZE
+    )
+
+    rms_weight = (
+        torch.randn((HEAD_DIM,), dtype=torch.float32, device=device) * 0.1 + 1.0
+    ).to(weight_dtype)
+    cos_sin = torch.randn(
+        (max_position + 1, ROPE_DIM), dtype=torch.float32, device=device
+    )
+    num_kv_blocks = (active_rows + kv_block_size - 1) // kv_block_size + 1
+    kv_cache = torch.full(
+        (num_kv_blocks, kv_block_size, KV_TOKEN_BYTES),
+        0xCD,
+        dtype=torch.uint8,
+        device=device,
+    )
+    kv_slots = torch.full((capture_rows,), -1, dtype=torch.int64, device=device)
+    kv_slots[:active_rows] = torch.arange(
+        active_rows, dtype=torch.int64, device=device
+    )
+    return (
+        state_cache,
+        token_to_req,
+        positions,
+        state_slots,
+        block_table,
+        rms_weight,
+        cos_sin,
+        kv_cache,
+        kv_slots,
+    )
+
+
+def run_triton(inputs: tuple[torch.Tensor, ...]) -> None:
+    (
+        state_cache,
+        token_to_req,
+        positions,
+        state_slots,
+        block_table,
+        rms_weight,
+        cos_sin,
+        kv_cache,
+        kv_slots,
+    ) = inputs
+    _fused_kv_compress_norm_rope_insert_indexer_attn[(state_slots.numel(),)](
+        state_cache,
+        state_cache.stride(0),
+        state_cache.stride(1),
+        token_to_req,
+        positions,
+        state_slots,
+        block_table,
+        block_table.stride(0),
+        STATE_BLOCK_SIZE,
+        rms_weight,
+        1.0e-6,
+        cos_sin,
+        cos_sin.stride(0),
+        kv_cache,
+        kv_slots,
+        kv_cache.shape[1],
+        HEAD_SIZE=HEAD_DIM,
+        TRITON_BLOCK_SIZE=HEAD_DIM,
+        STATE_WIDTH=STATE_WIDTH,
+        COMPRESS_RATIO=COMPRESS_RATIO,
+        OVERLAP=True,
+        ROPE_HEAD_DIM=ROPE_DIM,
+        FP8_MAX=448.0,
+        QUANT_BLOCK=HEAD_DIM,
+        TOKEN_STRIDE=HEAD_DIM,
+        SCALE_DIM=4,
+        KV_BLOCK_STRIDE=kv_cache.stride(0),
+        num_warps=1,
+    )
+
+
+def run_native(inputs: tuple[torch.Tensor, ...]) -> None:
+    (
+        state_cache,
+        token_to_req,
+        positions,
+        state_slots,
+        block_table,
+        rms_weight,
+        cos_sin,
+        kv_cache,
+        kv_slots,
+    ) = inputs
+    musa_ops.deepseek_v4_c4_indexer_compress_cache(
+        state_cache,
+        token_to_req,
+        positions,
+        state_slots,
+        block_table,
+        rms_weight,
+        cos_sin,
+        kv_cache,
+        kv_slots,
+        1.0e-6,
+        STATE_BLOCK_SIZE,
+        STATE_WIDTH,
+        kv_cache.shape[1],
+    )
+
+
+def clone_with_cache(inputs: tuple[torch.Tensor, ...]) -> tuple[torch.Tensor, ...]:
+    cloned = list(inputs)
+    cloned[7] = inputs[7].clone()
+    return tuple(cloned)
+
+
+def event_time_us(fn, inputs, warmups: int, iterations: int) -> float:
+    for _ in range(warmups):
+        fn(inputs)
+    torch.musa.synchronize()
+    start = torch.musa.Event(enable_timing=True)
+    end = torch.musa.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        fn(inputs)
+    end.record()
+    end.synchronize()
+    return float(start.elapsed_time(end)) * 1000.0 / iterations
+
+
+def capture_graph(fn, inputs) -> torch.musa.MUSAGraph:
+    # Compile/JIT outside capture, then capture exactly one production-shaped op.
+    for _ in range(3):
+        fn(inputs)
+    torch.musa.synchronize()
+    graph = torch.musa.MUSAGraph()
+    with torch.musa.graph(graph):
+        fn(inputs)
+    return graph
+
+
+def graph_event_time_us(
+    graph: torch.musa.MUSAGraph, warmups: int, iterations: int
+) -> float:
+    for _ in range(warmups):
+        graph.replay()
+    torch.musa.synchronize()
+    start = torch.musa.Event(enable_timing=True)
+    end = torch.musa.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        graph.replay()
+    end.record()
+    end.synchronize()
+    return float(start.elapsed_time(end)) * 1000.0 / iterations
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--capture-rows", type=int, default=5)
+    parser.add_argument("--active-rows", type=int, default=1)
+    parser.add_argument("--kv-block-size", type=int, choices=(64, 256), default=256)
+    parser.add_argument(
+        "--weight-dtype", choices=("float32", "bfloat16"), default="float32"
+    )
+    parser.add_argument("--warmups", type=int, default=200)
+    parser.add_argument("--iterations", type=int, default=2000)
+    parser.add_argument("--graph", action="store_true")
+    args = parser.parse_args()
+
+    weight_dtype = getattr(torch, args.weight_dtype)
+    base_inputs = make_inputs(
+        args.capture_rows, args.active_rows, args.kv_block_size, weight_dtype
+    )
+    triton_inputs = clone_with_cache(base_inputs)
+    native_inputs = clone_with_cache(base_inputs)
+    run_triton(triton_inputs)
+    run_native(native_inputs)
+    torch.musa.synchronize()
+
+    triton_cache = triton_inputs[7]
+    native_cache = native_inputs[7]
+    cache_equal = bool(torch.equal(triton_cache, native_cache))
+    result = {
+        "capture_rows": args.capture_rows,
+        "active_rows": args.active_rows,
+        "kv_block_size": args.kv_block_size,
+        "weight_dtype": args.weight_dtype,
+        "cache_equal": cache_equal,
+        "cache_mismatch_count": int(
+            torch.count_nonzero(triton_cache != native_cache).item()
+        ),
+    }
+    if not cache_equal:
+        print(json.dumps(result, sort_keys=True))
+        raise SystemExit(1)
+
+    triton_us = event_time_us(
+        run_triton, clone_with_cache(base_inputs), args.warmups, args.iterations
+    )
+    native_us = event_time_us(
+        run_native, clone_with_cache(base_inputs), args.warmups, args.iterations
+    )
+    result.update(
+        {
+            "triton_event_us": triton_us,
+            "native_event_us": native_us,
+            "speedup": triton_us / native_us,
+        }
+    )
+    if args.graph:
+        triton_graph_inputs = clone_with_cache(base_inputs)
+        native_graph_inputs = clone_with_cache(base_inputs)
+        triton_graph = capture_graph(run_triton, triton_graph_inputs)
+        native_graph = capture_graph(run_native, native_graph_inputs)
+
+        triton_graph_inputs[7].fill_(0xCD)
+        native_graph_inputs[7].fill_(0xCD)
+        triton_graph.replay()
+        native_graph.replay()
+        torch.musa.synchronize()
+        graph_cache_equal = bool(
+            torch.equal(triton_graph_inputs[7], native_graph_inputs[7])
+        )
+        result["graph_cache_equal"] = graph_cache_equal
+        result["graph_cache_mismatch_count"] = int(
+            torch.count_nonzero(
+                triton_graph_inputs[7] != native_graph_inputs[7]
+            ).item()
+        )
+        if not graph_cache_equal:
+            print(json.dumps(result, sort_keys=True))
+            raise SystemExit(1)
+
+        triton_graph_us = graph_event_time_us(
+            triton_graph, args.warmups, args.iterations
+        )
+        native_graph_us = graph_event_time_us(
+            native_graph, args.warmups, args.iterations
+        )
+        result.update(
+            {
+                "triton_graph_event_us": triton_graph_us,
+                "native_graph_event_us": native_graph_us,
+                "graph_speedup": triton_graph_us / native_graph_us,
+            }
+        )
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deepseek_v4_c4_indexer_compressor.py
+++ b/tests/test_deepseek_v4_c4_indexer_compressor.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+import struct
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+KERNEL = ROOT / "csrc/musa/attention/deepseek_v4_c4_indexer_compressor.mu"
+WRAPPER = ROOT / "vllm_musa/kernels/deepseek_v4_c4_indexer_compressor.py"
+SERIES_PATCH = (
+    ROOT
+    / "vllm_musa/patches/series/0093-MUSA-dispatch-DeepSeek-V4-C4-indexer-compression-to-.patch"
+)
+
+
+def _bf16_roundtrip(value: float) -> float:
+    """Round one Python float through IEEE fp32 then bf16 (round-to-nearest-even)."""
+    bits = struct.unpack("<I", struct.pack("<f", value))[0]
+    rounded = bits + 0x7FFF + ((bits >> 16) & 1)
+    return struct.unpack("<f", struct.pack("<I", rounded & 0xFFFF0000))[0]
+
+
+def _state_value(page: int, offset: int, dim: int) -> float:
+    # Deterministic, non-symmetric values make page/head-offset mistakes visible.
+    return math.sin((page * 4099 + offset * 521 + dim * 17 + 1) * 0.001)
+
+
+def _cpu_reference_row(
+    req: int,
+    position: int,
+    block_table: list[list[int]],
+    eps: float,
+) -> tuple[list[float], float]:
+    values_by_dim: list[float] = []
+    for dim in range(128):
+        row_values = []
+        row_scores = []
+        for row, source_position in enumerate(range(position - 7, position + 1)):
+            if source_position < 0:
+                row_values.append(0.0)
+                row_scores.append(float("-inf"))
+                continue
+            page = block_table[req][source_position // 4]
+            page_offset = source_position % 4
+            head_offset = 128 if row >= 4 else 0
+            row_values.append(_state_value(page, page_offset, head_offset + dim))
+            row_scores.append(
+                _state_value(page, page_offset, 256 + head_offset + dim)
+            )
+        max_score = max(row_scores)
+        softmax = [
+            0.0 if score == float("-inf") else math.exp(score - max_score)
+            for score in row_scores
+        ]
+        denominator = sum(softmax)
+        values_by_dim.append(
+            sum(value * score for value, score in zip(row_values, softmax, strict=True))
+            / denominator
+        )
+
+    variance = sum(value * value for value in values_by_dim) / 128.0
+    inv_rms = 1.0 / math.sqrt(variance + eps)
+    output = [
+        value * inv_rms * (1.0 + (dim % 11 - 5) * 0.002)
+        for dim, value in enumerate(values_by_dim)
+    ]
+    compressed_position = (position // 4) * 4
+    for pair in range(32):
+        dim = 64 + pair * 2
+        angle = compressed_position * 0.003 + pair * 0.007
+        cos_value = math.cos(angle)
+        sin_value = math.sin(angle)
+        even, odd = output[dim], output[dim + 1]
+        output[dim] = even * cos_value - odd * sin_value
+        output[dim + 1] = odd * cos_value + even * sin_value
+    output = [_bf16_roundtrip(value) for value in output]
+    absmax = max(1e-4, max(abs(value) for value in output))
+    scale = 2.0 ** math.ceil(math.log2(absmax / 448.0))
+    return output, scale
+
+
+def _cpu_reference_store(
+    token_to_req: list[int],
+    positions: list[int],
+    state_slots: list[int],
+    block_table: list[list[int]],
+    kv_slots: list[int],
+    kv_block_size: int,
+    eps: float,
+) -> dict[tuple[int, int], tuple[list[float], float]]:
+    output = {}
+    for token, position in enumerate(positions):
+        if state_slots[token] < 0 or (position + 1) % 4 != 0:
+            continue
+        kv_slot = kv_slots[token]
+        if kv_slot < 0:
+            continue
+        page, offset = divmod(kv_slot, kv_block_size)
+        output[(page, offset)] = _cpu_reference_row(
+            token_to_req[token], position, block_table, eps
+        )
+    return output
+
+
+def test_native_op_is_registered_and_built() -> None:
+    kernel = KERNEL.read_text()
+    setup = (ROOT / "setup.py").read_text()
+    header = (ROOT / "csrc/musa/musa_ops.h").read_text()
+    bindings = (ROOT / "csrc/musa/torch_bindings.cpp").read_text()
+    custom_ops = (ROOT / "vllm_musa/_custom_ops.py").read_text()
+
+    assert "deepseek_v4_c4_indexer_compressor.mu" in setup
+    assert "void deepseek_v4_c4_indexer_compress_cache(" in header
+    assert "deepseek_v4_c4_indexer_compress_cache(Tensor state_cache" in bindings
+    assert "def deepseek_v4_c4_indexer_compress_cache(" in custom_ops
+    assert "deepseek_v4_c4_indexer_compressor_kernel" in kernel
+
+
+def test_kernel_uses_warp_per_token_register_pipeline() -> None:
+    source = KERNEL.read_text()
+
+    assert "constexpr int64_t kCompressRows = 2 * kCompressRatio;" in source
+    assert "constexpr int64_t kWarpsPerBlock = 4;" in source
+    assert "const int warp = threadIdx.x >> 5;" in source
+    assert "const int lane = threadIdx.x & 31;" in source
+    assert "float kv[kCompressRows][4];" in source
+    assert "float score[kCompressRows][4];" in source
+    assert "const float exp0 = exp2f" in source
+    assert "const float exp3 = exp2f" in source
+    assert "warp_reduce_max_u32" in source
+    assert "const __mt_fp8x4_e4m3 packed" in source
+    assert "__shared__" not in source
+    assert "__syncthreads" not in source
+
+
+def test_kernel_preserves_vllm_pad_boundary_and_page_abi() -> None:
+    source = KERNEL.read_text()
+
+    assert "state_slot < 0" in source
+    assert "(position + 1) % kCompressRatio != 0" in source
+    assert "req_idx * block_table_stride + logical_block" in source
+    assert "head_offset = row >= kCompressRatio ? kHeadDim : 0" in source
+    assert "kv_slot < 0" in source
+    assert "kv_block_idx * kv_cache_stride0" in source
+    assert "kKvBlockSize * kTokenValueBytes" in source
+    assert "__bfloat162float(__float2bfloat16(output[elem]))" in source
+    assert "Do not import SGLang's subsequent Hadamard transform" in source
+
+
+def test_source_patch_keeps_triton_fallback() -> None:
+    patch = SERIES_PATCH.read_text()
+    native_call = patch.index("try_musa_deepseek_v4_c4_indexer_compressor(")
+    triton_dispatch = patch.index("if head_dim == 512:")
+
+    assert native_call < triton_dispatch
+    assert "if handled:" in patch
+    assert "+            return" in patch
+
+
+def test_wrapper_is_default_on_and_shape_bounded() -> None:
+    source = WRAPPER.read_text()
+
+    assert '_SUPPORTED_KV_BLOCK_SIZES = (64, 256)' in source
+    assert "0 < num_rows <= _MAX_DECODE_ROWS" in source
+    assert "return False, reason" in source
+    assert "VLLM_MUSA_DEEPSEEK_V4_C4_INDEXER_COMPRESS_IMPL" not in source
+    assert "os.environ" not in source
+
+
+def test_cpu_oracle_keeps_nonboundary_and_pad_slots_untouched() -> None:
+    block_table = [[3, 1, 6, 0], [2, 5, 7, 4]]
+    cache = _cpu_reference_store(
+        token_to_req=[0, 0, 1, 1],
+        positions=[3, 4, 7, 11],
+        state_slots=[0, 1, 2, -1],
+        block_table=block_table,
+        kv_slots=[0, 1, 257, 258],
+        kv_block_size=256,
+        eps=1e-6,
+    )
+
+    assert set(cache) == {(0, 0), (1, 1)}
+    first_values, first_scale = cache[(0, 0)]
+    second_values, second_scale = cache[(1, 1)]
+    assert len(first_values) == len(second_values) == 128
+    assert all(math.isfinite(value) for value in first_values + second_values)
+    assert math.isfinite(first_scale) and first_scale > 0
+    assert math.isfinite(second_scale) and second_scale > 0
+    assert first_values != second_values
+
+
+def test_bf16_cpu_oracle_uses_round_to_nearest_even() -> None:
+    # Exact bf16 values remain unchanged; an in-between fp32 value rounds to the
+    # nearest bf16 representation instead of being blindly truncated.
+    assert _bf16_roundtrip(1.0) == 1.0
+    assert _bf16_roundtrip(-2.0) == -2.0
+    value = struct.unpack("<f", struct.pack("<I", 0x3F80C000))[0]
+    assert _bf16_roundtrip(value) == 1.0078125

--- a/tests/test_musa_jit_custom_all_reduce_graph.py
+++ b/tests/test_musa_jit_custom_all_reduce_graph.py
@@ -11,6 +11,38 @@ custom_ar = pytest.importorskip(
 )
 
 
+@pytest.mark.parametrize(
+    ("model_type", "architectures", "capture_sizes", "expected"),
+    [
+        ("deepseek_v4", ("DeepseekV4ForCausalLM",), (1,), True),
+        ("deepseek_v4", ("DeepseekV4ForCausalLM",), (1, 2, 4), False),
+        (None, ("DeepseekV4ForCausalLM",), (1, 2, 4), False),
+        ("qwen3", ("Qwen3ForCausalLM",), (1, 2, 4), True),
+    ],
+)
+def test_graph_registered_inputs_model_gate(
+    monkeypatch, model_type, architectures, capture_sizes, expected
+):
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            model_type=model_type,
+            architectures=architectures,
+        ),
+        architectures=architectures,
+    )
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config_or_none",
+        lambda: SimpleNamespace(
+            model_config=model_config,
+            compilation_config=SimpleNamespace(
+                cudagraph_capture_sizes=capture_sizes,
+            ),
+        ),
+    )
+
+    assert custom_ar._use_graph_registered_inputs_for_current_model() is expected
+
+
 def test_register_graph_buffers_populates_persistent_rank_data(monkeypatch):
     impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
     impl.rank = 0
@@ -130,3 +162,37 @@ def test_graph_launch_uses_next_persistent_slot(monkeypatch):
     assert captured["world_size"] == 2
     assert captured["shot"] == 2
     assert impl._pending_graph_inputs == [input_tensor]
+
+
+def test_deepseek_graph_capture_uses_fixed_staging(monkeypatch):
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl._use_graph_registered_inputs = False
+    impl._IS_CAPTURING = True
+    impl.buffer_rank_data = torch.zeros(8, dtype=torch.int64)
+    impl.signal_ptrs_cpu = torch.zeros(2, dtype=torch.int64)
+    impl.meta_ptrs = [10, 20]
+    impl.buffer_ptrs = [30, 40]
+    impl.max_size = 1024
+    impl.rank = 0
+    impl.world_size = 2
+
+    monkeypatch.setattr(impl, "_is_current_stream_capturing", lambda: True)
+    monkeypatch.setattr(
+        impl,
+        "_graph_custom_all_reduce_impl",
+        lambda _input: pytest.fail("DeepSeek must not register graph input pointers"),
+    )
+    monkeypatch.setattr(custom_ar.jit_ar, "preferred_shot", lambda _world, _size: 1)
+    captured = {}
+
+    def launch_unregistered(*args):
+        captured["args"] = args
+
+    monkeypatch.setattr(custom_ar.jit_ar, "launch_unregistered", launch_unregistered)
+    input_tensor = torch.randn(4, dtype=torch.bfloat16)
+
+    output = impl._custom_all_reduce_impl(input_tensor)
+
+    assert output.shape == input_tensor.shape
+    assert captured["args"][2] is input_tensor
+    assert captured["args"][3] is output

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -519,6 +519,38 @@ def deepseek_v4_qnorm_rope_kv_insert(
     )
 
 
+def deepseek_v4_c4_indexer_compress_cache(
+    state_cache: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    state_slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    rms_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_slot_mapping: torch.Tensor,
+    rms_eps: float,
+    state_block_size: int,
+    state_width: int,
+    kv_block_size: int,
+) -> None:
+    return torch.ops._C_musa_ops.deepseek_v4_c4_indexer_compress_cache(
+        state_cache,
+        token_to_req_indices,
+        positions,
+        state_slot_mapping,
+        block_table,
+        rms_norm_weight,
+        cos_sin_cache,
+        kv_cache,
+        kv_slot_mapping,
+        rms_eps,
+        state_block_size,
+        state_width,
+        kv_block_size,
+    )
+
+
 def deepseek_v4_fused_q_kv_rmsnorm(
     q: torch.Tensor,
     kv: torch.Tensor,

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -25,6 +25,39 @@ _MU_POINTER_ATTRIBUTE_RANGE_START_ADDR = 11
 cudaError_t = ctypes.c_int
 
 
+def _use_graph_registered_inputs_for_current_model() -> bool:
+    """Use direct graph inputs only when their capture residency is bounded."""
+    try:
+        from vllm.config import get_current_vllm_config_or_none
+
+        vllm_config = get_current_vllm_config_or_none()
+    except (ImportError, RuntimeError):
+        return True
+
+    model_config = getattr(vllm_config, "model_config", None)
+    if model_config is None:
+        return True
+
+    hf_config = getattr(model_config, "hf_config", None)
+    architectures = getattr(model_config, "architectures", None)
+    if architectures is None and hf_config is not None:
+        architectures = getattr(hf_config, "architectures", None)
+    is_deepseek_v4 = getattr(hf_config, "model_type", None) == "deepseek_v4" or any(
+        "DeepseekV4" in str(arch) for arch in architectures or ()
+    )
+    if not is_deepseek_v4:
+        return True
+
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    capture_sizes = getattr(compilation_config, "cudagraph_capture_sizes", None)
+    if not capture_sizes:
+        return False
+    try:
+        return max(int(size) for size in capture_sizes) <= 1
+    except (TypeError, ValueError):
+        return False
+
+
 class cudaIpcMemHandle_t(ctypes.Structure):
     _fields_ = [("internal", ctypes.c_byte * 128)]
 
@@ -285,6 +318,9 @@ class _MusaJitCustomAllreduceImpl:
         self.group = group
         self.max_size = max_size
         self._IS_CAPTURING = False
+        self._use_graph_registered_inputs = (
+            _use_graph_registered_inputs_for_current_model()
+        )
         self._comm_id: int | None = None
         self.meta_ptrs: list[int] = []
         self.meta_opened_ipc_ptrs: list[int] = []
@@ -359,14 +395,20 @@ class _MusaJitCustomAllreduceImpl:
         self.signal_ptrs_cpu = torch.tensor(self.meta_ptrs, dtype=torch.int64)
         buffer_ptrs = self.buffer_ptrs + [0] * (8 - self.world_size)
         self.buffer_rank_data = torch.tensor(buffer_ptrs, dtype=torch.int64)
-        graph_slots = _MAX_GRAPH_RANK_DATA_BYTES // (
-            _MAX_RANKS * torch.tensor([], dtype=torch.int64).element_size()
-        )
-        self.graph_rank_data = torch.zeros(
-            (graph_slots, _MAX_RANKS),
-            dtype=torch.int64,
-            device=self.device,
-        )
+        if self._use_graph_registered_inputs:
+            graph_slots = _MAX_GRAPH_RANK_DATA_BYTES // (
+                _MAX_RANKS * torch.tensor([], dtype=torch.int64).element_size()
+            )
+            self.graph_rank_data = torch.zeros(
+                (graph_slots, _MAX_RANKS),
+                dtype=torch.int64,
+                device=self.device,
+            )
+        else:
+            logger.info_once(
+                "Using fixed-staging MUSA JIT custom all-reduce for "
+                "DeepSeek-V4 CUDA graph capture."
+            )
         self._comm_id = _register_comm(self)
         self.disabled = False
         logger.info_once(
@@ -570,7 +612,11 @@ class _MusaJitCustomAllreduceImpl:
     def _custom_all_reduce_impl(self, input: torch.Tensor) -> torch.Tensor:
         assert self.buffer_rank_data is not None
         assert self.signal_ptrs_cpu is not None
-        if self._IS_CAPTURING and self._is_current_stream_capturing():
+        if (
+            self._use_graph_registered_inputs
+            and self._IS_CAPTURING
+            and self._is_current_stream_capturing()
+        ):
             return self._graph_custom_all_reduce_impl(input)
         out = torch.empty_like(input)
         shot = jit_ar.preferred_shot(

--- a/vllm_musa/kernels/deepseek_v4_c4_indexer_compressor.py
+++ b/vllm_musa/kernels/deepseek_v4_c4_indexer_compressor.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native C4 indexer compressor for DeepSeek-V4 decode on MUSA.
+
+The production source patch imports this module lazily. Supported small-token
+decode shapes use the native kernel; unsupported shapes, including prefill,
+fall back to vLLM's Triton implementation.
+"""
+
+from __future__ import annotations
+
+import torch
+
+_HEAD_DIM = 128
+_ROPE_DIM = 64
+_STATE_BLOCK_SIZE = 4
+_STATE_WIDTH = 256
+_STATE_ROW_WIDTH = 512
+_MAX_DECODE_ROWS = 128
+_SUPPORTED_KV_BLOCK_SIZES = (64, 256)
+_INDEX_DTYPES = (torch.int32, torch.int64)
+
+
+def _is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return getattr(tensor, "device", None) is not None and tensor.device.type == "musa"
+
+
+def _guard_c4_indexer_compressor(
+    state_cache: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    state_slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    rms_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_slot_mapping: torch.Tensor,
+    state_block_size: int,
+    state_width: int,
+    kv_block_size: int,
+) -> tuple[bool, str]:
+    tensors = (
+        state_cache,
+        token_to_req_indices,
+        positions,
+        state_slot_mapping,
+        block_table,
+        rms_norm_weight,
+        cos_sin_cache,
+        kv_cache,
+        kv_slot_mapping,
+    )
+    if not all(_is_musa_tensor(tensor) for tensor in tensors):
+        return False, "all tensors must be on MUSA"
+    if len({tensor.device for tensor in tensors}) != 1:
+        return False, "all tensors must be on the same MUSA device"
+    if state_cache.dtype != torch.float32:
+        return False, f"state_cache must be float32, got {state_cache.dtype}"
+    if state_cache.dim() != 3 or tuple(state_cache.shape[1:]) != (
+        _STATE_BLOCK_SIZE,
+        _STATE_ROW_WIDTH,
+    ):
+        return False, (
+            "state_cache must have shape [num_blocks, 4, 512], got "
+            f"{tuple(state_cache.shape)}"
+        )
+    if (
+        state_cache.stride(-1) != 1
+        or state_cache.stride(1) % 4 != 0
+        or state_cache.stride(0) % 4 != 0
+        or state_cache.storage_offset() % 4 != 0
+    ):
+        return False, "state_cache does not satisfy aligned float4 row loads"
+    if int(state_block_size) != _STATE_BLOCK_SIZE or int(state_width) != _STATE_WIDTH:
+        return False, (
+            "native C4 contract requires state_block_size=4 and state_width=256, "
+            f"got {state_block_size=} {state_width=}"
+        )
+
+    if state_slot_mapping.dim() != 1:
+        return False, "state_slot_mapping must be 1D"
+    num_rows = state_slot_mapping.numel()
+    if not 0 < num_rows <= _MAX_DECODE_ROWS:
+        return False, f"native C4 path supports 1..128 decode rows, got {num_rows}"
+    for name, tensor in (
+        ("token_to_req_indices", token_to_req_indices),
+        ("positions", positions),
+        ("state_slot_mapping", state_slot_mapping),
+        ("kv_slot_mapping", kv_slot_mapping),
+        ("block_table", block_table),
+    ):
+        if tensor.dtype not in _INDEX_DTYPES:
+            return False, f"{name} must be int32 or int64, got {tensor.dtype}"
+    for name, tensor in (
+        ("token_to_req_indices", token_to_req_indices),
+        ("positions", positions),
+        ("kv_slot_mapping", kv_slot_mapping),
+    ):
+        if tensor.dim() != 1 or tensor.numel() < num_rows:
+            return False, f"{name} must be 1D and cover all {num_rows} rows"
+    if block_table.dim() != 2 or block_table.shape[0] == 0 or block_table.shape[1] == 0:
+        return False, "block_table must be a non-empty 2D tensor"
+    if block_table.stride(1) != 1:
+        return False, "block_table rows must be contiguous"
+    if not all(
+        tensor.is_contiguous()
+        for tensor in (
+            token_to_req_indices,
+            positions,
+            state_slot_mapping,
+            kv_slot_mapping,
+        )
+    ):
+        return False, "index vectors must be contiguous"
+
+    if rms_norm_weight.dtype not in (torch.float32, torch.bfloat16):
+        return False, (
+            "rms_norm_weight must be float32 or bfloat16, got "
+            f"{rms_norm_weight.dtype}"
+        )
+    if rms_norm_weight.dim() != 1 or rms_norm_weight.numel() != _HEAD_DIM:
+        return False, (
+            "rms_norm_weight must have shape [128], got "
+            f"{tuple(rms_norm_weight.shape)}"
+        )
+    if not rms_norm_weight.is_contiguous():
+        return False, "rms_norm_weight must be contiguous"
+    if (
+        cos_sin_cache.dtype != torch.float32
+        or cos_sin_cache.dim() != 2
+        or cos_sin_cache.shape[1] != _ROPE_DIM
+        or cos_sin_cache.stride(1) != 1
+    ):
+        return False, (
+            "cos_sin_cache must be row-contiguous float32 [max_position, 64], got "
+            f"shape={tuple(cos_sin_cache.shape)} dtype={cos_sin_cache.dtype}"
+        )
+
+    if int(kv_block_size) not in _SUPPORTED_KV_BLOCK_SIZES:
+        return False, (
+            f"kv_block_size must be one of {_SUPPORTED_KV_BLOCK_SIZES}, "
+            f"got {kv_block_size}"
+        )
+    if (
+        kv_cache.dtype != torch.uint8
+        or kv_cache.dim() < 2
+        or kv_cache.shape[0] == 0
+        or kv_cache.shape[1] != int(kv_block_size)
+        or kv_cache.stride(-1) != 1
+    ):
+        return False, (
+            "kv_cache must be a uint8 paged cache whose second dimension is the "
+            f"KV block size, got shape={tuple(kv_cache.shape)} dtype={kv_cache.dtype}"
+        )
+    logical_page_bytes = int(kv_block_size) * (_HEAD_DIM + 4)
+    if kv_cache.stride(0) < logical_page_bytes or kv_cache.stride(0) % 4 != 0:
+        return False, (
+            f"kv_cache page stride {kv_cache.stride(0)} cannot hold/aligned-store "
+            f"the {logical_page_bytes}-byte page ABI"
+        )
+    if kv_cache.storage_offset() % 4 != 0:
+        return False, "kv_cache storage offset must be 4-byte aligned"
+    return True, ""
+
+
+def try_musa_deepseek_v4_c4_indexer_compressor(
+    state_cache: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    state_slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    rms_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_slot_mapping: torch.Tensor,
+    rms_eps: float,
+    state_block_size: int,
+    state_width: int,
+    kv_block_size: int,
+) -> tuple[bool, str]:
+    """Run the native decode path or request the Triton shape fallback."""
+    supported, reason = _guard_c4_indexer_compressor(
+        state_cache,
+        token_to_req_indices,
+        positions,
+        state_slot_mapping,
+        block_table,
+        rms_norm_weight,
+        cos_sin_cache,
+        kv_cache,
+        kv_slot_mapping,
+        state_block_size,
+        state_width,
+        kv_block_size,
+    )
+    if not supported:
+        return False, reason
+
+    from vllm_musa import _custom_ops as musa_ops
+
+    musa_ops.deepseek_v4_c4_indexer_compress_cache(
+        state_cache,
+        token_to_req_indices,
+        positions,
+        state_slot_mapping,
+        block_table,
+        rms_norm_weight,
+        cos_sin_cache,
+        kv_cache,
+        kv_slot_mapping,
+        float(rms_eps),
+        int(state_block_size),
+        int(state_width),
+        int(kv_block_size),
+    )
+    return True, "musa_native_c4_indexer_compressor"

--- a/vllm_musa/patches/series/0093-MUSA-dispatch-DeepSeek-V4-C4-indexer-compression-to-.patch
+++ b/vllm_musa/patches/series/0093-MUSA-dispatch-DeepSeek-V4-C4-indexer-compression-to-.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Mon, 27 Jul 2026 10:01:28 +0800
+Subject: [PATCH] MUSA: dispatch DeepSeek-V4 C4 indexer compression to native
+ op
+
+---
+ .../common/ops/fused_compress_quant_cache.py  | 32 +++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+diff --git a/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py b/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
+index 4ec4d72902..78df401a32 100644
+--- a/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
++++ b/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
+@@ -72,6 +72,38 @@ def compress_norm_rope_store_triton(
+     Picks one of the three kernels in this module based on ``head_dim`` and
+     ``use_fp4_cache``. Identical launch signature for all three.
+     """
++    if (
++        head_dim == 128
++        and not use_fp4_cache
++        and compress_ratio == 4
++        and overlap
++        and (
++            current_platform.is_musa()
++            or getattr(state_cache.device, "type", None) == "musa"
++        )
++    ):
++        from vllm_musa.kernels.deepseek_v4_c4_indexer_compressor import (
++            try_musa_deepseek_v4_c4_indexer_compressor,
++        )
++
++        handled, _ = try_musa_deepseek_v4_c4_indexer_compressor(
++            state_cache=state_cache,
++            token_to_req_indices=token_to_req_indices,
++            positions=positions,
++            state_slot_mapping=slot_mapping,
++            block_table=block_table,
++            rms_norm_weight=rms_norm_weight,
++            cos_sin_cache=cos_sin_cache,
++            kv_cache=kv_cache,
++            kv_slot_mapping=k_cache_metadata.slot_mapping,
++            rms_eps=rms_norm_eps,
++            state_block_size=block_size,
++            state_width=state_width,
++            kv_block_size=kv_cache.shape[1],
++        )
++        if handled:
++            return
++
+     if head_dim == 512:
+         kernel = _fused_kv_compress_norm_rope_insert_sparse_attn
+         num_warps = 4

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -15,7 +15,7 @@ is pre-patched.
   sequence and patches removed from the commit stack cannot leave stale files.
   Author headers are normalized to the synthetic `musa <musa@local>` identity.
 
-Currently **92 patches** — the MUSA source edits against the immutable vLLM commit
+Currently **94 patches** — the MUSA source edits against the immutable vLLM commit
 recorded as `VLLM_COMMIT` in `third_party/PINS` (release label `v0.24.0`), applied
 at build. Runtime object/registration patches (which patch live objects at import)
 are kept separately in `vllm_musa/patches/`, not in this build-time series. Run


### PR DESCRIPTION
## Summary

This PR adds a native MUSA decode kernel for the DeepSeek-V4 C4 recent-indexer cache compressor and fixes a CUDA Graph memory regression introduced by the direct-pointer custom all-reduce (CAR) path in PR #138.

The two changes are intentionally kept in separate commits:

1. `57def1ec perf(musa): fuse DeepSeek-V4 C4 indexer compression`
2. `4da2475c fix(musa): bound DeepSeek-V4 CAR graph memory`

## Performance results

### Final-stack BS1/4/16/64 evidence

| Batch/concurrency | Output TPS | Total TPS | Mean TTFT | Mean TPOT | Result |
|---:|---:|---:|---:|---:|---:|
| 1 | **48.6551** mean of 3 | 243.4657 mean | 784.61 ms | 19.7079 ms | 3/3 |
| 4 | **135.8190** | 679.6257 | 3397.20 ms | 26.1351 ms | 4/4 |
| 16 | **298.5451** | 1493.8919 | 11287.80 ms | 42.4728 ms | 16/16 |
| 64 | **389.9380** | 1951.2133 | 39830.06 ms | 124.3161 ms | 64/64 |
