### PR TITLE
Qwen3.6-35B-A3B BF16 serving optimizations on MUSA

### DIFF
--- a/tests/jit_kernel/test_csrc_jit_kernels.py
+++ b/tests/jit_kernel/test_csrc_jit_kernels.py
@@ -513,6 +513,47 @@ def test_csrc_topk_kernels_match_reference(
     _assert_close(weights, ref_weights, atol=3e-3, rtol=3e-3)
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_csrc_topk_fuses_qwen_shared_gate(dtype: torch.dtype) -> None:
+    from vllm_musa.jit_kernel.csrc.topk import topk_softmax
+
+    torch.manual_seed(790)
+    device = torch.device("musa")
+    rows = 7
+    routed_experts = 256
+    routed_topk = 8
+    combined_logits = torch.randn(
+        (rows, routed_experts + 1), device=device, dtype=dtype
+    )
+
+    weights = torch.empty(
+        (rows, routed_topk + 1), device=device, dtype=torch.float32
+    )
+    ids = torch.empty(
+        (rows, routed_topk + 1), device=device, dtype=torch.int32
+    )
+    topk_softmax(
+        weights,
+        ids,
+        combined_logits,
+        renormalize=True,
+        num_fused_shared_experts=1,
+    )
+
+    routed_weights, routed_ids = _topk_softmax_ref(
+        combined_logits[:, :routed_experts], routed_topk, True
+    )
+    shared_weights = torch.sigmoid(combined_logits[:, routed_experts:]).float()
+    shared_ids = torch.full(
+        (rows, 1), routed_experts, device=device, dtype=torch.int32
+    )
+    ref_weights = torch.cat((routed_weights, shared_weights), dim=-1)
+    ref_ids = torch.cat((routed_ids, shared_ids), dim=-1)
+
+    _assert_ids_equal(ids, ref_ids)
+    _assert_close(weights, ref_weights, atol=3e-3, rtol=3e-3)
+
+
 def test_csrc_jit_integration_imports() -> None:
     import vllm_musa.model_executor.layers.fused_moe.router.grouped_topk_router as topk_router
     import vllm_musa.model_executor.layers.layernorm as layernorm

--- a/tests/test_gdn_dual_stream_source.py
+++ b/tests/test_gdn_dual_stream_source.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source contract for the MUSA GDN projection overlap."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_PATH = (
+    ROOT
+    / "vllm_musa"
+    / "model_executor"
+    / "layers"
+    / "mamba"
+    / "gdn"
+    / "qwen_gdn_linear_attn.py"
+)
+
+
+def test_gdn_dual_stream_projection_contract() -> None:
+    source = SOURCE_PATH.read_text(encoding="utf-8")
+
+    assert "_GDN_DUAL_STREAM_TOKEN_THRESHOLD = 1024" in source
+    assert "torch.musa.Stream()" in source
+    assert "create=not is_capturing" in source
+    assert "alt_stream.wait_stream(current_stream)" in source
+    assert "current_stream.wait_stream(alt_stream)" in source
+    assert "VLLM_MUSA_GDN_DUAL_PROJ_STREAM" not in source
+
+    qkvz = "mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)"
+    ba = "ba, _ = self.in_proj_ba(hidden_states)"
+    aux_context = "with torch.musa.stream(alt_stream):"
+    wait_for_aux = "current_stream.wait_stream(alt_stream)"
+
+    overlap_start = source.index("def _forward_input_projections")
+    overlap_end = source.index("def _forward_core", overlap_start)
+    overlap = source[overlap_start:overlap_end]
+    assert overlap.index(qkvz) < overlap.index(aux_context)
+    assert overlap.index(aux_context) < overlap.index(ba)
+    assert overlap.index(ba) < overlap.index(wait_for_aux)

--- a/tests/test_manifest_completeness.py
+++ b/tests/test_manifest_completeness.py
@@ -13,6 +13,7 @@ offline in normal CI.
 """
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -68,6 +69,14 @@ def test_series_bijection_with_manifest(m):
         f"series⇔manifest mismatch: only on disk={on_disk - in_manifest}; "
         f"only in manifest={in_manifest - on_disk}"
     )
+
+
+def test_series_readme_count_matches_disk() -> None:
+    readme = (PATCHES / "series" / "README.md").read_text(encoding="utf-8")
+    match = re.search(r"Currently \*\*(\d+) patches\*\*", readme)
+    assert match is not None, "series README must state the current patch count"
+    on_disk = sum(1 for _ in (PATCHES / "series").glob("*.patch"))
+    assert int(match.group(1)) == on_disk
 
 
 def test_object_patches_have_cat6_entries(m):

--- a/tests/test_moe_fused_shared_topk_source.py
+++ b/tests/test_moe_fused_shared_topk_source.py
@@ -17,6 +17,7 @@ def test_unquantized_moe_uses_fused_shared_topk_extension() -> None:
     assert "topk_weights, topk_ids = extend_topk_with_shared(" in source
     assert "VLLM_MUSA_MOE_FUSED_SHARED_TOPK" not in source
     assert "torch.cat([topk_weights, shared_weight]" not in source
+    assert "topk_weights.shape[1] == routed_topk + 1" in source
 
 
 def test_fused_shared_topk_preserves_bf16_sigmoid_rounding() -> None:
@@ -31,3 +32,39 @@ def test_fused_shared_topk_has_no_runtime_gate() -> None:
     source = (REPO_ROOT / "vllm_musa/utils/environ.py").read_text()
 
     assert "VLLM_MUSA_MOE_FUSED_SHARED_TOPK" not in source
+
+
+def test_qwen_fold_combines_router_and_shared_gate_projection() -> None:
+    patch = (
+        REPO_ROOT
+        / "vllm_musa/patches/series/"
+        "0076-MUSA-model-fold-the-Qwen3.5-shared-expert-into-fused.patch"
+    ).read_text()
+    assert "num_experts=self.n_routed_experts" in patch
+    assert "if self.shared_expert is None or self._musa_shared_fold" in patch
+    assert "self.experts.router._musa_num_fused_shared_experts = 1" in patch
+
+
+def test_musa_topk_consumes_combined_qwen_gate_output() -> None:
+    router = (
+        REPO_ROOT
+        / "vllm_musa/model_executor/layers/fused_moe/router/"
+        "grouped_topk_router.py"
+    ).read_text()
+    fallback = (
+        REPO_ROOT
+        / "vllm_musa/model_executor/layers/fused_moe/router/"
+        "fused_topk_router.py"
+    ).read_text()
+    wrapper = (REPO_ROOT / "vllm_musa/jit_kernel/csrc/topk.py").read_text()
+    kernel = (
+        REPO_ROOT / "vllm_musa/jit_kernel/csrc/topk/topk_gating.mu"
+    ).read_text()
+    assert "num_fused_shared_experts=num_fused_shared_experts" in router
+    assert "routed_experts = self.global_num_experts" in fallback
+    assert "router_logits[:, :routed_experts].contiguous()" in fallback
+    assert "router_logits[:, routed_experts:].contiguous()" in fallback
+    assert "int(num_fused_shared_experts)" in wrapper
+    assert "int num_fused_shared_experts" in kernel
+    assert "num_experts == 257 && topk == 9" in kernel
+    assert "topk_softmax_no_bias_renorm_warp_shared1_kernel_fixed_k" in kernel

--- a/tests/test_qwen36_bf16_w1_config_source.py
+++ b/tests/test_qwen36_bf16_w1_config_source.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source contract for the Qwen3.6 BF16 C25 W1-only MoE tile."""
+
+from pathlib import Path
+
+
+PATCH = (
+    Path(__file__).resolve().parent.parent
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0101-perf-specialize-qwen36-bf16-w1-c25.patch"
+)
+
+
+def test_qwen36_bf16_c25_specializes_only_w1_config():
+    source = PATCH.read_text()
+
+    assert "current_platform.is_musa()" in source
+    assert "hidden_states.dtype == torch.bfloat16" in source
+    assert "M == 25" in source
+    assert "tuple(w1.shape) == (257, 1024, 2048)" in source
+    assert "tuple(w2.shape) == (257, 2048, 512)" in source
+    assert "top_k_num == 9" in source
+    assert "global_num_experts == 257" in source
+    assert "expert_map is None" in source
+    assert "block_shape is None" in source
+
+    assert 'config.get("BLOCK_SIZE_M") == 32' in source
+    assert 'config.get("BLOCK_SIZE_N") == 32' in source
+    assert 'config.get("BLOCK_SIZE_K") == 64' in source
+    assert 'config.get("num_warps") == 4' in source
+    assert "BLOCK_SIZE_N=64" in source
+    assert "BLOCK_SIZE_K=128" in source
+    assert "num_warps=8" in source
+
+    # One use aligns experts for W1 and one dispatches W1. The untouched W2
+    # dispatch remains on ``config`` because it is outside this narrow diff.
+    assert source.count("+        w1_config,") == 2
+    assert "VLLM_MUSA" not in source

