### PR TITLE
Fix qwen3.5 enable mtp failed to start

### DIFF
--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -36,7 +36,6 @@ class TestCustomOpsRuntimePatches:
         # the dflash fallback is now the vllm._custom_ops cat-6 object
         # patch; load + apply() it and assert it rebinds to the _shared helpers.
         import vllm
-
         from vllm_musa.patches import _get_patch_files, _load_patch_module, _shared
 
         vllm_ops = ModuleType("vllm._custom_ops")
@@ -456,9 +455,9 @@ class TestMUSAFlashAttentionReshapeCache:
     """
 
     def _load_fa_utils_with_musa_platform(self, monkeypatch, musa_ops_namespace):
-        import vllm
         import vllm.platforms as vllm_platforms
 
+        import vllm
         import vllm_musa
 
         monkeypatch.setenv("VLLM_MUSA_RESHAPE_CACHE_FLASH", "1")
@@ -702,6 +701,110 @@ class TestMUSAPlatformDefaults:
                 max_cudagraph_capture_size=max_cudagraph_capture_size,
                 cudagraph_capture_sizes=cudagraph_capture_sizes,
             ),
+        )
+
+    def _make_hybrid_spec_config(
+        self,
+        *,
+        is_hybrid=True,
+        cudagraph_mode=None,
+        compilation_mode=None,
+        enable_sp=False,
+        fuse_gemm_comms=False,
+        fuse_attn_quant=False,
+    ):
+        from types import SimpleNamespace
+
+        from vllm.config import CompilationMode
+
+        vllm_config = self._make_vllm_config(cudagraph_mode=cudagraph_mode)
+        vllm_config.model_config.is_hybrid = is_hybrid
+        vllm_config.speculative_config = SimpleNamespace(
+            method="qwen3_5_mtp",
+            num_speculative_tokens=2,
+            use_dflash=lambda: False,
+        )
+        vllm_config.compilation_config.mode = (
+            CompilationMode.VLLM_COMPILE
+            if compilation_mode is None
+            else compilation_mode
+        )
+        vllm_config.compilation_config.pass_config = SimpleNamespace(
+            enable_sp=enable_sp,
+            fuse_gemm_comms=fuse_gemm_comms,
+            fuse_attn_quant=fuse_attn_quant,
+        )
+        return vllm_config
+
+    def test_hybrid_mtp_full_cudagraph_coerced_to_piecewise(self):
+        from vllm.config import CUDAGraphMode
+
+        from vllm_musa.platform import MUSAPlatformBase
+
+        os.environ.pop("VLLM_MUSA_HYBRID_SPEC_ALLOW_FULL", None)
+        vllm_config = self._make_hybrid_spec_config(
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+            enable_sp=True,
+            fuse_gemm_comms=True,
+            fuse_attn_quant=True,
+        )
+
+        MUSAPlatformBase.check_and_update_config(vllm_config)
+
+        pc = vllm_config.compilation_config.pass_config
+        assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.PIECEWISE
+        assert pc.enable_sp is False
+        assert pc.fuse_gemm_comms is False
+        assert pc.fuse_attn_quant is False
+
+    def test_hybrid_mtp_compilation_none_disables_cudagraph(self):
+        from vllm.config import CompilationMode, CUDAGraphMode
+
+        from vllm_musa.platform import MUSAPlatformBase
+
+        os.environ.pop("VLLM_MUSA_HYBRID_SPEC_ALLOW_FULL", None)
+        vllm_config = self._make_hybrid_spec_config(
+            cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+            compilation_mode=CompilationMode.NONE,
+        )
+
+        MUSAPlatformBase.check_and_update_config(vllm_config)
+
+        assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+
+    def test_non_hybrid_spec_keeps_full_cudagraph(self):
+        from vllm.config import CUDAGraphMode
+
+        from vllm_musa.platform import MUSAPlatformBase
+
+        os.environ.pop("VLLM_MUSA_HYBRID_SPEC_ALLOW_FULL", None)
+        vllm_config = self._make_hybrid_spec_config(
+            is_hybrid=False,
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        )
+
+        MUSAPlatformBase.check_and_update_config(vllm_config)
+
+        assert (
+            vllm_config.compilation_config.cudagraph_mode
+            == CUDAGraphMode.FULL_AND_PIECEWISE
+        )
+
+    def test_hybrid_spec_full_cudagraph_diagnostic_override(self):
+        from vllm.config import CUDAGraphMode
+
+        from vllm_musa.platform import MUSAPlatformBase
+
+        os.environ["VLLM_MUSA_HYBRID_SPEC_ALLOW_FULL"] = "1"
+        vllm_config = self._make_hybrid_spec_config(
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        )
+
+        MUSAPlatformBase.check_and_update_config(vllm_config)
+
+        assert (
+            vllm_config.compilation_config.cudagraph_mode
+            == CUDAGraphMode.FULL_AND_PIECEWISE
         )
 
     def test_qwen3_moe_does_not_cap_default_cudagraph_capture_size(self):

--- a/vllm_musa/jit_kernel/tilelang/causal_conv1d.py
+++ b/vllm_musa/jit_kernel/tilelang/causal_conv1d.py
@@ -69,6 +69,7 @@ def _causal_conv1d_fwd_kernel(
     state_stride_seq: int,
     state_stride_dim: int,
     state_stride_token: int,
+    cache_indices_stride: int,
     o_stride_dim: int,
     o_stride_token: int,
     has_bias: bool,
@@ -152,7 +153,7 @@ def _causal_conv1d_fwd_kernel(
 
             cache_idx = seq_idx
             if has_cache_indices:
-                cache_idx = cache_indices[seq_idx]
+                cache_idx = cache_indices[seq_idx * cache_indices_stride]
                 if has_cache_index_mapping:
                     cache_idx = cache_index_mapping[cache_idx]
             valid_seq = segment_len > 0
@@ -950,6 +951,7 @@ def _causal_conv1d_decode_width4_batched_kernel(
     state_stride_seq: int,
     state_stride_dim: int,
     state_stride_token: int,
+    cache_indices_stride: int,
     o_stride_token: int,
     has_bias: bool,
     has_cache_indices: bool,
@@ -1009,7 +1011,7 @@ def _causal_conv1d_decode_width4_batched_kernel(
 
             cache_idx = seq_idx
             if has_cache_indices and seq_idx < batch:
-                cache_idx = cache_indices[seq_idx]
+                cache_idx = cache_indices[seq_idx * cache_indices_stride]
                 if has_cache_index_mapping:
                     cache_idx = cache_index_mapping[cache_idx]
             valid = seq_idx < batch and feat < dim
@@ -1195,7 +1197,9 @@ def _causal_conv1d_fwd_impl(
     out_arg = storage_window(out)
     bias_arg = storage_window(bias) if bias is not None else x_arg
     conv_states_arg = storage_window(conv_states) if conv_states is not None else x_arg
-    cache_indices_arg = cache_indices if cache_indices is not None else query_start_loc
+    cache_indices_arg = (
+        storage_window(cache_indices) if cache_indices is not None else query_start_loc
+    )
     cache_index_mapping_arg = (
         cache_index_mapping if cache_index_mapping is not None else cache_indices_arg
     )
@@ -1255,6 +1259,7 @@ def _causal_conv1d_fwd_impl(
             int(state_stride_seq),
             int(state_stride_dim),
             int(state_stride_token),
+            int(cache_indices.stride(0)) if cache_indices is not None else 1,
             int(out.stride(1)),
             bias is not None,
             cache_indices is not None,
@@ -1410,6 +1415,7 @@ def _causal_conv1d_fwd_impl(
         int(state_stride_seq),
         int(state_stride_dim),
         int(state_stride_token),
+        int(cache_indices.stride(0)) if cache_indices is not None else 1,
         int(out.stride(0)),
         int(out.stride(1)),
         bias is not None,
@@ -1677,6 +1683,7 @@ def musa_tilelang_causal_conv1d_update(
         int(conv_state.stride(0)),
         int(conv_state.stride(1)),
         int(conv_state.stride(2)),
+        int(idx.stride(0)),
         int(outt.stride(1)),
         bias is not None,
         has_cache_indices,
@@ -1687,13 +1694,14 @@ def musa_tilelang_causal_conv1d_update(
         256,
         1,
     )
+    idx_arg = storage_window(idx)
     ker(
         storage_window(xt),
         storage_window(weight),
         storage_window(bias) if bias is not None else storage_window(xt),
         storage_window(conv_state),
-        idx,
-        idx,
+        idx_arg,
+        idx_arg,
         has_init,
         storage_window(outt),
         int(batch),

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -519,10 +519,12 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
             b_non_spec = b
 
         if spec_sequence_masks is not None:
+            a_spec = a.index_select(0, spec_token_indx)
+            b_spec = b.index_select(0, spec_token_indx)
             core_attn_out_spec, _ = fused_sigmoid_gating_delta_rule_update(
                 A_log=self.A_log,
-                a=a,
-                b=b,
+                a=a_spec,
+                b=b_spec,
                 dt_bias=self.dt_bias,
                 q=query_spec,
                 k=key_spec,

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -569,6 +569,18 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
                 self._sm_count = 60
 
         # ==================== MUSA ADAPTATION ====================
+        self.num_speculative_tokens = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config is not None
+            else 0
+        )
+        # With MTP, a decode/verify row carries 1 + draft tokens. Keep the
+        # attention split aligned with Mamba/GDN metadata so pure MTP verify
+        # batches are not misclassified as prefills.
+        self.decode_threshold = (
+            self.reorder_batch_threshold + self.num_speculative_tokens
+        )
+
         if self.use_full_cuda_graph:
             self._cu_seqlens_k_buffer = torch.zeros(
                 vllm_config.scheduler_config.max_num_seqs + 1,
@@ -605,8 +617,12 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
             split_decodes_and_prefills(
                 common_attn_metadata,
-                decode_threshold=self.reorder_batch_threshold,
+                decode_threshold=self.decode_threshold,
                 require_uniform=False,
+                treat_short_extends_as_decodes=(
+                    self.num_speculative_tokens == 0
+                    or common_attn_metadata.is_prefilling is None
+                ),
             )
         )
 
@@ -1298,31 +1314,66 @@ class FlashAttentionImpl(AttentionImpl):
                     # verify (multiple query tokens per seq), or layers ineligible for the
                     # mubin fast path (sliding-window/softcap/fp8/sinks). All tokens attend
                     # through the paged KV cache with the original query_start_loc layout.
-                    flash_attn_varlen_func(
-                        q=query[:num_actual_tokens].view(
-                            -1, self.num_heads, self.head_size
-                        ),
-                        k=key_cache,
-                        v=value_cache,
-                        out=output[:num_actual_tokens].view(
-                            -1, self.num_heads, self.head_size
-                        ),
-                        cu_seqlens_q=cu_seqlens_q,
-                        max_seqlen_q=max_seqlen_q,
-                        seqused_k=seqused_k,
-                        max_seqlen_k=max_seqlen_k,
-                        softmax_scale=self.scale,
-                        causal=attn_metadata.causal,
-                        window_size=sliding_window_size,
-                        block_table=block_table,
-                        softcap=self.logits_soft_cap,
-                        scheduler_metadata=scheduler_metadata,
-                        q_descale=q_descale,
-                        k_descale=k_descale,
-                        v_descale=v_descale,
-                        num_splits=attn_metadata.max_num_splits,
-                        s_aux=self.sinks,
+                    use_fused_kv_verify = (
+                        num_decodes > 0
+                        and num_prefills == 0
+                        and num_decode_tokens > num_decodes
+                        and max_seqlen_q > 1
+                        and attn_metadata.causal
                     )
+
+                    if use_fused_kv_verify:
+                        # MTP verify has multiple query tokens per request. KV
+                        # cache has already been populated by do_kv_cache_update;
+                        # use the paged decode kernel for the verify attention
+                        # instead of the varlen paged fallback, which is not
+                        # graph-safe for this MUSA shape.
+                        output[:num_actual_tokens] = flash_attn_with_kvcache(
+                            q=query[:num_actual_tokens].view(
+                                -1, self.num_heads, self.head_size
+                            ),
+                            k_cache=key_cache,
+                            v_cache=value_cache,
+                            cache_seqlens=seqused_k,
+                            page_table=block_table,
+                            cu_seqlens_q=cu_seqlens_q,
+                            max_seqlen_q=max_seqlen_q,
+                            softmax_scale=self.scale,
+                            causal=attn_metadata.causal,
+                            window_size=sliding_window_size,
+                            softcap=self.logits_soft_cap,
+                            q_descale=q_descale,
+                            k_descale=k_descale,
+                            v_descale=v_descale,
+                            num_splits=max(attn_metadata.max_num_splits, 1),
+                            s_aux=self.sinks,
+                        )
+                    else:
+                        flash_attn_varlen_func(
+                            q=query[:num_actual_tokens].view(
+                                -1, self.num_heads, self.head_size
+                            ),
+                            k=key_cache,
+                            v=value_cache,
+                            out=output[:num_actual_tokens].view(
+                                -1, self.num_heads, self.head_size
+                            ),
+                            cu_seqlens_q=cu_seqlens_q,
+                            max_seqlen_q=max_seqlen_q,
+                            seqused_k=seqused_k,
+                            max_seqlen_k=max_seqlen_k,
+                            softmax_scale=self.scale,
+                            causal=attn_metadata.causal,
+                            window_size=sliding_window_size,
+                            block_table=block_table,
+                            softcap=self.logits_soft_cap,
+                            scheduler_metadata=scheduler_metadata,
+                            q_descale=q_descale,
+                            k_descale=k_descale,
+                            v_descale=v_descale,
+                            num_splits=attn_metadata.max_num_splits,
+                            s_aux=self.sinks,
+                        )
                 # ========================== END ==========================
 
                 return output


### PR DESCRIPTION
- Fixed causal_conv1d stride handling in the TileLang kernel.
    - cache_indices can be a strided view under MTP.
    - The kernel now reads it with the real stride instead of assuming contiguous layout.

- Fixed token alignment in the Qwen GDN MTP path.
    - The spec branch now re-indexes a/b with spec_token_indx before calling the delta-rule update.
    - This prevents spec/non-spec state misalignment.

- Split FlashAttention handling for MTP verify vs normal paged fallback.
    - Pure MTP verify batches now go through flash_attn_with_kvcache.
    - Normal non-MTP paged fallback still uses flash_attn_varlen_func.
    - This is not just an output-buffer change; it switches to the correct kernel path for multi-token verify.