--- a/tests/test_qwen_gdn_output_allocation.py
+++ b/tests/test_qwen_gdn_output_allocation.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: I001
+"""Focused allocation contract for the MUSA Qwen GDN output buffer."""
+
+from types import SimpleNamespace
+
+# isort: off
+import torchada  # noqa: F401
+import torch
+
+# isort: on
+
+from vllm.config import CUDAGraphMode
+
+from vllm_musa.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
+
+
+def _patch_forward_context(
+    monkeypatch,
+    *,
+    runtime_mode: CUDAGraphMode,
+    bucket_size: int | None,
+    has_attention_metadata: bool = True,
+) -> None:
+    batch_descriptor = (
+        SimpleNamespace(num_tokens=bucket_size) if bucket_size is not None else None
+    )
+    forward_context = SimpleNamespace(
+        attn_metadata=object() if has_attention_metadata else None,
+        batch_descriptor=batch_descriptor,
+        cudagraph_runtime_mode=runtime_mode,
+    )
+    monkeypatch.setattr(gdn, "get_forward_context", lambda: forward_context)
+
+
+def _patch_allocators(monkeypatch) -> list[str]:
+    calls: list[str] = []
+
+    def fake_empty(shape, *, dtype, device):
+        calls.append("empty")
+        return torch.full(shape, -7, dtype=dtype, device=device)
+
+    def fake_zeros(shape, *, dtype, device):
+        calls.append("zeros")
+        return torch.full(shape, 0, dtype=dtype, device=device)
+
+    monkeypatch.setattr(gdn.torch, "empty", fake_empty)
+    monkeypatch.setattr(gdn.torch, "zeros", fake_zeros)
+    return calls
+
+
+def test_exact_cudagraph_bucket_skips_gdn_output_zeroing(monkeypatch) -> None:
+    _patch_forward_context(
+        monkeypatch,
+        runtime_mode=CUDAGraphMode.FULL,
+        bucket_size=25,
+    )
+    calls = _patch_allocators(monkeypatch)
+
+    def fail_runtime_config_lookup():
+        raise AssertionError("runtime config lookup")
+
+    monkeypatch.setattr(gdn, "get_current_vllm_config", fail_runtime_config_lookup)
+
+    output = gdn._allocate_gdn_output(
+        (25, 2, 2),
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        capture_sizes=tuple(range(1, 65)),
+    )
+
+    assert calls == ["empty"]
+    assert torch.equal(output, torch.full_like(output, -7))
+
+
+def test_padded_cudagraph_bucket_zeros_only_danger_zone(monkeypatch) -> None:
+    _patch_forward_context(
+        monkeypatch,
+        runtime_mode=CUDAGraphMode.FULL,
+        bucket_size=8,
+    )
+    calls = _patch_allocators(monkeypatch)
+
+    output = gdn._allocate_gdn_output(
+        (8, 2, 2),
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        capture_sizes=(1, 4, 8),
+    )
+
+    assert calls == ["empty"]
+    assert torch.equal(output[:4], torch.full_like(output[:4], -7))
+    assert torch.equal(output[4:], torch.zeros_like(output[4:]))
+
+
+def test_eager_gdn_output_keeps_zero_initialized_contract(monkeypatch) -> None:
+    _patch_forward_context(
+        monkeypatch,
+        runtime_mode=CUDAGraphMode.NONE,
+        bucket_size=None,
+    )
+    calls = _patch_allocators(monkeypatch)
+
+    output = gdn._allocate_gdn_output(
+        (25, 2, 2),
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        capture_sizes=tuple(range(1, 65)),
+    )
+
+    assert calls == ["zeros"]
+    assert torch.equal(output, torch.zeros_like(output))
+
+
+def test_profile_warmup_keeps_zero_initialized_contract(monkeypatch) -> None:
+    _patch_forward_context(
+        monkeypatch,
+        runtime_mode=CUDAGraphMode.FULL,
+        bucket_size=25,
+        has_attention_metadata=False,
+    )
+    calls = _patch_allocators(monkeypatch)
+
+    output = gdn._allocate_gdn_output(
+        (25, 2, 2),
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        capture_sizes=tuple(range(1, 65)),
+    )
+
+    assert calls == ["zeros"]
+    assert torch.equal(output, torch.zeros_like(output))

--- a/vllm_musa/jit_kernel/csrc/topk.py
+++ b/vllm_musa/jit_kernel/csrc/topk.py
@@ -24,6 +24,7 @@ def _topk_softmax_impl(
     renormalize: bool = False,
     moe_softcapping: float = 0.0,
     correction_bias: Optional[torch.Tensor] = None,
+    num_fused_shared_experts: int = 0,
 ) -> None:
     has_correction_bias = correction_bias is not None
     bias_arg = correction_bias if has_correction_bias else topk_weights.reshape(-1)
@@ -35,6 +36,7 @@ def _topk_softmax_impl(
         float(moe_softcapping),
         bias_arg,
         bool(has_correction_bias),
+        int(num_fused_shared_experts),
     )
 
 
@@ -65,6 +67,7 @@ def _topk_softmax_custom(
     renormalize: bool = False,
     moe_softcapping: float = 0.0,
     has_correction_bias: bool = False,
+    num_fused_shared_experts: int = 0,
 ) -> None:
     bias_arg = correction_bias if has_correction_bias else topk_weights.reshape(-1)
     _topk_module().sgl_musa_topk_softmax(
@@ -75,6 +78,7 @@ def _topk_softmax_custom(
         float(moe_softcapping),
         bias_arg,
         bool(has_correction_bias),
+        int(num_fused_shared_experts),
     )
 
 
@@ -86,6 +90,7 @@ def _topk_softmax_custom_fake(
     renormalize: bool = False,
     moe_softcapping: float = 0.0,
     has_correction_bias: bool = False,
+    num_fused_shared_experts: int = 0,
 ) -> None:
     return
 
@@ -142,6 +147,7 @@ def topk_softmax(
     renormalize: bool = False,
     moe_softcapping: float = 0.0,
     correction_bias: Optional[torch.Tensor] = None,
+    num_fused_shared_experts: int = 0,
 ) -> None:
     """sgl_kernel-compatible top-k softmax entry point."""
     has_correction_bias = correction_bias is not None
@@ -154,6 +160,7 @@ def topk_softmax(
         renormalize,
         moe_softcapping,
         has_correction_bias,
+        num_fused_shared_experts,
     )
 
 

--- a/vllm_musa/jit_kernel/csrc/topk/topk_gating.mu
+++ b/vllm_musa/jit_kernel/csrc/topk/topk_gating.mu
@@ -439,6 +439,92 @@ __launch_bounds__(kWarpsPerCta *kWarpSize, 1) void topk_softmax_no_bias_renorm_w
   }
 }
 
+template <typename T, int NumExperts, int ValuesPerThread, int TopK>
+__global__ __launch_bounds__(
+    kWarpsPerCta *kWarpSize,
+    1) void topk_softmax_no_bias_renorm_warp_shared1_kernel_fixed_k(
+    const T *__restrict__ combined_gating_output,
+    float *__restrict__ topk_weights, int32_t *__restrict__ topk_ids,
+    int num_tokens) {
+  constexpr int InputExperts = NumExperts + 1;
+  constexpr int OutTopK = TopK + 1;
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / kWarpSize;
+  const int lane = lane_id();
+  const int row = blockIdx.x * kWarpsPerCta + warp_id;
+  if (row >= num_tokens) {
+    return;
+  }
+
+  float logits[ValuesPerThread];
+
+#pragma unroll
+  for (int i = 0; i < ValuesPerThread; ++i) {
+    const int expert = lane + i * kWarpSize;
+    logits[i] =
+        to_float(combined_gating_output[row * InputExperts + expert]);
+  }
+
+  float selected_logits[TopK];
+  int selected_ids[TopK];
+
+#pragma unroll
+  for (int k_idx = 0; k_idx < TopK; ++k_idx) {
+    float max_val = logits[0];
+    int max_idx = lane;
+#pragma unroll
+    for (int i = 1; i < ValuesPerThread; ++i) {
+      const int expert = lane + i * kWarpSize;
+      const float val = logits[i];
+      if (val > max_val) {
+        max_val = val;
+        max_idx = expert;
+      }
+    }
+    warp_argmax(max_val, max_idx);
+
+    if (lane == 0) {
+      selected_logits[k_idx] = max_val;
+      selected_ids[k_idx] = max_idx;
+    }
+
+#pragma unroll
+    for (int i = 0; i < ValuesPerThread; ++i) {
+      const int expert = lane + i * kWarpSize;
+      if (expert == max_idx) {
+        logits[i] = kFloatMinimum;
+      }
+    }
+  }
+
+  if (lane == 0) {
+    const float selected_max = selected_logits[0];
+    selected_logits[0] = 1.0f;
+    float selected_sum = 1.0f;
+#pragma unroll
+    for (int k_idx = 1; k_idx < TopK; ++k_idx) {
+      selected_logits[k_idx] = __expf(selected_logits[k_idx] - selected_max);
+      selected_sum += selected_logits[k_idx];
+    }
+    const float inv_selected_sum = 1.0f / selected_sum;
+#pragma unroll
+    for (int k_idx = 0; k_idx < TopK; ++k_idx) {
+      const int out_idx = row * OutTopK + k_idx;
+      topk_weights[out_idx] = selected_logits[k_idx] * inv_selected_sum;
+      topk_ids[out_idx] = selected_ids[k_idx];
+    }
+
+    const int shared_out_idx = row * OutTopK + TopK;
+    const float shared_logit =
+        to_float(combined_gating_output[row * InputExperts + NumExperts]);
+    const T rounded_shared_weight =
+        from_float<T>(stable_sigmoid(shared_logit));
+    topk_weights[shared_out_idx] = to_float(rounded_shared_weight);
+    topk_ids[shared_out_idx] = NumExperts;
+  }
+}
+
 template <typename T, int NumExperts, int TopK>
 __global__
 __launch_bounds__(kWarpsPerCta *kWarpSize, 1) void topk_softmax_no_bias_renorm_halfwarp_kernel_fixed_k(
@@ -811,7 +897,7 @@ template <typename T, bool IsSoftmax>
 void launch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
                  ffi::TensorView gating_output, bool renormalize,
                  float moe_softcapping, ffi::TensorView correction_bias,
-                 bool has_correction_bias) {
+                 bool has_correction_bias, int num_fused_shared_experts) {
   const int num_tokens = static_cast<int>(gating_output.size(0));
   const int num_experts = static_cast<int>(gating_output.size(1));
   const int topk = static_cast<int>(topk_weights.size(1));
@@ -828,6 +914,27 @@ void launch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
 
   ffi::MUSADeviceGuard device_guard(gating_output.device().device_id);
   musaStream_t stream = get_stream(gating_output.device());
+
+  if constexpr (IsSoftmax) {
+    if (num_fused_shared_experts == 1 && num_experts == 257 && topk == 9 &&
+        renormalize && !has_correction_bias && moe_softcapping <= 0.0f) {
+      constexpr int values_per_thread = 8;
+      const int blocks = (num_tokens + kWarpsPerCta - 1) / kWarpsPerCta;
+      topk_softmax_no_bias_renorm_warp_shared1_kernel_fixed_k<
+          T, 256, values_per_thread, 8>
+          <<<blocks, kWarpsPerCta * kWarpSize, 0, stream>>>(
+              input_ptr, weights_ptr, ids_ptr, num_tokens);
+      const musaError_t err = musaGetLastError();
+      TVM_FFI_ICHECK_EQ(err, musaSuccess)
+          << "MUSA fused-shared topk kernel failed: "
+          << musaGetErrorString(err);
+      return;
+    }
+  }
+
+  TVM_FFI_ICHECK_EQ(num_fused_shared_experts, 0)
+      << "Fused shared top-k currently supports only softmax-renorm "
+         "E=256, topk=8, shared=1.";
 
   if (num_experts == 128) {
     constexpr int values_per_thread = 4;
@@ -1021,19 +1128,22 @@ template <bool IsSoftmax>
 void dispatch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
                    ffi::TensorView gating_output, bool renormalize,
                    float moe_softcapping, ffi::TensorView correction_bias,
-                   bool has_correction_bias) {
+                   bool has_correction_bias, int num_fused_shared_experts) {
   if (dtype_equal(gating_output.dtype(), dl_float32)) {
     launch_topk<float, IsSoftmax>(topk_weights, topk_ids, gating_output,
                                   renormalize, moe_softcapping, correction_bias,
-                                  has_correction_bias);
+                                  has_correction_bias,
+                                  num_fused_shared_experts);
   } else if (dtype_equal(gating_output.dtype(), dl_float16)) {
     launch_topk<half, IsSoftmax>(topk_weights, topk_ids, gating_output,
                                  renormalize, moe_softcapping, correction_bias,
-                                 has_correction_bias);
+                                 has_correction_bias,
+                                 num_fused_shared_experts);
   } else if (dtype_equal(gating_output.dtype(), dl_bfloat16)) {
     launch_topk<__mt_bfloat16, IsSoftmax>(topk_weights, topk_ids, gating_output,
                                           renormalize, moe_softcapping,
-                                          correction_bias, has_correction_bias);
+                                          correction_bias, has_correction_bias,
+                                          num_fused_shared_experts);
   } else {
     TVM_FFI_THROW(ValueError) << "Unsupported gating_output dtype";
   }
@@ -1044,12 +1154,13 @@ void sgl_musa_topk_softmax(ffi::TensorView topk_weights,
                            ffi::TensorView gating_output, bool renormalize,
                            double moe_softcapping,
                            ffi::TensorView correction_bias,
-                           bool has_correction_bias) {
+                           bool has_correction_bias,
+                           int num_fused_shared_experts) {
   check_topk_inputs(topk_weights, topk_ids, gating_output, correction_bias,
                     has_correction_bias);
   dispatch_topk<true>(topk_weights, topk_ids, gating_output, renormalize,
                       static_cast<float>(moe_softcapping), correction_bias,
-                      has_correction_bias);
+                      has_correction_bias, num_fused_shared_experts);
 }
 
 void sgl_musa_topk_sigmoid(ffi::TensorView topk_weights,
@@ -1060,7 +1171,7 @@ void sgl_musa_topk_sigmoid(ffi::TensorView topk_weights,
   check_topk_inputs(topk_weights, topk_ids, gating_output, correction_bias,
                     has_correction_bias);
   dispatch_topk<false>(topk_weights, topk_ids, gating_output, renormalize, 0.0f,
-                       correction_bias, has_correction_bias);
+                       correction_bias, has_correction_bias, 0);
 }
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_topk_softmax, sgl_musa_topk_softmax);

--- a/vllm_musa/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm_musa/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -25,6 +25,9 @@ def _compute_routing(
     input_ids: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     scoring_func = getattr(self, "scoring_func", "softmax")
+    num_fused_shared_experts = int(
+        getattr(self, "_musa_num_fused_shared_experts", 0)
+    )
     jit_result = _musa_jit_fused_topk(
         hidden_states=hidden_states,
         gating_output=router_logits,
@@ -33,9 +36,38 @@ def _compute_routing(
         indices_type=indices_type,
         correction_bias=None,
         scoring_func=scoring_func,
+        num_fused_shared_experts=num_fused_shared_experts,
     )
     if jit_result is not None:
         return jit_result
+
+    if num_fused_shared_experts:
+        # Correctness fallback for builds where the JIT top-k kernel is disabled
+        # or unavailable. The combined gate produces routed logits followed by
+        # one shared logit; split them before the ordinary router so the shared
+        # expert can never participate in routed top-k selection.
+        assert num_fused_shared_experts == 1
+        routed_experts = self.global_num_experts
+        routed_logits = router_logits[:, :routed_experts].contiguous()
+        shared_logits = router_logits[:, routed_experts:].contiguous()
+        topk_weights, topk_ids, _ = fused_topk(
+            hidden_states=hidden_states,
+            gating_output=routed_logits,
+            topk=self.top_k,
+            renormalize=self.renormalize,
+            indices_type=indices_type,
+            scoring_func=scoring_func,
+        )
+        from vllm_musa.jit_kernel.extend_topk_shared import (
+            extend_topk_with_shared,
+        )
+
+        return extend_topk_with_shared(
+            topk_weights,
+            topk_ids,
+            shared_logits,
+            routed_experts,
+        )
 
     topk_weights, topk_ids, _ = fused_topk(
         hidden_states=hidden_states,

--- a/vllm_musa/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm_musa/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -42,10 +42,8 @@ def _compute_routing(
         return jit_result
 
     if num_fused_shared_experts:
-        # Correctness fallback for builds where the JIT top-k kernel is disabled
-        # or unavailable. The combined gate produces routed logits followed by
-        # one shared logit; split them before the ordinary router so the shared
-        # expert can never participate in routed top-k selection.
+        # Combined logits contain routed columns followed by one shared logit.
+        # Keep the shared expert out of routed top-k selection.
         assert num_fused_shared_experts == 1
         routed_experts = self.global_num_experts
         routed_logits = router_logits[:, :routed_experts].contiguous()

--- a/vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -67,7 +67,17 @@ def _musa_jit_fused_topk(
     indices_type: torch.dtype | None,
     correction_bias: torch.Tensor | None = None,
     scoring_func: str = "softmax",
+    num_fused_shared_experts: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor] | None:
+    if num_fused_shared_experts and not (
+        num_fused_shared_experts == 1
+        and gating_output.shape[1] == 257
+        and topk == 8
+        and renormalize
+        and correction_bias is None
+        and scoring_func == "softmax"
+    ):
+        return None
     if not _can_use_musa_jit_topk(hidden_states, gating_output, topk, correction_bias):
         return None
 
@@ -75,15 +85,16 @@ def _musa_jit_fused_topk(
     if musa_jit_topk is None:
         return None
 
+    output_topk = topk + num_fused_shared_experts
     topk_weights = torch.empty(
         gating_output.shape[0],
-        topk,
+        output_topk,
         dtype=torch.float32,
         device=gating_output.device,
     )
     topk_ids = torch.empty(
         gating_output.shape[0],
-        topk,
+        output_topk,
         dtype=torch.int32,
         device=gating_output.device,
     )
@@ -95,6 +106,7 @@ def _musa_jit_fused_topk(
             gating_output,
             renormalize,
             correction_bias=correction_bias,
+            num_fused_shared_experts=num_fused_shared_experts,
         )
     elif scoring_func == "sigmoid":
         musa_jit_topk.topk_sigmoid(

--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -100,16 +100,25 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             # to FusedMoE, so the runner never supplies a separate
             # shared_experts_input here; x is the shared expert's input, matching
             # the routed experts it now rides with.
-            assert (
-                shared_experts_input is None
-            ), "folded shared expert expects shared_experts=None"
-            shared_logits, _ = layer._musa_shared_gate(x)
-            topk_weights, topk_ids = extend_topk_with_shared(
-                topk_weights,
-                topk_ids,
-                shared_logits,
-                layer._musa_shared_expert_id,
+            assert shared_experts_input is None, (
+                "folded shared expert expects shared_experts=None"
             )
+            routed_topk = self.moe.experts_per_token
+            if topk_weights.shape[1] == routed_topk:
+                # Compatibility fallback for an upstream runner that did not
+                # combine the routed and shared gate projections.
+                shared_logits, _ = layer._musa_shared_gate(x)
+                topk_weights, topk_ids = extend_topk_with_shared(
+                    topk_weights,
+                    topk_ids,
+                    shared_logits,
+                    layer._musa_shared_expert_id,
+                )
+            else:
+                # The MUSA router already appended the shared id/weight while
+                # consuming the combined [routed, shared] gate output.
+                assert topk_weights.shape[1] == routed_topk + 1
+                assert topk_ids.shape[1] == routed_topk + 1
             global_num_experts = layer._musa_shared_expert_id + 1
         else:
             global_num_experts = layer.global_num_experts

--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -105,8 +105,7 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             )
             routed_topk = self.moe.experts_per_token
             if topk_weights.shape[1] == routed_topk:
-                # Compatibility fallback for an upstream runner that did not
-                # combine the routed and shared gate projections.
+                # Append the shared route when only routed weights are present.
                 shared_logits, _ = layer._musa_shared_gate(x)
                 topk_weights, topk_ids = extend_topk_with_shared(
                     topk_weights,
@@ -115,8 +114,7 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                     layer._musa_shared_expert_id,
                 )
             else:
-                # The MUSA router already appended the shared id/weight while
-                # consuming the combined [routed, shared] gate output.
+                # Combined gate routing includes one shared id and weight.
                 assert topk_weights.shape[1] == routed_topk + 1
                 assert topk_ids.shape[1] == routed_topk + 1
             global_num_experts = layer._musa_shared_expert_id + 1

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -3,12 +3,15 @@
 
 from __future__ import annotations
 
+import bisect
 import inspect
 from typing import Any
 
 import torch
 from mate.gdn_decode import gated_delta_rule_decode
 from mate.gdn_prefill import chunk_gated_delta_rule
+from vllm.config import CUDAGraphMode, get_current_vllm_config
+from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     QwenGatedDeltaNetAttention,
@@ -58,6 +61,42 @@ def _get_gdn_input_projection_stream(*, create: bool) -> Any | None:
     return stream
 
 
+def _allocate_gdn_output(
+    shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+    capture_sizes: tuple[int, ...],
+) -> torch.Tensor:
+    """Allocate GDN output while zeroing only possible graph padding."""
+    forward_context = get_forward_context()
+    batch_descriptor = forward_context.batch_descriptor
+    if (
+        forward_context.attn_metadata is None
+        or forward_context.cudagraph_runtime_mode == CUDAGraphMode.NONE
+        or batch_descriptor is None
+    ):
+        return torch.zeros(shape, dtype=dtype, device=device)
+
+    current_bucket = batch_descriptor.num_tokens
+    bucket_index = (
+        bisect.bisect_left(capture_sizes, current_bucket) if capture_sizes else -1
+    )
+    if (
+        bucket_index < 0
+        or bucket_index >= len(capture_sizes)
+        or capture_sizes[bucket_index] != current_bucket
+        or shape[0] != current_bucket
+    ):
+        return torch.zeros(shape, dtype=dtype, device=device)
+
+    previous_bucket = capture_sizes[bucket_index - 1] if bucket_index > 0 else 0
+    output = torch.empty(shape, dtype=dtype, device=device)
+    if current_bucket - previous_bucket > 1:
+        output[previous_bucket:current_bucket].zero_()
+    return output
+
+
 @QwenGatedDeltaNetAttention.register_oot
 class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
     """MUSA replacement for Qwen3.5 GDN attention.
@@ -75,6 +114,10 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
     ) -> None:
         super().__init__(config, vllm_config, prefix, gqa_interleaved_layout)
         self._musa_optimization_contract = resolve_optimization_contract(vllm_config)
+        compilation_config = vllm_config.compilation_config
+        self._gdn_cudagraph_capture_sizes = tuple(
+            compilation_config.cudagraph_capture_sizes or ()
+        )
 
     def _forward_input_projections(
         self,
@@ -163,10 +206,11 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
                 self.head_v_dim,
             )
 
-        core_attn_out = torch.zeros(
+        core_attn_out = _allocate_gdn_output(
             (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
+            capture_sizes=self._gdn_cudagraph_capture_sizes,
         )
 
         torch.ops.vllm.qwen_gdn_attention_core(

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import inspect
+from typing import Any
 
 import torch
 from mate.gdn_decode import gated_delta_rule_decode
@@ -19,6 +20,9 @@ from vllm_musa.optimization_contract import (
 )
 
 logger = init_logger(__name__)
+
+_GDN_DUAL_STREAM_TOKEN_THRESHOLD = 1024
+_GDN_INPUT_PROJECTION_STREAMS: dict[int, Any] = {}
 
 _MATE_GDN_PREFILL_HAS_OUTPUT = (
     "output" in inspect.signature(chunk_gated_delta_rule).parameters
@@ -38,6 +42,22 @@ def _log_once(method_name: str, message: str, *args) -> None:
     log_method(message, *args)
 
 
+def _is_current_stream_capturing() -> bool:
+    try:
+        return bool(torch.cuda.is_current_stream_capturing())
+    except (AttributeError, RuntimeError):
+        return False
+
+
+def _get_gdn_input_projection_stream(*, create: bool) -> Any | None:
+    device_index = int(torch.musa.current_device())
+    stream = _GDN_INPUT_PROJECTION_STREAMS.get(device_index)
+    if stream is None and create:
+        stream = torch.musa.Stream()
+        _GDN_INPUT_PROJECTION_STREAMS[device_index] = stream
+    return stream
+
+
 @QwenGatedDeltaNetAttention.register_oot
 class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
     """MUSA replacement for Qwen3.5 GDN attention.
@@ -55,6 +75,29 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
     ) -> None:
         super().__init__(config, vllm_config, prefix, gqa_interleaved_layout)
         self._musa_optimization_contract = resolve_optimization_contract(vllm_config)
+
+    def _forward_input_projections(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if hidden_states.size(0) < _GDN_DUAL_STREAM_TOKEN_THRESHOLD:
+            is_capturing = _is_current_stream_capturing()
+            # Decode graph warmup creates the shared stream before capture. If
+            # capture starts without warmup, keep the serial path instead of
+            # constructing a stream inside the capture region.
+            alt_stream = _get_gdn_input_projection_stream(create=not is_capturing)
+            if alt_stream is not None and is_capturing:
+                current_stream = torch.musa.current_stream(device=hidden_states.device)
+                alt_stream.wait_stream(current_stream)
+                mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+                with torch.musa.stream(alt_stream):
+                    ba, _ = self.in_proj_ba(hidden_states)
+                current_stream.wait_stream(alt_stream)
+                return mixed_qkvz, ba
+
+        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+        ba, _ = self.in_proj_ba(hidden_states)
+        return mixed_qkvz, ba
 
     def _forward_core(
         self,
@@ -98,8 +141,7 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
         )
 
         num_tokens = hidden_states.size(0)
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
+        mixed_qkvz, ba = self._forward_input_projections(hidden_states)
 
         qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
         mixed_qkv = mixed_qkvz[:, :qkv_size]

--- a/vllm_musa/patches/series/0076-MUSA-model-fold-the-Qwen3.5-shared-expert-into-fused.patch
+++ b/vllm_musa/patches/series/0076-MUSA-model-fold-the-Qwen3.5-shared-expert-into-fused.patch
@@ -96,7 +96,11 @@ index acce2a767..de163b0e6 100644
              gate=self.gate,
              num_experts=self.n_routed_experts,
              top_k=config.num_experts_per_tok,
-@@ -178,6 +231,11 @@
+@@ -175,7 +228,13 @@
+             n_shared_experts=1 if self.shared_expert is None else None,
+             shared_expert_gate=self.shared_expert_gate
+-            if self.shared_expert is None
++            if self.shared_expert is None or self._musa_shared_fold
              else None,
          )
  
@@ -104,7 +108,6 @@ index acce2a767..de163b0e6 100644
 +            routed = getattr(self.experts, "routed_experts", self.experts)
 +            routed._musa_shared_mlp = self.shared_expert
 +            routed._musa_shared_gate = self.shared_expert_gate
++            self.experts.router._musa_num_fused_shared_experts = 1
 +
      def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-         # NOTE: hidden_states can have either 1D or 2D shape.
-         orig_shape = hidden_states.shape

--- a/vllm_musa/patches/series/0099-perf-reuse-common-gdn-full-decode-metadata.patch
+++ b/vllm_musa/patches/series/0099-perf-reuse-common-gdn-full-decode-metadata.patch
@@ -1,0 +1,113 @@
+From 01ab4ea625085fda5ab5b6d0f82cbc3d0461f920 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Mon, 3 Aug 2026 06:09:42 +0000
+Subject: [PATCH] perf: reuse common GDN full decode metadata
+
+---
+ .../v1/attention/test_gdn_metadata_builder.py | 19 ++++++++
+ vllm/v1/attention/backends/gdn_attn.py        | 45 ++++++++++++-------
+ 2 files changed, 49 insertions(+), 15 deletions(-)
+
+diff --git a/tests/v1/attention/test_gdn_metadata_builder.py b/tests/v1/attention/test_gdn_metadata_builder.py
+index 221f933d8..2368cec1a 100644
+--- a/tests/v1/attention/test_gdn_metadata_builder.py
++++ b/tests/v1/attention/test_gdn_metadata_builder.py
+@@ -221,3 +221,22 @@ def test_full_cudagraph_spec_metadata_uses_request_count():
+     assert meta.spec_query_start_loc.shape == (batch.batch_size + 1,)
+     assert meta.num_accepted_tokens is not None
+     assert meta.num_accepted_tokens.shape == (batch.batch_size,)
++
++
++def test_full_cudagraph_regular_decode_reuses_common_tensors():
++    """Uniform non-spec decode can use stable model-runner buffers directly."""
++    builder = _create_gdn_builder(full_cuda_graph=True)
++    builder.vllm_config.cache_config.mamba_cache_mode = "none"
++    batch = BatchSpec(seq_lens=[40, 30, 20], query_lens=[1, 1, 1])
++    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE)
++
++    meta = builder.build(common_prefix_len=0, common_attn_metadata=common)
++
++    assert meta.non_spec_query_start_loc is not None
++    assert meta.non_spec_query_start_loc.data_ptr() == common.query_start_loc.data_ptr()
++    assert meta.non_spec_state_indices_tensor is not None
++    assert (
++        meta.non_spec_state_indices_tensor.data_ptr()
++        == common.block_table_tensor[:, 0].data_ptr()
++    )
++    assert common._num_computed_tokens_cache is None
+diff --git a/vllm/v1/attention/backends/gdn_attn.py b/vllm/v1/attention/backends/gdn_attn.py
+index 0a034c131..1dfab4fa6 100644
+--- a/vllm/v1/attention/backends/gdn_attn.py
++++ b/vllm/v1/attention/backends/gdn_attn.py
+@@ -180,7 +180,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+ 
+         query_start_loc = m.query_start_loc
+         query_start_loc_cpu = m.query_start_loc_cpu
+-        context_lens_tensor = m.compute_num_computed_tokens()
+         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
+         block_table_tensor = mamba_get_block_table_tensor(
+             m.block_table_tensor,
+@@ -395,6 +394,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                 )
+ 
+         if num_prefills > 0:
++            # Pure decode does not consume context lengths. Keep this lazy so
++            # hybrid models with multiple GDN cache groups do not enqueue the
++            # same elementwise subtraction once per group on every step.
++            context_lens_tensor = m.compute_num_computed_tokens()
+             has_initial_state = context_lens_tensor > 0
+             if spec_sequence_masks_cpu is not None:
+                 has_initial_state = has_initial_state[~spec_sequence_masks_cpu]
+@@ -475,23 +478,35 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+             and num_spec_decodes == 0
+             and num_decodes <= self.decode_cudagraph_max_bs
+         ):
+-            self.non_spec_state_indices_tensor[:num_decodes].copy_(
+-                non_spec_state_indices_tensor, non_blocking=True
++            # In mamba_cache_mode=none, the common query/block-table tensors
++            # are stable model-runner buffers. A full, uniform decode batch can
++            # therefore feed their views directly to the captured graph. The
++            # private buffers remain necessary for other cache layouts or when
++            # request padding must be materialized here.
++            reuse_common_decode_tensors = (
++                self.vllm_config.cache_config.mamba_cache_mode == "none"
++                and num_decodes == batch_size
+             )
+-            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
+-                :batch_size
+-            ]
+-            non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
++            if not reuse_common_decode_tensors:
++                self.non_spec_state_indices_tensor[:num_decodes].copy_(
++                    non_spec_state_indices_tensor, non_blocking=True
++                )
++                non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
++                    :batch_size
++                ]
++                non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
+ 
+-            self.non_spec_query_start_loc[: num_decodes + 1].copy_(
+-                non_spec_query_start_loc, non_blocking=True
+-            )
+-            non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
+-            if num_decodes < batch_size:
+-                assert non_spec_query_start_loc_cpu is not None
+-                non_spec_query_start_loc[num_decodes + 1 :].fill_(
+-                    non_spec_query_start_loc_cpu[-1].item()
++                self.non_spec_query_start_loc[: num_decodes + 1].copy_(
++                    non_spec_query_start_loc, non_blocking=True
+                 )
++                non_spec_query_start_loc = self.non_spec_query_start_loc[
++                    : batch_size + 1
++                ]
++                if num_decodes < batch_size:
++                    assert non_spec_query_start_loc_cpu is not None
++                    non_spec_query_start_loc[num_decodes + 1 :].fill_(
++                        non_spec_query_start_loc_cpu[-1].item()
++                    )
+ 
+         attn_metadata = GDNAttentionMetadata(
+             num_prefills=num_prefills,
+-- 
+2.34.1
+

--- a/vllm_musa/patches/series/0100-perf-skip-ssm-slot-mapping-in-uniform-decode.patch
+++ b/vllm_musa/patches/series/0100-perf-skip-ssm-slot-mapping-in-uniform-decode.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000100 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Mon, 3 Aug 2026 07:15:00 +0000
+Subject: [PATCH] perf: skip SSM slot mapping in uniform decode
+
+---
+ vllm/v1/worker/gpu_model_runner.py | 36 +++++++++++++++++++++++-----
+ 1 file changed, 31 insertions(+), 5 deletions(-)
+
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -530,6 +530,9 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
+         self.cross_layers_attn_backend: type[AttentionBackend] | None = None
+         # indexes: [kv_cache_group_id][attn_group]
+         self.attn_groups: list[list[AttentionGroup]] = []
++        # Cache groups whose forward path consumes token-level slot mappings.
++        # Populated together with ``attn_groups`` after backends are resolved.
++        self._slot_mapping_kv_cache_gids: tuple[int, ...] = ()
+         # self.kv_cache_config: KVCacheConfig
+ 
+         # mm_hash ->  encoder_output
+@@ -2185,11 +2188,28 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
+         )
+         self.seq_lens[num_reqs:].fill_(0)
+ 
+-        self.input_batch.block_table.compute_slot_mapping(
+-            num_reqs,
+-            self.query_start_loc.gpu[: num_reqs + 1],
+-            self.positions[:total_num_scheduled_tokens],
+-        )
++        if (
++            total_num_scheduled_tokens == num_reqs
++            and self.speculative_config is None
++            and self.cache_config.mamba_cache_mode == "none"
++            and self._slot_mapping_kv_cache_gids
++        ):
++            # SSM metadata consumes the per-group block table directly as state
++            # indices; it does not consume token-level slot mappings. Avoid one
++            # launch per SSM cache group in uniform non-spec decode while still
++            # updating every attention group that writes token KV entries.
++            for kv_cache_gid in self._slot_mapping_kv_cache_gids:
++                self.input_batch.block_table[kv_cache_gid].compute_slot_mapping(
++                    num_reqs,
++                    self.query_start_loc.gpu[: num_reqs + 1],
++                    self.positions[:total_num_scheduled_tokens],
++                )
++        else:
++            self.input_batch.block_table.compute_slot_mapping(
++                num_reqs,
++                self.query_start_loc.gpu[: num_reqs + 1],
++                self.positions[:total_num_scheduled_tokens],
++            )
+ 
+         # Copy the tensors to the GPU.
+         self._prepare_input_ids(
+@@ -6998,6 +7018,12 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
+         for i, attn_backend_map in enumerate(attention_backend_maps):
+             self.attn_groups.append(create_attn_groups(attn_backend_map, i))
+ 
++        self._slot_mapping_kv_cache_gids = tuple(
++            kv_cache_gid
++            for kv_cache_gid, attn_groups in enumerate(self.attn_groups)
++            if any(not attn_group.backend.is_ssm() for attn_group in attn_groups)
++        )
++
+     def initialize_metadata_builders(
+         self, kv_cache_config: KVCacheConfig, kernel_block_sizes: list[int]
+     ) -> None:
+-- 
+2.34.1
+

--- a/vllm_musa/patches/series/0101-perf-specialize-qwen36-bf16-w1-c25.patch
+++ b/vllm_musa/patches/series/0101-perf-specialize-qwen36-bf16-w1-c25.patch
@@ -4,10 +4,10 @@ Date: Tue, 4 Aug 2026 06:30:00 +0800
 Subject: [PATCH] perf: specialize Qwen3.6 BF16 W1 tile at C25
 
 Qwen3.6-35B-A3B's folded BF16 MoE has asymmetric projections: W1 uses
-K=2048/N=1024 while W2 uses K=512/N=2048.  A 60-case sweep using captured
-real-routing distributions showed that keeping the current N32/K64/W4 tile
-for W2 but using N64/K128/W8 for W1 improves the complete MoE path by 1.57%
-in aggregate, with 48/60 wins and no regression above 2%.
+K=2048/N=1024 while W2 uses K=512/N=2048. Use a wider N64/K128/W8 tile for
+W1 while keeping the default N32/K64/W4 tile for W2. This preserves the
+projection-specific launch geometry without changing the generic BF16 MoE
+configuration.
 
 Keep the existing M32 alignment so W1 and W2 can reuse the sorted-expert
 workspace.  Guard the specialization on the exact MUSA BF16 C25 shape and
@@ -47,11 +47,11 @@ index 73135e18d..82d70cd6d 100644
 +        and config.get("num_warps") == 4
 +        and config.get("num_stages") == 1
 +    ):
-+        # Qwen3.6's BF16 W1 projection is K=2048/N=1024, while W2 is
-+        # K=512/N=2048. Real-routing C25 sweeps show that W1 benefits from
-+        # wider K/N tiles and eight warps, but applying the same config to W2
-+        # erases the gain. Keep the shared BLOCK_SIZE_M so expert alignment is
-+        # reusable, and specialize only the first projection.
++        # Qwen3.6 BF16 uses different W1 and W2 projection shapes but shares
++        # the sorted-expert workspace. Keep the common BLOCK_SIZE_M and use
++        # wider K/N tiles and eight warps for W1. Retain the default W2
++        # configuration so this specialization applies only to the first
++        # projection.
 +        w1_config = dict(config)
 +        w1_config.update(
 +            BLOCK_SIZE_N=64,

--- a/vllm_musa/patches/series/0101-perf-specialize-qwen36-bf16-w1-c25.patch
+++ b/vllm_musa/patches/series/0101-perf-specialize-qwen36-bf16-w1-c25.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000101 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Tue, 4 Aug 2026 06:30:00 +0800
+Subject: [PATCH] perf: specialize Qwen3.6 BF16 W1 tile at C25
+
+Qwen3.6-35B-A3B's folded BF16 MoE has asymmetric projections: W1 uses
+K=2048/N=1024 while W2 uses K=512/N=2048.  A 60-case sweep using captured
+real-routing distributions showed that keeping the current N32/K64/W4 tile
+for W2 but using N64/K128/W8 for W1 improves the complete MoE path by 1.57%
+in aggregate, with 48/60 wins and no regression above 2%.
+
+Keep the existing M32 alignment so W1 and W2 can reuse the sorted-expert
+workspace.  Guard the specialization on the exact MUSA BF16 C25 shape and
+the current default config so other models, precisions, batch sizes, and
+future retuned defaults retain the upstream path.
+---
+ .../layers/fused_moe/fused_moe.py             | 39 +++++++++++++++++--
+ 1 file changed, 37 insertions(+), 2 deletions(-)
+
+diff --git a/vllm/model_executor/layers/fused_moe/fused_moe.py b/vllm/model_executor/layers/fused_moe/fused_moe.py
+index 73135e18d..82d70cd6d 100644
+--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
++++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
+@@ -1631,4 +1631,39 @@ def fused_experts_impl(
+     config = get_config_func(M)
++    w1_config = config
++    if (
++        current_platform.is_musa()
++        and hidden_states.dtype == torch.bfloat16
++        and M == 25
++        and tuple(w1.shape) == (257, 1024, 2048)
++        and tuple(w2.shape) == (257, 2048, 512)
++        and top_k_num == 9
++        and global_num_experts == 257
++        and expert_map is None
++        and block_shape is None
++        and not (
++            use_fp8_w8a8
++            or use_int8_w8a8
++            or use_int8_w8a16
++            or use_int4_w4a16
++        )
++        and config.get("BLOCK_SIZE_M") == 32
++        and config.get("BLOCK_SIZE_N") == 32
++        and config.get("BLOCK_SIZE_K") == 64
++        and config.get("GROUP_SIZE_M") == 1
++        and config.get("num_warps") == 4
++        and config.get("num_stages") == 1
++    ):
++        # Qwen3.6's BF16 W1 projection is K=2048/N=1024, while W2 is
++        # K=512/N=2048. Real-routing C25 sweeps show that W1 benefits from
++        # wider K/N tiles and eight warps, but applying the same config to W2
++        # erases the gain. Keep the shared BLOCK_SIZE_M so expert alignment is
++        # reusable, and specialize only the first projection.
++        w1_config = dict(config)
++        w1_config.update(
++            BLOCK_SIZE_N=64,
++            BLOCK_SIZE_K=128,
++            num_warps=8,
++        )
+-
++
+     # We can reuse the memory between these because by the time we need
+     # cache3, we're done with cache1
+@@ -1672,6 +1707,6 @@ def fused_experts_impl(
+     sorted_token_ids, expert_ids, num_tokens_post_padded = _prepare_expert_assignment(
+         topk_ids,
+-        config,
++        w1_config,
+         num_tokens,
+         top_k_num,
+         global_num_experts,
+@@ -1695,7 +1730,7 @@ def fused_experts_impl(
+         num_tokens_post_padded,
+         apply_router_weight_on_input,
+         top_k_num,
+-        config,
++        w1_config,
+         compute_type=compute_type,
+         use_fp8_w8a8=use_fp8_w8a8,
+         use_int8_w8a8=use_int8_w8a8,

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,8 +17,9 @@ is pre-patched.
   the highest prefix. Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **104 patches**. The final patch binds DeepSeek-V4 shared-MLP and
-sparse-indexer policy to the MUSA optimization contract. The series contains
+Currently **107 patches**. This branch adds Qwen3.6 patches for common GDN
+decode metadata reuse, uniform-decode SSM slot-mapping removal, and the BF16 W1
+tile specialization on top of the upstream 104-patch series. The series contains
 MUSA source edits against the immutable vLLM commit recorded as `VLLM_COMMIT`
 in `third_party/PINS` (release label `v0.24.0`), applied at build. Runtime
 object/registration patches (which patch live objects at import) are kept


### PR DESCRIPTION
# Summary

This branch is rebased onto `upstream/v0.24.0-dev@0c91f7ff` and contains the
following seven commits.  The runtime path has no experiment environment gates.

| Commit | Optimization | Evidence / measured effect |
|---|---|---|
| `6c4cba95` | Fuse Qwen routed/shared gate projection and routing | Same-node diagnostic A/B: 684.90 -> 709.84 output tok/s (+3.64%), 31.87 -> 30.62 ms mean TPOT (-1.26 ms). |
| `88eea5b8` | Run the two GDN decode input projections on dual streams | Production microbench: 174.22 -> 159.16 us for the projection pair (-8.64%); standalone E2E gain is not claimed. |
| `fa011f05` | Do not clear the GDN decode output buffer when the following kernel overwrites it | Removes a redundant decode memset/allocation step; the small standalone E2E delta is below serving noise. |
| `f20b019c` | Reuse common full-decode GDN metadata | Five-step profile: `aten::sub` 30 calls removed; `aten::copy_` 178 -> 148 and `_copy_from` 149 -> 119. |
| `4aae92ec` | Skip SSM slot mapping for uniform non-spec decode | Five-step profile: slot-mapping launches 20 -> 5 and device time 316.48 -> 93.08 us. |
| `cabde760` | Specialize the Qwen3.6 BF16 C25 W1 tile (`M32/N64/K128/W8`) | Three-run E2E A/B: 720.55 -> 736.19 output tok/s (+2.17%), 30.108 -> 29.548 ms mean TPOT (-0.561 ms). |
| `8628ad9c` | Clean patch metadata and manifest bookkeeping | No runtime code-path change; keeps the patch series and source-contract tests consistent. |

The page64 hybrid-cache and independent Mamba BlockPool changes are already in
the rebased upstream base, not duplicated in this PR.  Their retained capacity
data are: per-layer Mamba state slots `217 -> 65` (3.34x smaller) and reported
attention KV capacity `134,582 -> 2,236,416` tokens (16.62x higher).  The Mamba
groups still use independent address spaces, which preserves the large-batch
precision fix for the former page/block-ID overlap.

## Current result (post-rebase)

### Five consecutive runs

| Run | Completed/failed | Output tok/s | Mean TTFT | Mean TPOT | Note |
|---|---:|---:|---:|---:|---|
| R1 | 85 / 0 | 725.70 | 1,774.11 ms | 29.40 ms | First measured round; cold-state TTFT outlier |
| R2 | 85 / 0 | 730.51 | 705.39 ms | 29.92 ms | steady |
| R3 | 85 / 0 | 734.92 | 704.78 ms | 29.75 ms | steady |
| R4 | 85 / 0 | 739.54 | 709.87 ms | 29.52 ms | steady |
| R5 | 85 / 0 | **736.50** | **704.32 ms** | **29.59 ms** | Current result |
| R2--R5 mean | 340 / 0 | 735.37 | 706.09 ms | 29.70 ms | Stability reference, not Current result |

The earlier same-SHA three-run reference was 738.23 tok/s, 717.30 ms TTFT,
and 29.529 ms TPOT.  R5 differs by -0.23% throughput, -12.98 ms TTFT, and
+0.061 ms TPOT; this is within the observed non-isolated run variation and is
not evidence of a material rebase regression.

## vLLM server command

```bash

vllm serve /home/dist/models/Qwen3.6-35B-A3B/ \
  -tp 1 \
  --port 8356 \
  --served-model-name Qwen3.6-35B-A3B \
  --max-num-seqs 64 \
  --max-num-batched-tokens 11264 \
  -cc.cudagraph_mode=FULL_DECODE_ONLY \
  --cudagraph-capture-sizes \
    1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 \
    17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 \
    33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 \
    49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 \
  --no-enable-chunked-prefill \
  --no-enable-prefix-caching \
  -ac.backend FLASH_ATTN \
  --trust-remote-code \
  --max-model-len 4096 \
  --mamba-ssm-cache-dtype float32 \
  --gpu-memory-utilization 0.95 \
  -cc.mode=NONE
```

## vLLM benchmark command

```bash
vllm bench serve \
  --backend openai \
  --base-url http://127.0.0.1:8356 \
  --endpoint /v1/completions \
  --model /home/dist/models/Qwen3.6-35B-A3B/ \
  --served-model-name Qwen3.6-35B-A3B \
  --dataset-name random \
  --random-input-len 2500 \
  --random-output-len 1500 \
  --random-range-ratio 0.0 \
  --num-prompts 85 \
  --request-rate 17 \
  --max-concurrency 25 \
  --num-warmups 25 \
  --temperature 0 \
  --ignore-eos \
  --seed 0 \
  --disable-tqdm \
  --save-result \
  --save-detailed \
  --result-dir /tmp/musa3511-pr-final-20260806/r5 \
  --result-filename qwen36-c25-r5.json
```

The five-run script invoked this exact benchmark command with only
`--result-dir`, `--result-filename`, and the round number changed between
rounds.
