### PR TITLE
[MUSA-60092] Fix DeepSeek-V4 MTP multibatch sparse-prefill OOM

### DIFF
--- a/csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu
+++ b/csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu
@@ -159,6 +159,61 @@ __global__ void deepseek_v4_inv_rope_fp8_quant_kernel(
   }
 }
 
+// The FP32-scale path has no cross-chunk packing dependency. Give each
+// 128-element quantization chunk its own block so the four chunks in a
+// DeepSeek-V4 head can execute concurrently. Only real tokens are launched;
+// token 0 also clears the at-most-three scale-padding slots required by the
+// downstream aligned layout.
+__global__ void deepseek_v4_inv_rope_fp8_quant_chunk_kernel(
+    const __mt_bfloat16* __restrict__ o, int64_t o_stride_token,
+    int64_t o_stride_head, const void* __restrict__ positions,
+    int position_kind, const float* __restrict__ cos_sin_cache,
+    int64_t cache_stride_pos, uint8_t* __restrict__ fp8_out,
+    int64_t fp8_stride_group, int64_t fp8_stride_token,
+    float* __restrict__ scale, int64_t scale_stride_group,
+    int64_t scale_stride_k, int64_t num_tokens, int64_t aligned_tokens,
+    int64_t heads_per_group) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x);
+  const int64_t global_head = static_cast<int64_t>(blockIdx.y);
+  const int64_t chunk = static_cast<int64_t>(blockIdx.z);
+  const int tid = threadIdx.x;
+
+  const int64_t group = global_head / heads_per_group;
+  const int64_t head_in_group = global_head - group * heads_per_group;
+  const int64_t out_chunk = head_in_group * kChunksPerHead + chunk;
+  const int64_t dim = chunk * kQuantGroupSize + tid;
+
+  const int64_t pos = load_index(positions, position_kind, token);
+  const float* cos_ptr = cos_sin_cache + pos * cache_stride_pos;
+  const float* sin_ptr = cos_ptr + kRopeDim / 2;
+  const __mt_bfloat16* input =
+      o + token * o_stride_token + global_head * o_stride_head;
+  uint8_t* output = fp8_out + group * fp8_stride_group +
+                    token * fp8_stride_token + head_in_group * kHeadDim;
+
+  const float value = load_rotated_or_raw(input, dim, cos_ptr, sin_ptr);
+  __shared__ float reduce[kThreads];
+  const float absmax = reduce_max_128(reduce, tid, fabsf(value));
+  const float scale_raw = fmaxf(absmax / kFp8Max, kScaleEps);
+  const float scale_pow2 = exp2f(ceilf(log2f(scale_raw)));
+
+  if (tid == 0) {
+    scale[group * scale_stride_group + token + out_chunk * scale_stride_k] =
+        scale_pow2;
+  }
+
+  float q = value / scale_pow2;
+  q = fminf(fmaxf(q, kFp8Min), kFp8Max);
+  const __mt_fp8_e4m3 packed(q);
+  output[dim] = packed.__x;
+
+  const int64_t padding = aligned_tokens - num_tokens;
+  if (token == 0 && tid < padding) {
+    scale[group * scale_stride_group + num_tokens + tid +
+          out_chunk * scale_stride_k] = 0.0f;
+  }
+}
+
 int index_kind(const torch::Tensor& tensor, const char* name) {
   if (tensor.scalar_type() == torch::kInt32) {
     return kIndexInt32;
@@ -263,15 +318,17 @@ std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_inv_rope_fp8_quant(
             scale_buf.stride(0), scale_buf.stride(2), num_tokens,
             heads_per_group);
   } else {
-    deepseek_v4_inv_rope_fp8_quant_kernel<false>
-        <<<grid, block, 0, stream>>>(
-            static_cast<const __mt_bfloat16*>(o.data_ptr()), o.stride(0),
-            o.stride(1), positions.data_ptr(), index_kind(positions, "positions"),
-            static_cast<const float*>(cos_sin_cache.data_ptr()),
-            cos_sin_cache.stride(0), static_cast<uint8_t*>(fp8_buf.data_ptr()),
-            fp8_buf.stride(0), fp8_buf.stride(1), scale_buf.data_ptr(),
-            scale_buf.stride(0), scale_buf.stride(2), num_tokens,
-            heads_per_group);
+    const dim3 chunk_grid(static_cast<unsigned int>(num_tokens),
+                          static_cast<unsigned int>(num_heads),
+                          static_cast<unsigned int>(kChunksPerHead));
+    deepseek_v4_inv_rope_fp8_quant_chunk_kernel<<<chunk_grid, block, 0, stream>>>(
+        static_cast<const __mt_bfloat16*>(o.data_ptr()), o.stride(0),
+        o.stride(1), positions.data_ptr(), index_kind(positions, "positions"),
+        static_cast<const float*>(cos_sin_cache.data_ptr()),
+        cos_sin_cache.stride(0), static_cast<uint8_t*>(fp8_buf.data_ptr()),
+        fp8_buf.stride(0), fp8_buf.stride(1),
+        static_cast<float*>(scale_buf.data_ptr()), scale_buf.stride(0),
+        scale_buf.stride(2), num_tokens, aligned_tokens, heads_per_group);
   }
 
   const auto err = musaGetLastError();

--- a/csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu
+++ b/csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu
@@ -171,8 +171,8 @@ __global__ void deepseek_v4_inv_rope_fp8_quant_chunk_kernel(
     int64_t cache_stride_pos, uint8_t* __restrict__ fp8_out,
     int64_t fp8_stride_group, int64_t fp8_stride_token,
     float* __restrict__ scale, int64_t scale_stride_group,
-    int64_t scale_stride_k, int64_t num_tokens, int64_t aligned_tokens,
-    int64_t heads_per_group) {
+    int64_t scale_stride_token, int64_t scale_stride_k, int64_t num_tokens,
+    int64_t aligned_tokens, int64_t heads_per_group) {
   const int64_t token = static_cast<int64_t>(blockIdx.x);
   const int64_t global_head = static_cast<int64_t>(blockIdx.y);
   const int64_t chunk = static_cast<int64_t>(blockIdx.z);
@@ -198,8 +198,8 @@ __global__ void deepseek_v4_inv_rope_fp8_quant_chunk_kernel(
   const float scale_pow2 = exp2f(ceilf(log2f(scale_raw)));
 
   if (tid == 0) {
-    scale[group * scale_stride_group + token + out_chunk * scale_stride_k] =
-        scale_pow2;
+    scale[group * scale_stride_group + token * scale_stride_token +
+          out_chunk * scale_stride_k] = scale_pow2;
   }
 
   float q = value / scale_pow2;
@@ -209,7 +209,8 @@ __global__ void deepseek_v4_inv_rope_fp8_quant_chunk_kernel(
 
   const int64_t padding = aligned_tokens - num_tokens;
   if (token == 0 && tid < padding) {
-    scale[group * scale_stride_group + num_tokens + tid +
+    scale[group * scale_stride_group +
+          (num_tokens + tid) * scale_stride_token +
           out_chunk * scale_stride_k] = 0.0f;
   }
 }
@@ -291,10 +292,14 @@ std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_inv_rope_fp8_quant(
   } else {
     scale_storage = torch::empty({n_groups * num_scale_blocks * aligned_tokens},
                                  o.options().dtype(torch::kFloat32));
+    // Keep each group-local [token, block] scale matrix contiguous.  The
+    // downstream DeepSeek-V4 o-proj consumes one group at a time, so this
+    // layout preserves the public [token, group, block] view while avoiding a
+    // device copy for every layer and decode step.
     scale_buf =
         scale_storage.as_strided({n_groups, num_tokens, num_scale_blocks},
-                                 {num_scale_blocks * aligned_tokens, 1,
-                                  aligned_tokens});
+                                 {num_scale_blocks * aligned_tokens,
+                                  num_scale_blocks, 1});
   }
 
   if (num_tokens == 0 || num_heads == 0) {
@@ -328,7 +333,8 @@ std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_inv_rope_fp8_quant(
         cos_sin_cache.stride(0), static_cast<uint8_t*>(fp8_buf.data_ptr()),
         fp8_buf.stride(0), fp8_buf.stride(1),
         static_cast<float*>(scale_buf.data_ptr()), scale_buf.stride(0),
-        scale_buf.stride(2), num_tokens, aligned_tokens, heads_per_group);
+        scale_buf.stride(1), scale_buf.stride(2), num_tokens, aligned_tokens,
+        heads_per_group);
   }
 
   const auto err = musaGetLastError();

--- a/csrc/musa/gemv.mu
+++ b/csrc/musa/gemv.mu
@@ -616,6 +616,51 @@ bool ShouldUseDeepSeekV4Fp8MoeSplitTile(
            IsForcedBlockConfigValid(config, nr_n, hidden_size, vlen);
 }
 
+bool SelectDeepSeekV4Fp8OProjTile(
+    int current_arch,
+    bool is_fp8,
+    bool use_swigelu,
+    bool use_rms_norm,
+    bool use_int4_w4a16,
+    int reduce_size,
+    int hidden_size,
+    int nr_n,
+    int scale_k_group_tile,
+    int vlen,
+    int bseqlen,
+    BlockConfig* config) {
+    if (current_arch < 300 || !is_fp8 || use_swigelu || use_rms_norm ||
+        use_int4_w4a16 || reduce_size != 1024 || hidden_size != 4096 ||
+        nr_n != 1024 || scale_k_group_tile != 128) {
+        return false;
+    }
+
+    // DeepSeek-V4 TP8 O-proj is [M,4096] x [1024,4096]^T.  The platform's
+    // VLLM_MUSA_GEMV_MOE_BLOCK=16x8 default belongs to routed MoE, but the
+    // non-MoE GEMV historically consumed it too.  Cold-L2 calibration on an
+    // S5000 mp60 shows that the production graph-capture ladder needs more N
+    // tiles at small M and different K reductions as M grows.  Match only the
+    // exact O-proj contract; unsupported/eager sizes retain the generic path.
+    switch (bseqlen) {
+        case 1:
+        case 2:
+        case 8:
+            *config = BlockConfig{4, 32, 0.f, true};
+            break;
+        case 4:
+        case 32:
+        case 64:
+            *config = BlockConfig{8, 16, 0.f, true};
+            break;
+        case 16:
+            *config = BlockConfig{32, 4, 0.f, true};
+            break;
+        default:
+            return false;
+    }
+    return IsForcedBlockConfigValid(*config, nr_n, hidden_size, vlen);
+}
+
 void musa_fused_gemv(
     torch::Tensor &A,
     torch::Tensor &B,
@@ -730,18 +775,35 @@ void musa_fused_gemv(
         fallback_config = BlockConfig{128, 1, -1.0f, false};
     }
     BlockConfig forced_config{0, 0, 0.f, false};
+    BlockConfig deepseek_v4_o_proj_config{0, 0, 0.f, false};
     BlockConfig* best_config = &fallback_config;
-    if (ParseForcedBlockConfig(&forced_config)) {
-        TORCH_CHECK(
-            IsForcedBlockConfigValid(forced_config, nr_n, hidden_size, vlen),
-            kGemvMoeBlockEnv, "=", forced_config.block_n, "x",
-            forced_config.block_k, " is invalid for nr_n=", nr_n,
-            ", hidden_size=", hidden_size, ", vlen=", vlen);
-        best_config = &forced_config;
+    if (SelectDeepSeekV4Fp8OProjTile(
+            current_arch,
+            is_fp8,
+            use_swigelu,
+            use_rms_norm,
+            use_int4_w4a16,
+            reduce_size,
+            hidden_size,
+            nr_n,
+            scale_k_group_tile,
+            vlen,
+            bseqlen,
+            &deepseek_v4_o_proj_config)) {
+        best_config = &deepseek_v4_o_proj_config;
     } else {
-        for (auto& config : configs) {
-            if (config.valid && config.score > best_config->score) {
-                best_config = &config;
+        if (ParseForcedBlockConfig(&forced_config)) {
+            TORCH_CHECK(
+                IsForcedBlockConfigValid(forced_config, nr_n, hidden_size, vlen),
+                kGemvMoeBlockEnv, "=", forced_config.block_n, "x",
+                forced_config.block_k, " is invalid for nr_n=", nr_n,
+                ", hidden_size=", hidden_size, ", vlen=", vlen);
+            best_config = &forced_config;
+        } else {
+            for (auto& config : configs) {
+                if (config.valid && config.score > best_config->score) {
+                    best_config = &config;
+                }
             }
         }
     }

--- a/csrc/musa/gemv.mu
+++ b/csrc/musa/gemv.mu
@@ -661,6 +661,32 @@ bool SelectDeepSeekV4Fp8OProjTile(
     return IsForcedBlockConfigValid(*config, nr_n, hidden_size, vlen);
 }
 
+bool SelectDeepSeekV4Fp8SharedGateUpTile(
+    int current_arch,
+    bool is_fp8,
+    bool use_swigelu,
+    bool use_rms_norm,
+    bool use_int4_w4a16,
+    int reduce_size,
+    int hidden_size,
+    int nr_n,
+    int scale_k_group_tile,
+    int vlen,
+    int bseqlen,
+    BlockConfig* config) {
+    if (current_arch < 300 || !is_fp8 || use_swigelu || use_rms_norm ||
+        use_int4_w4a16 || reduce_size != 512 || hidden_size != 4096 ||
+        nr_n != 512 || scale_k_group_tile != 128 || bseqlen != 1) {
+        return false;
+    }
+
+    // Python dispatch already limits this exact contract to the DeepSeek-V4
+    // TP8 shared-expert gate-up layer.  Select the cold-L2 winner here before
+    // the routed-MoE 16x8 environment default can leak into the dense GEMV.
+    *config = BlockConfig{4, 32, 0.f, true};
+    return IsForcedBlockConfigValid(*config, nr_n, hidden_size, vlen);
+}
+
 void musa_fused_gemv(
     torch::Tensor &A,
     torch::Tensor &B,
@@ -775,7 +801,7 @@ void musa_fused_gemv(
         fallback_config = BlockConfig{128, 1, -1.0f, false};
     }
     BlockConfig forced_config{0, 0, 0.f, false};
-    BlockConfig deepseek_v4_o_proj_config{0, 0, 0.f, false};
+    BlockConfig deepseek_v4_linear_config{0, 0, 0.f, false};
     BlockConfig* best_config = &fallback_config;
     if (SelectDeepSeekV4Fp8OProjTile(
             current_arch,
@@ -789,8 +815,21 @@ void musa_fused_gemv(
             scale_k_group_tile,
             vlen,
             bseqlen,
-            &deepseek_v4_o_proj_config)) {
-        best_config = &deepseek_v4_o_proj_config;
+            &deepseek_v4_linear_config) ||
+        SelectDeepSeekV4Fp8SharedGateUpTile(
+            current_arch,
+            is_fp8,
+            use_swigelu,
+            use_rms_norm,
+            use_int4_w4a16,
+            reduce_size,
+            hidden_size,
+            nr_n,
+            scale_k_group_tile,
+            vlen,
+            bseqlen,
+            &deepseek_v4_linear_config)) {
+        best_config = &deepseek_v4_linear_config;
     } else {
         if (ParseForcedBlockConfig(&forced_config)) {
             TORCH_CHECK(

--- a/tests/test_deepseek_v4_contract_source.py
+++ b/tests/test_deepseek_v4_contract_source.py
@@ -18,7 +18,7 @@ def test_platform_uses_contract_without_model_derived_kernel_envs() -> None:
     assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in source
 
 
-def test_shared_mlp_and_rmsnorm_bind_instance_contracts() -> None:
+def test_shared_mlp_owner_guards_and_rmsnorm_instance_contract() -> None:
     linear = _source("vllm_musa/model_executor/layers/linear.py")
     layernorm = _source("vllm_musa/model_executor/layers/layernorm.py")
     model_patch = _source(
@@ -26,8 +26,14 @@ def test_shared_mlp_and_rmsnorm_bind_instance_contracts() -> None:
         "0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch"
     )
 
-    assert "DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8" in linear
-    assert "prefers_optimization(" in linear
+    assert "def forward_swiglu_clamp(" in linear
+    assert "This hook is only called by DeepSeek-V4's MLP" in linear
+    assert "not envs.VLLM_BATCH_INVARIANT" in linear
+    assert "_deepgemm_block_fp8(self.quant_method)" in linear
+    assert (
+        'tuple(getattr(self, "weight_block_size", None) or ()) == (128, 128)' in linear
+    )
+    assert "swiglu_limit == 10.0" in linear
     assert "bind_optimization_contract(self.down_proj" in model_patch
     assert "bind_optimization_contract(self" in layernorm
     assert "DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256" in layernorm
@@ -45,6 +51,20 @@ def test_sparse_indexer_contract_keeps_glm_entry_shape_local() -> None:
     assert "use_musa_materialized_prefill" in patch
     assert "q_quant.shape[1] == 32" in patch
     assert "and self.use_musa_native_indexer" in patch
+
+
+def test_mtp_sparse_prefill_fixes_are_bound_at_the_dsv4_owner() -> None:
+    patch = _source(
+        "vllm_musa/patches/series/"
+        "0102-MUSA-preserve-DeepSeek-V4-MTP-sparse-prefill-headroom.patch"
+    )
+
+    assert "DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT" in patch
+    assert "allow_dsv4_tp8_mtp_direct_out=" in patch
+    assert 'attention_backend_hint="flashmla"' in patch
+    assert "deepseek_v4_mtp_sparse_prefill_headroom_bytes" in patch
+    assert "musa_workspace_headroom_bytes" in patch
+    assert "if current_platform.is_musa():" in patch
 
 
 def test_fused_add_rmsnorm_argument_is_graph_static_and_env_override_wins() -> None:

--- a/tests/test_deepseek_v4_o_proj_dispatch.py
+++ b/tests/test_deepseek_v4_o_proj_dispatch.py
@@ -10,6 +10,7 @@ MODULE_PATH = (
     / "deepseek_v4_jit"
     / "fp8_einsum.py"
 )
+GEMV_PATH = Path(__file__).resolve().parents[1] / "csrc" / "musa" / "gemv.mu"
 
 
 def _module_tree() -> ast.Module:
@@ -61,3 +62,34 @@ def test_o_proj_dispatch_keeps_small_m_gemv_fallback() -> None:
     assert source.index("fp8_gemm_nt(") < source.index("musa_ops.musa_fused_gemv(")
     assert "tokens >= _DEEPGEMM_MIN_TOKENS" in source
     assert "is_deep_gemm_e8m0_used=False" in source
+
+
+def test_o_proj_gemv_uses_calibrated_capture_ladder_tiles() -> None:
+    source = GEMV_PATH.read_text(encoding="utf-8")
+    helper = source[
+        source.index("bool SelectDeepSeekV4Fp8OProjTile(") : source.index(
+            "void musa_fused_gemv("
+        )
+    ]
+    generic = source[
+        source.index("void musa_fused_gemv(") : source.index(
+            "void musa_fused_gemv_moe("
+        )
+    ]
+
+    assert "reduce_size != 1024" in helper
+    assert "hidden_size != 4096" in helper
+    assert "nr_n != 1024" in helper
+    assert "scale_k_group_tile != 128" in helper
+    assert "case 1:" in helper and "case 2:" in helper and "case 8:" in helper
+    assert "BlockConfig{4, 32" in helper
+    assert "case 4:" in helper and "case 32:" in helper and "case 64:" in helper
+    assert "BlockConfig{8, 16" in helper
+    assert "case 16:" in helper and "BlockConfig{32, 4" in helper
+
+    dispatch = generic[
+        generic.index("BlockConfig forced_config") : generic.index("switch (")
+    ]
+    assert dispatch.index("SelectDeepSeekV4Fp8OProjTile(") < dispatch.index(
+        "ParseForcedBlockConfig(&forced_config)"
+    )

--- a/tests/test_deepseek_v4_o_proj_dispatch.py
+++ b/tests/test_deepseek_v4_o_proj_dispatch.py
@@ -11,6 +11,9 @@ MODULE_PATH = (
     / "fp8_einsum.py"
 )
 GEMV_PATH = Path(__file__).resolve().parents[1] / "csrc" / "musa" / "gemv.mu"
+CUSTOM_OPS_PATH = (
+    Path(__file__).resolve().parents[1] / "vllm_musa" / "_custom_ops.py"
+)
 
 
 def _module_tree() -> ast.Module:
@@ -93,3 +96,51 @@ def test_o_proj_gemv_uses_calibrated_capture_ladder_tiles() -> None:
     assert dispatch.index("SelectDeepSeekV4Fp8OProjTile(") < dispatch.index(
         "ParseForcedBlockConfig(&forced_config)"
     )
+
+
+def test_o_proj_gemv_writes_one_group_result_directly() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = _module_tree()
+    dispatcher = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "try_musa_deepseek_v4_fp8_einsum_gemv"
+    )
+    gemv_call = next(
+        node
+        for node in ast.walk(dispatcher)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "musa_fused_gemv"
+    )
+    output_keyword = next(
+        keyword for keyword in gemv_call.keywords if keyword.arg == "output"
+    )
+
+    assert isinstance(output_keyword.value, ast.Name)
+    assert output_keyword.value.id == "direct_group_out"
+    assert "group_out_view if group_out_view.is_contiguous() else None" in source
+    assert "if direct_group_out is None:" in source
+    assert "group_out_view.copy_(group_out)" in source
+
+
+def test_musa_fused_gemv_accepts_caller_owned_fp8_output() -> None:
+    tree = ast.parse(CUSTOM_OPS_PATH.read_text(encoding="utf-8"))
+    wrapper = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "musa_fused_gemv"
+    )
+    output_arg = next(arg for arg in wrapper.args.args if arg.arg == "output")
+    assert output_arg.arg == "output"
+
+    native_call = next(
+        node
+        for node in ast.walk(wrapper)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "musa_fused_gemv"
+    )
+    assert isinstance(native_call.args[2], ast.Name)
+    assert native_call.args[2].id == "output"

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -12,12 +12,26 @@ from vllm_musa.optimization_contract import (
     bind_optimization_contract,
     resolve_optimization_contract,
 )
+from vllm_musa.optimization_contract.policy import (
+    deepseek_v4_mtp_sparse_prefill_headroom_bytes,
+)
 
 
-def _flash_base_config(*, tp: int = 8, speculative: bool = False):
+def _flash_base_config(
+    *,
+    tp: int = 8,
+    speculative: bool = False,
+    speculative_method: str = "mtp",
+    max_num_seqs: int = 1,
+    max_num_batched_tokens: int = 8195,
+    mtp_draft: bool = False,
+    cache_dtype: str = "fp8",
+):
+    architectures = ["DeepSeekV4MTPModel" if mtp_draft else "DeepseekV4ForCausalLM"]
+    model_type = "deepseek_mtp" if mtp_draft else "deepseek_v4"
     text_config = SimpleNamespace(
-        architectures=["DeepseekV4ForCausalLM"],
-        model_type="deepseek_v4",
+        architectures=architectures,
+        model_type=model_type,
         hidden_size=4096,
         num_hidden_layers=43,
         num_attention_heads=64,
@@ -38,7 +52,8 @@ def _flash_base_config(*, tp: int = 8, speculative: bool = False):
         },
     )
     model_config = SimpleNamespace(
-        architectures=["DeepseekV4ForCausalLM"],
+        architectures=architectures,
+        model_type=model_type,
         hf_text_config=text_config,
         hf_config=text_config,
         dtype="bfloat16",
@@ -56,14 +71,19 @@ def _flash_base_config(*, tp: int = 8, speculative: bool = False):
             data_parallel_size=1,
             decode_context_parallel_size=1,
         ),
-        cache_config=SimpleNamespace(cache_dtype="fp8", block_size=64),
-        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        cache_config=SimpleNamespace(cache_dtype=cache_dtype, block_size=64),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=max_num_seqs,
+            max_num_batched_tokens=max_num_batched_tokens,
+        ),
         attention_config=SimpleNamespace(backend="FLASHMLA"),
         compilation_config=SimpleNamespace(
             mode="NONE",
             cudagraph_mode="FULL_DECODE_ONLY",
         ),
-        speculative_config=object() if speculative else None,
+        speculative_config=(
+            SimpleNamespace(method=speculative_method) if speculative else None
+        ),
         quant_config=SimpleNamespace(weight_block_size=[128, 128]),
     )
 
@@ -154,25 +174,19 @@ def test_incomplete_deepseek_identity_fails_closed() -> None:
             "model_config",
             "dtype",
             "float16",
-            frozenset(
-                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
-            ),
+            frozenset({OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}),
         ),
         (
             "model_config",
             "quantization",
             "compressed-tensors",
-            frozenset(
-                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
-            ),
+            frozenset({OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}),
         ),
         (
             "model_config",
             "use_mla",
             False,
-            frozenset(
-                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
-            ),
+            frozenset({OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}),
         ),
     ],
 )
@@ -285,6 +299,100 @@ def test_speculative_execution_keeps_support_but_disables_tp8_preferences() -> N
     )
 
 
+def test_tp8_mtp_target_prefers_sparse_prefill_fixes() -> None:
+    config = _flash_base_config(
+        speculative=True,
+        max_num_seqs=64,
+        cache_dtype="fp8_ds_mla",
+    )
+    contract = resolve_optimization_contract(config)
+
+    assert contract.profile == "deepseek_v4.tp8_flash_base_mtp"
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT)
+    assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM
+    )
+    assert deepseek_v4_mtp_sparse_prefill_headroom_bytes(config) == 537_067_520
+
+
+def test_flashmla_owner_hint_only_fills_a_missing_backend() -> None:
+    config = _flash_base_config(
+        speculative=True,
+        max_num_seqs=64,
+        cache_dtype="fp8_ds_mla",
+    )
+    config.attention_config.backend = None
+
+    unhinted = resolve_optimization_contract(config)
+    hinted = resolve_optimization_contract(
+        config,
+        attention_backend_hint="flashmla",
+    )
+
+    assert not unhinted.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT
+    )
+    assert hinted.prefers(OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT)
+
+    config.attention_config.backend = "FLASH_ATTN"
+    conflicting = resolve_optimization_contract(
+        config,
+        attention_backend_hint="flashmla",
+    )
+    assert conflicting.execution.attention_backend == "flash_attn"
+    assert not conflicting.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT
+    )
+
+
+def test_tp8_mtp_draft_prefers_sparse_prefill_fixes() -> None:
+    config = _flash_base_config(
+        max_num_seqs=64,
+        mtp_draft=True,
+        cache_dtype="fp8_ds_mla",
+    )
+    contract = resolve_optimization_contract(config)
+
+    assert contract.model.role is ModelRole.MTP_DRAFT
+    assert contract.profile == "deepseek_v4.tp8_flash_mtp_draft"
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT)
+    assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM
+    )
+
+
+@pytest.mark.parametrize(
+    ("owner", "field", "value"),
+    [
+        ("parallel_config", "tensor_parallel_size", 4),
+        ("scheduler_config", "max_num_seqs", 1),
+        ("cache_config", "cache_dtype", "auto"),
+        ("attention_config", "backend", "FLASH_ATTN"),
+        ("compilation_config", "mode", "VLLM_COMPILE"),
+        ("compilation_config", "cudagraph_mode", "PIECEWISE"),
+    ],
+)
+def test_tp8_mtp_sparse_prefill_fixes_fail_closed(
+    owner: str,
+    field: str,
+    value: object,
+) -> None:
+    config = _flash_base_config(
+        max_num_seqs=64,
+        mtp_draft=True,
+    )
+    setattr(getattr(config, owner), field, value)
+
+    contract = resolve_optimization_contract(config)
+
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM
+    )
+
+
 @pytest.mark.parametrize(
     ("owner", "field", "value"),
     [
@@ -309,7 +417,9 @@ def test_one_field_execution_mismatch_keeps_only_shared_mlp(
     if owner == "scheduler_config":
         assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     else:
-        assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+        assert not contract.prefers(
+            OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8
+        )
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
     )

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -106,6 +106,22 @@ def test_flash_base_tp4_is_supported_but_not_tp8_preferred() -> None:
     assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
 
 
+def test_flash_base_multibatch_keeps_shared_mlp_path() -> None:
+    config = _flash_base_config()
+    config.scheduler_config.max_num_seqs = 64
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.profile == "deepseek_v4.unvalidated"
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+
+
 def test_model_config_without_execution_topology_is_support_only() -> None:
     config = _flash_base_config()
 
@@ -279,7 +295,7 @@ def test_speculative_execution_keeps_support_but_disables_tp8_preferences() -> N
         ("compilation_config", "cudagraph_mode", "PIECEWISE"),
     ],
 )
-def test_one_field_execution_mismatch_disables_tp8_profile(
+def test_one_field_execution_mismatch_keeps_only_shared_mlp(
     owner: str,
     field: str,
     value: object,
@@ -290,7 +306,10 @@ def test_one_field_execution_mismatch_disables_tp8_profile(
     contract = resolve_optimization_contract(config)
 
     assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
-    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    if owner == "scheduler_config":
+        assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    else:
+        assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
     )
@@ -331,6 +350,7 @@ def test_pooling_and_missing_quant_runtime_disable_tp8_profile() -> None:
     contract = resolve_optimization_contract(config, is_pooling_model=True)
 
     assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
     )

--- a/tests/test_deepseek_v4_shared_gate_gemv_source.py
+++ b/tests/test_deepseek_v4_shared_gate_gemv_source.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_shared_gate_gemv_is_layer_scoped() -> None:
+    source = (
+        ROOT
+        / "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+    ).read_text()
+    assert '".shared_experts.gate_up_proj"' in source
+    assert 'getattr(layer, "tp_size", None) == 8' in source
+    assert "tuple(params.weight.shape) == (512, 4096)" in source
+    assert "use_deepseek_v4_shared_gate_up_gemv" in source
+
+
+def test_shared_gate_native_tile_precedes_generic_override() -> None:
+    source = (ROOT / "csrc/musa/gemv.mu").read_text()
+    selector = source.index("SelectDeepSeekV4Fp8SharedGateUpTile(")
+    dispatch = source.index("SelectDeepSeekV4Fp8SharedGateUpTile(", selector + 1)
+    forced = source.index("ParseForcedBlockConfig(&forced_config)", dispatch)
+    assert dispatch < forced
+    assert "BlockConfig{4, 32, 0.f, true}" in source[selector:dispatch]

--- a/tests/test_flashmla_sparse_direct_out.py
+++ b/tests/test_flashmla_sparse_direct_out.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm_musa.v1.attention.ops import flashmla
+
+
+class _FakeFlashMLA:
+    def __init__(self) -> None:
+        self.public_calls = 0
+
+    def flash_mla_sparse_fwd(self, **kwargs):
+        self.public_calls += 1
+        q = kwargs["q"]
+        result = torch.full_like(q, 3)
+        aux_shape = (q.shape[0], q.shape[1])
+        max_logits = torch.full(aux_shape, 4, dtype=torch.float32)
+        lse = torch.full(aux_shape, 5, dtype=torch.float32)
+        return result, max_logits, lse
+
+
+class _FakeAdapter:
+    def __init__(
+        self,
+        *,
+        result_idx: tuple[int, ...] = (8, 9, 10),
+        launch_error: Exception | None = None,
+    ) -> None:
+        self.result_idx = list(result_idx)
+        self.launch_error = launch_error
+        self.calls = 0
+
+    def executable(self, *args):
+        self.calls += 1
+        if self.launch_error is not None:
+            raise self.launch_error
+        out, max_logits, lse = args[-3:]
+        out.fill_(6)
+        max_logits.fill_(7)
+        lse.fill_(8)
+
+
+def _fake_kernel(
+    adapter: _FakeAdapter,
+    *,
+    backend: str = "tvm_ffi",
+    param_names: tuple[str, ...] = flashmla._MATE_SPARSE_DIRECT_OUT_PARAM_NAMES,
+):
+    return SimpleNamespace(
+        execution_backend=backend,
+        adapter=adapter,
+        prim_func=SimpleNamespace(
+            params=[SimpleNamespace(name=name) for name in param_names]
+        ),
+    )
+
+
+def _inputs(heads: int = 64):
+    q = torch.zeros((8, heads, 512), dtype=torch.bfloat16)
+    kv = torch.zeros((8, 1, 512), dtype=torch.bfloat16)
+    indices = torch.zeros((8, 1, 64), dtype=torch.int32)
+    topk_length = torch.full((8,), 64, dtype=torch.int32)
+    attn_sink = torch.zeros((heads,), dtype=torch.float32)
+    out = torch.empty_like(q)
+    return q, kv, indices, topk_length, attn_sink, out
+
+
+def _direct_out_patches(
+    adapter: _FakeAdapter,
+    *,
+    kernel_backend: str = "tvm_ffi",
+    param_names: tuple[str, ...] = flashmla._MATE_SPARSE_DIRECT_OUT_PARAM_NAMES,
+    raise_complete_if_dry_run=lambda: None,
+    is_musa_tensor=lambda tensor: True,
+    is_capturing=lambda: False,
+):
+    kernel = _fake_kernel(
+        adapter,
+        backend=kernel_backend,
+        param_names=param_names,
+    )
+    return patch.multiple(
+        flashmla,
+        _MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR=None,
+        _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED=True,
+        _mate_raise_complete_if_dry_run=raise_complete_if_dry_run,
+        _mate_resolve_num_mps=lambda device, requested: 1,
+        _mate_sparse_model1_kernel=lambda *args, **kwargs: kernel,
+        _mate_optional_prefill_attn_sink=lambda sink, heads, device: (
+            torch.empty((0,), dtype=torch.float32),
+            sink is not None,
+        ),
+        _mate_require_token_lengths=(
+            lambda lengths, seq_len, topk, device, name: lengths
+        ),
+        _is_musa_tensor=is_musa_tensor,
+        _is_current_stream_capturing=is_capturing,
+    )
+
+
+def _call(
+    fake: _FakeFlashMLA,
+    *,
+    allow_direct_out: bool,
+    heads: int = 64,
+    out_alias_q: bool = False,
+):
+    q, kv, indices, topk_length, attn_sink, out = _inputs(heads)
+    if out_alias_q:
+        out = q
+    with patch.object(flashmla, "_flash_mla", fake):
+        result = flashmla.flash_mla_sparse_fwd(
+            q,
+            kv,
+            indices,
+            1.0,
+            attn_sink=attn_sink,
+            topk_length=topk_length,
+            out=out,
+            allow_dsv4_tp8_mtp_direct_out=allow_direct_out,
+        )
+    return result, out
+
+
+def test_dsv4_tp8_sparse_prefill_writes_directly_to_out() -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    with _direct_out_patches(adapter):
+        (result, max_logits, lse), out = _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 0
+    assert adapter.calls == 1
+    assert result is out
+    assert torch.all(out == 6)
+    assert torch.all(max_logits == 7)
+    assert torch.all(lse == 8)
+
+
+@pytest.mark.parametrize(
+    ("allow_direct_out", "heads"),
+    [(False, 64), (True, 8)],
+)
+def test_sparse_prefill_preserves_public_fallback_without_exact_owner_and_shape(
+    allow_direct_out: bool,
+    heads: int,
+) -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    with _direct_out_patches(adapter):
+        (result, max_logits, lse), out = _call(
+            fake,
+            allow_direct_out=allow_direct_out,
+            heads=heads,
+        )
+
+    assert fake.public_calls == 1
+    assert adapter.calls == 0
+    assert result is out
+    assert torch.all(out == 3)
+    assert torch.all(max_logits == 4)
+    assert torch.all(lse == 5)
+
+
+def test_sparse_prefill_preserves_public_fallback_on_non_musa_device() -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    with _direct_out_patches(
+        adapter,
+        is_musa_tensor=flashmla._is_musa_tensor,
+    ):
+        _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 1
+    assert adapter.calls == 0
+
+
+def test_sparse_prefill_preserves_public_fallback_during_graph_capture() -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    with _direct_out_patches(adapter, is_capturing=lambda: True):
+        _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 1
+    assert adapter.calls == 0
+
+
+def test_sparse_prefill_preserves_public_fallback_when_out_aliases_input() -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    with _direct_out_patches(adapter):
+        _call(fake, allow_direct_out=True, out_alias_q=True)
+
+    assert fake.public_calls == 1
+    assert adapter.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("kernel_backend", "param_names", "result_idx"),
+    [
+        ("python", flashmla._MATE_SPARSE_DIRECT_OUT_PARAM_NAMES, (8, 9, 10)),
+        ("tvm_ffi", ("wrong",), (8, 9, 10)),
+        ("tvm_ffi", flashmla._MATE_SPARSE_DIRECT_OUT_PARAM_NAMES, (3, 4, 5)),
+    ],
+)
+def test_sparse_prefill_preserves_public_fallback_on_private_abi_mismatch(
+    kernel_backend: str,
+    param_names: tuple[str, ...],
+    result_idx: tuple[int, ...],
+) -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter(result_idx=result_idx)
+
+    with _direct_out_patches(
+        adapter,
+        kernel_backend=kernel_backend,
+        param_names=param_names,
+    ):
+        _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 1
+    assert adapter.calls == 0
+
+
+def test_sparse_prefill_dry_run_completes_before_private_launch() -> None:
+    class _DryRunComplete(RuntimeError):
+        pass
+
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    def _raise_dry_run() -> None:
+        raise _DryRunComplete
+
+    with _direct_out_patches(
+        adapter,
+        raise_complete_if_dry_run=_raise_dry_run,
+    ):
+        with pytest.raises(_DryRunComplete):
+            _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 0
+    assert adapter.calls == 0
+
+
+def test_sparse_prefill_does_not_retry_after_private_launch_failure() -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter(launch_error=RuntimeError("launch failed"))
+
+    with _direct_out_patches(adapter):
+        with pytest.raises(RuntimeError, match="launch failed"):
+            _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 0
+    assert adapter.calls == 1

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -60,6 +60,7 @@ def musa_fused_gemv(
     use_rms_norm: bool = False,
     gamma: torch.Tensor = None,
     eps: float = 1e-6,
+    output: torch.Tensor | None = None,
 ):
     use_int4_w4a16 = False
     out_shape = x.shape[:-1] + (
@@ -84,7 +85,13 @@ def musa_fused_gemv(
             qweight.dtype == torch.float8_e4m3fn
         ), "FP8 grouped matmul weight only support float8_e4m3fn!"
         assert qweight_scales is not None, "FP8 grouped matmul weight scales is None!"
-        output = torch.empty(out_shape, device=x.device, dtype=torch.bfloat16)
+        if output is None:
+            output = torch.empty(out_shape, device=x.device, dtype=torch.bfloat16)
+        else:
+            assert output.shape == out_shape
+            assert output.device == x.device
+            assert output.dtype == torch.bfloat16
+            assert output.is_contiguous()
         torch.ops._C_musa_ops.musa_fused_gemv(
             x,
             qweight,
@@ -109,6 +116,7 @@ def musa_fused_gemv(
         out_shape = x.shape[:-1] + (
             qweight.shape[0] if not use_swigelu else qweight.shape[0] // 2,
         )
+        assert output is None, "caller-owned output is only supported for FP8 GEMV"
         output = torch.empty(out_shape, device=x.device, dtype=x.dtype)
         torch.ops._C_musa_ops.musa_fused_gemv(
             x,
@@ -125,6 +133,7 @@ def musa_fused_gemv(
         return output
     # general gemv
     else:
+        assert output is None, "caller-owned output is only supported for FP8 GEMV"
         output = torch.empty(out_shape, device=x.device, dtype=x.dtype)
         torch.ops._C_musa_ops.musa_fused_gemv(
             x,

--- a/vllm_musa/deepseek_v4_jit/fp8_einsum.py
+++ b/vllm_musa/deepseek_v4_jit/fp8_einsum.py
@@ -161,13 +161,19 @@ def try_musa_deepseek_v4_fp8_einsum_gemv(
         from vllm_musa import _custom_ops as musa_ops
 
         for group_idx in range(groups):
+            group_out_view = out[:, group_idx, :]
+            direct_group_out = (
+                group_out_view if group_out_view.is_contiguous() else None
+            )
             group_out = musa_ops.musa_fused_gemv(
                 activation[:, group_idx, :].contiguous(),
                 weight[group_idx].contiguous(),
                 activation_scale[:, group_idx, :].contiguous(),
                 scales[group_idx].contiguous(),
+                output=direct_group_out,
             )
-            out[:, group_idx, :].copy_(group_out)
+            if direct_group_out is None:
+                group_out_view.copy_(group_out)
     except Exception as exc:
         return False, f"{type(exc).__name__}: {exc}"
 

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -53,9 +53,15 @@ def _should_use_musa_fp8_small_m_gemv(
     weight_scale: torch.Tensor,
     group_size: int,
     use_deep_gemm_e8m0: bool,
+    use_deepseek_v4_shared_gate_up_gemv: bool = False,
 ) -> bool:
+    use_calibrated_deepseek_v4_shape = (
+        use_deepseek_v4_shared_gate_up_gemv
+        and input.shape == (1, 4096)
+        and weight.shape == (512, 4096)
+    )
     if (
-        not _MUSA_FP8_SMALL_M_GEMV_ENABLED
+        not (_MUSA_FP8_SMALL_M_GEMV_ENABLED or use_calibrated_deepseek_v4_shape)
         or not current_platform.is_musa()
         or use_deep_gemm_e8m0
         or group_size != 128
@@ -87,6 +93,7 @@ class MUSADeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
 
     def __init__(self, config: FP8ScaledMMLinearLayerConfig):
         super().__init__(config)
+        self.use_deepseek_v4_shared_gate_up_gemv = False
         self.use_deep_gemm_e8m0 = False
         act_scale_descriptor = config.activation_quant_key.scale
         self.is_deep_gemm_supported = is_deep_gemm_supported()
@@ -104,6 +111,16 @@ class MUSADeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         super().process_weights_after_loading(layer)
         params = self._get_layer_params(layer)
         assert layer.weight_block_size is not None
+
+        # Shape alone cannot distinguish the DeepSeek-V4 shared-expert gate-up
+        # from unrelated dense projections.  Cache the layer identity while
+        # the module prefix is still available and route only the TP8 shared
+        # expert instance through the calibrated BF16-input/FP8-weight GEMV.
+        self.use_deepseek_v4_shared_gate_up_gemv = (
+            getattr(layer, "tp_size", None) == 8
+            and ".shared_experts.gate_up_proj" in getattr(layer, "prefix", "")
+            and tuple(params.weight.shape) == (512, 4096)
+        )
 
         if self.is_deep_gemm_supported:
             weight_scale_invs = params.weight_scale_inv
@@ -161,7 +178,15 @@ class MUSADeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         group_size = self.weight_group_shape.col
 
         return run_deepgemm(
-            A, B, Bs, group_size, self.use_deep_gemm_e8m0, output=kwargs.get("output")
+            A,
+            B,
+            Bs,
+            group_size,
+            self.use_deep_gemm_e8m0,
+            output=kwargs.get("output"),
+            use_deepseek_v4_shared_gate_up_gemv=(
+                self.use_deepseek_v4_shared_gate_up_gemv
+            ),
         )
 
 
@@ -172,9 +197,15 @@ def run_deepgemm(
     group_size: int,
     use_deep_gemm_e8m0: bool,
     output: torch.Tensor | None = None,
+    use_deepseek_v4_shared_gate_up_gemv: bool = False,
 ) -> torch.Tensor:
     if _should_use_musa_fp8_small_m_gemv(
-        input, weight, weight_scale, group_size, use_deep_gemm_e8m0
+        input,
+        weight,
+        weight_scale,
+        group_size,
+        use_deep_gemm_e8m0,
+        use_deepseek_v4_shared_gate_up_gemv,
     ):
         return torch.ops.vllm.musa_fp8_small_m_gemv_op(
             input,

--- a/vllm_musa/model_executor/layers/linear.py
+++ b/vllm_musa/model_executor/layers/linear.py
@@ -6,12 +6,6 @@ from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.model_executor.layers.linear import RowParallelLinear
 from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
 
-from vllm_musa.optimization_contract import (
-    OptimizationFeature,
-    prefers_optimization,
-)
-
-
 def _deepgemm_block_fp8(quant_method) -> bool:
     # MUSA: the DeepGemm block-FP8 kernel writes the GEMM result into a caller
     # buffer, so out_proj/o_proj can skip the output-buffer copy at tp=1.
@@ -37,10 +31,11 @@ class MusaRowParallelLinear(RowParallelLinear):
         activation and linear path unchanged.
         """
         fast = (
-            prefers_optimization(
-                self,
-                OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8,
-            )
+            # This hook is only called by DeepSeek-V4's MLP.  Keep the
+            # confirmed kernel path independent of the contract snapshot
+            # taken before vLLM's runtime config exists; the tensor guards
+            # below remain the authoritative safety checks.
+            not envs.VLLM_BATCH_INVARIANT
             and self.input_is_parallel
             and _deepgemm_block_fp8(self.quant_method)
             and self.bias is None

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -12,6 +12,7 @@ from .types import (
 )
 
 _DEEPSEEK_V4_ARCHITECTURES = ("DeepseekV4ForCausalLM",)
+_DEEPSEEK_V4_MTP_ARCHITECTURES = ("DeepSeekV4MTPModel",)
 _DEEPSEEK_V4_QUANTIZATION = frozenset({"fp8", "deepseek_v4_fp8"})
 
 
@@ -23,10 +24,18 @@ def _has_complete_identity(model: ModelSignature) -> bool:
     )
 
 
-def _matches_flash_base(model: ModelSignature) -> bool:
+def _has_complete_mtp_draft_identity(model: ModelSignature) -> bool:
+    architectures = model.outer_architectures or model.architectures
     return (
-        _has_complete_identity(model)
-        and model.dtype == "bfloat16"
+        architectures == _DEEPSEEK_V4_MTP_ARCHITECTURES
+        and model.model_type == "deepseek_mtp"
+        and model.outer_model_type == "deepseek_mtp"
+    )
+
+
+def _matches_flash_shape(model: ModelSignature) -> bool:
+    return (
+        model.dtype == "bfloat16"
         and model.quantization in _DEEPSEEK_V4_QUANTIZATION
         and model.hidden_size == 4096
         and model.num_hidden_layers == 43
@@ -49,6 +58,14 @@ def _matches_flash_base(model: ModelSignature) -> bool:
     )
 
 
+def _matches_flash_base(model: ModelSignature) -> bool:
+    return _has_complete_identity(model) and _matches_flash_shape(model)
+
+
+def _matches_mtp_draft_flash_base(model: ModelSignature) -> bool:
+    return _has_complete_mtp_draft_identity(model) and _matches_flash_shape(model)
+
+
 def _matches_tp8_reference(
     execution: ExecutionSignature,
     *,
@@ -68,11 +85,38 @@ def _matches_tp8_reference(
         and not execution.has_speculative_config
         and execution.has_quant_config
         and not execution.is_pooling_model
-        and execution.cache_dtype == "fp8"
+        and execution.cache_dtype in {"fp8", "fp8_ds_mla"}
         and max_num_seqs_matches
         and execution.attention_backend == "flashmla"
         and execution.compilation_mode == "none"
         and execution.cudagraph_mode == "full_decode_only"
+    )
+
+
+def _matches_tp8_mtp(execution: ExecutionSignature) -> bool:
+    if not execution.has_speculative_config:
+        return False
+    if execution.speculative_method not in ("mtp", "deepseek_mtp"):
+        return False
+    if execution.max_num_seqs is None or execution.max_num_seqs <= 1:
+        return False
+    return _matches_tp8_reference(
+        replace(execution, has_speculative_config=False),
+        allow_multi_batch=True,
+    )
+
+
+def _matches_tp8_mtp_draft(execution: ExecutionSignature) -> bool:
+    # The draft-local VllmConfig no longer contains the outer
+    # speculative_config. Its exact DeepSeek-V4 MTP model role is the MTP
+    # proof; retain every other execution guard.
+    return execution.max_num_seqs > 1 and _matches_tp8_reference(
+        replace(
+            execution,
+            has_speculative_config=False,
+            speculative_method="",
+        ),
+        allow_multi_batch=True,
     )
 
 
@@ -84,10 +128,17 @@ def resolve_deepseek_v4_contract(
     if (
         "DeepseekV4ForCausalLM" not in architectures
         and model.model_type != "deepseek_v4"
+        and "DeepSeekV4MTPModel" not in architectures
+        and model.model_type != "deepseek_mtp"
     ):
         return None
 
-    model = replace(model, family=ModelFamily.DEEPSEEK_V4, role=ModelRole.TEXT)
+    is_mtp_draft = _has_complete_mtp_draft_identity(model)
+    model = replace(
+        model,
+        family=ModelFamily.DEEPSEEK_V4,
+        role=ModelRole.MTP_DRAFT if is_mtp_draft else ModelRole.TEXT,
+    )
     supported: set[OptimizationFeature] = set()
     preferred: set[OptimizationFeature] = set()
 
@@ -102,6 +153,8 @@ def resolve_deepseek_v4_contract(
                 OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
+                OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT,
+                OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM,
             }
         )
         if execution.has_parallel_config:
@@ -121,7 +174,14 @@ def resolve_deepseek_v4_contract(
         ):
             preferred.add(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
 
-        if _matches_tp8_reference(execution):
+        if _matches_tp8_mtp(execution):
+            preferred.update(
+                {
+                    OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT,
+                    OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM,
+                }
+            )
+        elif _matches_tp8_reference(execution):
             preferred.update(
                 {
                     OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
@@ -129,11 +189,23 @@ def resolve_deepseek_v4_contract(
                 }
             )
 
-    profile = (
-        "deepseek_v4.tp8_flash_base"
-        if _matches_flash_base(model) and _matches_tp8_reference(execution)
-        else "deepseek_v4.unvalidated"
-    )
+    if _matches_mtp_draft_flash_base(model):
+        mtp_draft_features = {
+            OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT,
+            OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM,
+        }
+        supported.update(mtp_draft_features)
+        if _matches_tp8_mtp_draft(execution):
+            preferred.update(mtp_draft_features)
+
+    if _matches_mtp_draft_flash_base(model) and _matches_tp8_mtp_draft(execution):
+        profile = "deepseek_v4.tp8_flash_mtp_draft"
+    elif _matches_flash_base(model) and _matches_tp8_mtp(execution):
+        profile = "deepseek_v4.tp8_flash_base_mtp"
+    elif _matches_flash_base(model) and _matches_tp8_reference(execution):
+        profile = "deepseek_v4.tp8_flash_base"
+    else:
+        profile = "deepseek_v4.unvalidated"
     return MusaOptimizationContract(
         model=model,
         execution=execution,

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -49,7 +49,16 @@ def _matches_flash_base(model: ModelSignature) -> bool:
     )
 
 
-def _matches_tp8_reference(execution: ExecutionSignature) -> bool:
+def _matches_tp8_reference(
+    execution: ExecutionSignature,
+    *,
+    allow_multi_batch: bool = False,
+) -> bool:
+    max_num_seqs_matches = execution.max_num_seqs == 1
+    if allow_multi_batch:
+        max_num_seqs_matches = (
+            execution.max_num_seqs is not None and execution.max_num_seqs > 0
+        )
     return (
         execution.has_parallel_config
         and execution.tensor_parallel_size == 8
@@ -60,7 +69,7 @@ def _matches_tp8_reference(execution: ExecutionSignature) -> bool:
         and execution.has_quant_config
         and not execution.is_pooling_model
         and execution.cache_dtype == "fp8"
-        and execution.max_num_seqs == 1
+        and max_num_seqs_matches
         and execution.attention_backend == "flashmla"
         and execution.compilation_mode == "none"
         and execution.cudagraph_mode == "full_decode_only"
@@ -102,6 +111,16 @@ def resolve_deepseek_v4_contract(
                     OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
                 }
             )
+        # The shared-expert clamp + FP8 down-projection is shape-safe for every
+        # positive max-num-seqs in the same no-MTP TP8 decode contract.  The
+        # original migration accidentally restricted this already-validated
+        # path to the single-sequence capture experiment, disabling it for the
+        # production capture ladder (e.g. max-num-seqs=64).
+        if _matches_tp8_reference(execution, allow_multi_batch=True) and not (
+            execution.batch_invariant_enabled
+        ):
+            preferred.add(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+
         if _matches_tp8_reference(execution):
             preferred.update(
                 {
@@ -109,8 +128,6 @@ def resolve_deepseek_v4_contract(
                     OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
                 }
             )
-            if not execution.batch_invariant_enabled:
-                preferred.add(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
 
     profile = (
         "deepseek_v4.tp8_flash_base"

--- a/vllm_musa/optimization_contract/policy.py
+++ b/vllm_musa/optimization_contract/policy.py
@@ -14,6 +14,10 @@ from typing import Any
 from .resolver import resolve_optimization_contract
 from .types import OptimizationFeature
 
+_DEEPSEEK_V4_SPARSE_PADDED_HEADS = 64
+_DEEPSEEK_V4_SPARSE_HEAD_DIM = 512
+_DEEPSEEK_V4_SPARSE_DTYPE_BYTES = 2
+
 
 def prefers_feature(vllm_config: Any, feature: OptimizationFeature) -> bool:
     """Return whether a config's frozen contract prefers ``feature``."""
@@ -69,3 +73,24 @@ def deepseek_v4_flashmla_sparse_page_size(vllm_config: Any) -> int:
     ):
         return 256
     return 64
+
+
+def deepseek_v4_mtp_sparse_prefill_headroom_bytes(vllm_config: Any) -> int:
+    """Return transient H64 query workspace omitted by MTP profiling."""
+    if not prefers_feature(
+        vllm_config,
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM,
+    ):
+        return 0
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    max_num_batched_tokens = int(
+        getattr(scheduler_config, "max_num_batched_tokens", 0) or 0
+    )
+    if max_num_batched_tokens <= 0:
+        return 0
+    return (
+        max_num_batched_tokens
+        * _DEEPSEEK_V4_SPARSE_PADDED_HEADS
+        * _DEEPSEEK_V4_SPARSE_HEAD_DIM
+        * _DEEPSEEK_V4_SPARSE_DTYPE_BYTES
+    )

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -221,6 +221,7 @@ def _execution_signature(
     scheduler_config = getattr(vllm_config, "scheduler_config", None)
     attention_config = getattr(vllm_config, "attention_config", None)
     compilation_config = getattr(vllm_config, "compilation_config", None)
+    speculative_config = getattr(vllm_config, "speculative_config", None)
 
     def size(name: str) -> int:
         value = getattr(parallel_config, name, 1)
@@ -258,6 +259,7 @@ def _execution_signature(
             getattr(compilation_config, "cudagraph_mode", None)
         ),
         batch_invariant_enabled=batch_invariant_enabled,
+        speculative_method=_normalize_name(getattr(speculative_config, "method", None)),
     )
 
 
@@ -266,6 +268,7 @@ def resolve_optimization_contract(
     *,
     model_config: Any | None = None,
     is_pooling_model: bool = False,
+    attention_backend_hint: str | None = None,
 ) -> MusaOptimizationContract:
     if model_config is None:
         model_config = getattr(vllm_config, "model_config", None)
@@ -273,6 +276,11 @@ def resolve_optimization_contract(
         vllm_config,
         is_pooling_model=is_pooling_model,
     )
+    if execution.attention_backend is None and attention_backend_hint is not None:
+        execution = replace(
+            execution,
+            attention_backend=_normalize_name(attention_backend_hint),
+        )
     if model_config is None:
         model = ModelSignature(
             family=ModelFamily.UNKNOWN,

--- a/vllm_musa/optimization_contract/types.py
+++ b/vllm_musa/optimization_contract/types.py
@@ -15,6 +15,7 @@ class ModelFamily(str, Enum):
 class ModelRole(str, Enum):
     UNKNOWN = "unknown"
     TEXT = "text_generation"
+    MTP_DRAFT = "mtp_draft"
     COSYVOICE_TALKER = "cosyvoice_talker"
 
 
@@ -25,6 +26,10 @@ class OptimizationFeature(str, Enum):
         "deepseek_v4.materialized_prefill_indexer"
     )
     DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256 = "deepseek_v4.tp8_flashmla_sparse_page256"
+    DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT = "deepseek_v4.tp8_mtp_sparse_direct_out"
+    DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM = (
+        "deepseek_v4.tp8_mtp_sparse_prefill_headroom"
+    )
     DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256 = (
         "deepseek_v4.tp8_fused_add_rmsnorm_block256"
     )
@@ -104,6 +109,7 @@ class ExecutionSignature:
     compilation_mode: str | None = None
     cudagraph_mode: str | None = None
     batch_invariant_enabled: bool = False
+    speculative_method: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_musa/patches/series/0102-MUSA-preserve-DeepSeek-V4-MTP-sparse-prefill-headroom.patch
+++ b/vllm_musa/patches/series/0102-MUSA-preserve-DeepSeek-V4-MTP-sparse-prefill-headroom.patch
@@ -1,0 +1,172 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Sat, 8 Aug 2026 06:56:54 +0800
+Subject: [PATCH] MUSA: preserve DeepSeek-V4 MTP sparse-prefill headroom
+
+---
+ vllm/models/deepseek_v4/nvidia/flashmla.py | 56 +++++++++++++++++-----
+ vllm/v1/worker/gpu_worker.py               | 36 ++++++++++++--
+ 2 files changed, 77 insertions(+), 15 deletions(-)
+
+diff --git a/vllm/models/deepseek_v4/nvidia/flashmla.py b/vllm/models/deepseek_v4/nvidia/flashmla.py
+index 8839e3cbd5..3ebe58040e 100644
+--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
++++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
+@@ -4,8 +4,14 @@
+ from typing import TYPE_CHECKING, cast
+
+ import torch
++from vllm_musa.v1.attention.ops.flashmla import (
++    flash_mla_sparse_fwd,
++    flash_mla_with_kvcache,
++)
+
++from vllm.config import get_current_vllm_config_or_none
+ from vllm.forward_context import get_forward_context
++from vllm.logger import init_logger
+ from vllm.models.deepseek_v4.attention import DeepseekV4Attention
+ from vllm.models.deepseek_v4.common.ops import (
+     combine_topk_swa_indices,
+@@ -20,13 +26,13 @@ from vllm.models.deepseek_v4.sparse_mla import (
+     DeepseekV4FlashMLABackend,
+     DeepseekV4FlashMLAMetadata,
+ )
+-from vllm_musa.v1.attention.ops.flashmla import (
+-    flash_mla_sparse_fwd,
+-    flash_mla_with_kvcache,
+-)
++from vllm.platforms import current_platform
+ from vllm.v1.worker.workspace import current_workspace_manager
+
++logger = init_logger(__name__)
++
+ if TYPE_CHECKING:
++    from vllm.config import VllmConfig
+     from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
+
+
+@@ -35,9 +41,34 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
+
+     backend_cls = DeepseekV4FlashMLABackend
+
+-    def __init__(self, *args, **kwargs) -> None:
+-        super().__init__(*args, **kwargs)
++    def __init__(
++        self,
++        vllm_config: "VllmConfig",
++        *args,
++        **kwargs,
++    ) -> None:
++        super().__init__(vllm_config, *args, **kwargs)
+         self._einsum_recipe, self._tma_aligned_scales = compute_fp8_einsum_recipe()
++        self._musa_tp8_mtp_sparse_direct_out = False
++        if current_platform.is_musa():
++            from vllm_musa.optimization_contract import (
++                OptimizationFeature,
++                resolve_optimization_contract,
++            )
++
++            contract_vllm_config = get_current_vllm_config_or_none() or vllm_config
++            optimization_contract = resolve_optimization_contract(
++                contract_vllm_config,
++                attention_backend_hint="flashmla",
++            )
++            self._musa_tp8_mtp_sparse_direct_out = optimization_contract.prefers(
++                OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT
++            )
++            logger.debug_once(
++                "MUSA DeepSeek-V4 FlashMLA contract: profile=%s, direct_out=%s.",
++                optimization_contract.profile,
++                self._musa_tp8_mtp_sparse_direct_out,
++            )
+
+     def _o_proj(self, o: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+         return deep_gemm_fp8_o_proj(
+@@ -72,12 +103,12 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
+         positions: torch.Tensor,
+         output: torch.Tensor,
+     ) -> None:
+-        assert output.shape == q.shape, (
+-            f"output buffer shape {output.shape} must match q shape {q.shape}"
+-        )
+-        assert output.dtype == q.dtype, (
+-            f"output buffer dtype {output.dtype} must match q dtype {q.dtype}"
+-        )
++        assert (
++            output.shape == q.shape
++        ), f"output buffer shape {output.shape} must match q shape {q.shape}"
++        assert (
++            output.dtype == q.dtype
++        ), f"output buffer dtype {output.dtype} must match q dtype {q.dtype}"
+
+         # Get SWA and indexer metadata from forward context
+         forward_context = get_forward_context()
+@@ -354,4 +385,5 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
+                 attn_sink=self.attn_sink,
+                 topk_length=combined_lens,
+                 out=output[query_start:query_end],
++                allow_dsv4_tp8_mtp_direct_out=(self._musa_tp8_mtp_sparse_direct_out),
+             )
+diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
+index 4c4594a478..b64ea2addc 100644
+--- a/vllm/v1/worker/gpu_worker.py
++++ b/vllm/v1/worker/gpu_worker.py
+@@ -217,9 +217,9 @@ class Worker(WorkerBase):
+
+         allocator = get_mem_allocator_instance()
+         if tag == "weights":
+-            assert allocator.get_current_usage() == 0, (
+-                "CuMem allocator can only be used for one instance per process."
+-            )
++            assert (
++                allocator.get_current_usage() == 0
++            ), "CuMem allocator can only be used for one instance per process."
+         return allocator.use_memory_pool(tag=tag)
+
+     @contextmanager
+@@ -409,7 +409,24 @@ class Worker(WorkerBase):
+             You may limit the usage of GPU memory
+             by adjusting the `gpu_memory_utilization` parameter.
+         """
++        musa_workspace_headroom_bytes = 0
++        if current_platform.is_musa():
++            from vllm_musa.optimization_contract.policy import (
++                deepseek_v4_mtp_sparse_prefill_headroom_bytes,
++            )
++
++            musa_workspace_headroom_bytes = (
++                deepseek_v4_mtp_sparse_prefill_headroom_bytes(self.vllm_config)
++            )
++
+         if kv_cache_memory_bytes := self.cache_config.kv_cache_memory_bytes:
++            if musa_workspace_headroom_bytes > 0:
++                logger.warning_once(
++                    "Explicit kv_cache_memory_bytes bypasses the automatic "
++                    "%.2f GiB DeepSeek-V4 MTP sparse-prefill headroom; the "
++                    "configured byte budget must include that workspace.",
++                    musa_workspace_headroom_bytes / GiB_bytes,
++                )
+             # still need a profile run which compiles the model for
+             # max_num_batched_tokens
+             self.model_runner.profile_run()
+@@ -490,7 +507,20 @@ class Worker(WorkerBase):
+             self.requested_memory
+             - profile_result.non_kv_cache_memory
+             - cudagraph_memory_estimate_applied
++            - musa_workspace_headroom_bytes
+         )
++        if musa_workspace_headroom_bytes > 0:
++            if self.available_kv_cache_memory_bytes <= 0:
++                raise ValueError(
++                    "DeepSeek-V4 MTP sparse-prefill headroom leaves no memory "
++                    "for the KV cache. Lower max_num_batched_tokens or "
++                    "gpu_memory_utilization."
++                )
++            logger.info_once(
++                "Reserved %.2f GiB of DeepSeek-V4 MTP sparse-prefill "
++                "workspace before KV-cache sizing.",
++                musa_workspace_headroom_bytes / GiB_bytes,
++            )
+
+         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory
+         logger.debug(

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,9 +17,10 @@ is pre-patched.
   the highest prefix. Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **107 patches**. This branch adds Qwen3.6 patches for common GDN
+Currently **108 patches**. This branch adds Qwen3.6 patches for common GDN
 decode metadata reuse, uniform-decode SSM slot-mapping removal, and the BF16 W1
-tile specialization on top of the upstream 104-patch series. The series contains
+tile specialization, plus the contract-bound DeepSeek-V4 MTP sparse-prefill
+headroom patch, on top of the upstream 104-patch series. The series contains
 MUSA source edits against the immutable vLLM commit recorded as `VLLM_COMMIT`
 in `third_party/PINS` (release label `v0.24.0`), applied at build. Runtime
 object/registration patches (which patch live objects at import) are kept

--- a/vllm_musa/v1/attention/ops/flashmla.py
+++ b/vllm_musa/v1/attention/ops/flashmla.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Callable, TypeVar
+
 import torch
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -27,6 +30,58 @@ else:
             )
             _flash_mla = None
             break
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def _identity_decorator(func: _F) -> _F:
+    return func
+
+
+_MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR: Exception | None = None
+try:
+    from mate.api_logging import mate_api as _mate_api
+    from mate.execution_context import (
+        raise_complete_if_dry_run as _mate_raise_complete_if_dry_run,
+    )
+    from mate.mate_runtime import resolve_num_mps as _mate_resolve_num_mps
+    from mate.sparse_mla.tilelang.sparse_mla_model1_fwd_pipelined import (
+        sparse_attention_fwd_kernel_model1 as _mate_sparse_model1_kernel,
+    )
+    from mate.sparse_mla.tilelang.sparse_mla_prefill_common import (
+        optional_prefill_attn_sink as _mate_optional_prefill_attn_sink,
+    )
+    from mate.sparse_mla.tilelang.sparse_mla_prefill_common import (
+        require_token_lengths as _mate_require_token_lengths,
+    )
+except (ImportError, ModuleNotFoundError) as exc:
+    _MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR = exc
+    _mate_api = _identity_decorator
+    _mate_raise_complete_if_dry_run = None
+    _mate_resolve_num_mps = None
+    _mate_sparse_model1_kernel = None
+    _mate_optional_prefill_attn_sink = None
+    _mate_require_token_lengths = None
+
+try:
+    _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED = version("mate").split("+", 1)[0] == "0.2.4"
+except PackageNotFoundError:
+    _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED = False
+
+_MATE_SPARSE_DIRECT_OUT_PARAM_NAMES = (
+    "q_handle",
+    "kv_handle",
+    "indices_handle",
+    "topk_length_handle",
+    "extra_kv_handle",
+    "extra_indices_handle",
+    "extra_topk_length_handle",
+    "attn_sink_handle",
+    "output_handle",
+    "max_logits_out_handle",
+    "lse_handle",
+)
+_MATE_SPARSE_DIRECT_OUT_RESULT_INDICES = (8, 9, 10)
 
 
 class _UnavailableFlashMLASchedMeta:
@@ -110,6 +165,194 @@ def get_mla_metadata(*args, **kwargs):
     return flash_mla.get_mla_metadata(*args, **kwargs)
 
 
+def _is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return current_platform.is_musa() and tensor.device.type == "musa"
+
+
+def _is_current_stream_capturing() -> bool:
+    try:
+        is_capturing = getattr(
+            torch.get_device_module(),
+            "is_current_stream_capturing",
+            None,
+        )
+        return True if is_capturing is None else bool(is_capturing())
+    except Exception:
+        # The private direct-output shim is not capture-safe. Fail closed when
+        # the accelerator cannot report capture state.
+        return True
+
+
+def _tensors_overlap(left: torch.Tensor, right: torch.Tensor) -> bool:
+    if left.device != right.device or left.numel() == 0 or right.numel() == 0:
+        return False
+    left_start = left.data_ptr()
+    left_end = left_start + left.numel() * left.element_size()
+    right_start = right.data_ptr()
+    right_end = right_start + right.numel() * right.element_size()
+    return left_start < right_end and right_start < left_end
+
+
+def _out_overlaps_inputs(
+    out: torch.Tensor,
+    *inputs: torch.Tensor | None,
+) -> bool:
+    return any(
+        input_tensor is not None and _tensors_overlap(out, input_tensor)
+        for input_tensor in inputs
+    )
+
+
+def _can_use_dsv4_tp8_sparse_direct_out(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    attn_sink: torch.Tensor | None,
+    topk_length: torch.Tensor | None,
+    out: torch.Tensor | None,
+    d_v: int,
+    allow_dsv4_tp8_mtp_direct_out: bool,
+) -> bool:
+    return (
+        allow_dsv4_tp8_mtp_direct_out
+        and _MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR is None
+        and _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED
+        and _mate_raise_complete_if_dry_run is not None
+        and _mate_resolve_num_mps is not None
+        and _mate_sparse_model1_kernel is not None
+        and _mate_optional_prefill_attn_sink is not None
+        and _mate_require_token_lengths is not None
+        and out is not None
+        and topk_length is not None
+        and _is_musa_tensor(q)
+        and not _is_current_stream_capturing()
+        and d_v == 512
+        and q.ndim == 3
+        and q.shape[0] > 0
+        and q.shape[1:] == (64, 512)
+        and q.dtype == torch.bfloat16
+        and q.is_contiguous()
+        and out.shape == q.shape
+        and out.dtype == q.dtype
+        and out.device == q.device
+        and out.is_contiguous()
+        and kv.ndim == 3
+        and kv.shape[1:] == (1, 512)
+        and kv.dtype == torch.bfloat16
+        and kv.device == q.device
+        and kv.is_contiguous()
+        and indices.ndim == 3
+        and indices.shape[0] == q.shape[0]
+        and indices.shape[1] == 1
+        and indices.shape[2] % 64 == 0
+        and indices.dtype == torch.int32
+        and indices.device == q.device
+        and indices.is_contiguous()
+        and topk_length.shape == (q.shape[0],)
+        and topk_length.dtype == torch.int32
+        and topk_length.device == q.device
+        and (
+            attn_sink is None
+            or (
+                attn_sink.shape == (64,)
+                and attn_sink.dtype == torch.float32
+                and attn_sink.device == q.device
+                and attn_sink.is_contiguous()
+            )
+        )
+        and not _out_overlaps_inputs(
+            out,
+            q,
+            kv,
+            indices,
+            topk_length,
+            attn_sink,
+        )
+    )
+
+
+def _has_expected_mate_sparse_direct_out_abi(kernel: Any) -> bool:
+    adapter = getattr(kernel, "adapter", None)
+    prim_func = getattr(kernel, "prim_func", None)
+    params = getattr(prim_func, "params", ())
+    param_names = tuple(getattr(param, "name", None) for param in params)
+    result_indices = tuple(getattr(adapter, "result_idx", ()))
+    return (
+        getattr(kernel, "execution_backend", None) == "tvm_ffi"
+        and callable(getattr(adapter, "executable", None))
+        and param_names == _MATE_SPARSE_DIRECT_OUT_PARAM_NAMES
+        and result_indices == _MATE_SPARSE_DIRECT_OUT_RESULT_INDICES
+    )
+
+
+@_mate_api
+def _flash_mla_sparse_fwd_direct_out(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    attn_sink: torch.Tensor | None,
+    topk_length: torch.Tensor,
+    out: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+    assert _mate_raise_complete_if_dry_run is not None
+    assert _mate_resolve_num_mps is not None
+    assert _mate_sparse_model1_kernel is not None
+    assert _mate_optional_prefill_attn_sink is not None
+    assert _mate_require_token_lengths is not None
+
+    seq_len, heads, dim = q.shape
+    normalized_topk_length = _mate_require_token_lengths(
+        topk_length,
+        seq_len,
+        indices.shape[-1],
+        q.device,
+        "topk_length",
+    )
+    kernel = _mate_sparse_model1_kernel(
+        heads,
+        dim,
+        has_extra=False,
+        kv_group=kv.shape[1],
+        sm_scale=sm_scale,
+        has_attn_sink=attn_sink is not None,
+        is_persistence=True,
+        persistent_blocks=_mate_resolve_num_mps(q.device, None),
+    )
+    if not _has_expected_mate_sparse_direct_out_abi(kernel):
+        logger.warning_once(
+            "MATE sparse-prefill private ABI does not match the validated "
+            "0.2.4 layout; using the public FlashMLA path."
+        )
+        return None
+
+    _mate_raise_complete_if_dry_run()
+    attn_sink_arg, _ = _mate_optional_prefill_attn_sink(
+        attn_sink,
+        heads,
+        q.device,
+    )
+    max_logits = torch.empty((seq_len, heads), dtype=torch.float32, device=q.device)
+    lse = torch.empty((seq_len, heads), dtype=torch.float32, device=q.device)
+    kernel.adapter.executable(
+        q,
+        kv,
+        indices,
+        normalized_topk_length,
+        kv,
+        indices[:, :, :0],
+        normalized_topk_length,
+        attn_sink_arg,
+        out,
+        max_logits,
+        lse,
+    )
+    logger.info_once(
+        "Using caller-owned output for DeepSeek-V4 TP8 MATE sparse prefill."
+    )
+    return out, max_logits, lse
+
+
 def flash_mla_sparse_fwd(
     q: torch.Tensor,
     kv: torch.Tensor,
@@ -119,8 +362,34 @@ def flash_mla_sparse_fwd(
     attn_sink: torch.Tensor | None = None,
     topk_length: torch.Tensor | None = None,
     out: torch.Tensor | None = None,
+    allow_dsv4_tp8_mtp_direct_out: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     flash_mla = _require_flashmla()
+
+    can_use_direct_out = _can_use_dsv4_tp8_sparse_direct_out(
+        q,
+        kv,
+        indices,
+        attn_sink,
+        topk_length,
+        out,
+        d_v,
+        allow_dsv4_tp8_mtp_direct_out,
+    )
+    if can_use_direct_out:
+        assert topk_length is not None
+        assert out is not None
+        direct_result = _flash_mla_sparse_fwd_direct_out(
+            q,
+            kv,
+            indices,
+            sm_scale,
+            attn_sink,
+            topk_length,
+            out,
+        )
+        if direct_result is not None:
+            return direct_result
 
     result, max_logits, lse = flash_mla.flash_mla_sparse_fwd(
         q=q,


### PR DESCRIPTION
## Stack

This draft is stacked on #174 (`46550bcc1`). Until #174 lands, the GitHub diff
also includes its commits. The MUSA-60092 change itself is the single commit
`7a0093da0`.

## Problem

DeepSeek-V4 TP8 + MTP4 can OOM during multi-batch sparse prefill at
`--gpu-memory-utilization 0.95`. The failing path allocates a padded H64 BF16
result (about 512 MiB at 8192 tokens) before copying it into an output buffer
that DSV4 already owns.

Controls reproduced the OOM before #166 and with the page-size experiment, so
this is not a #166 regression. A runtime H8 attempt was rejected because it was
numerically wrong.

## Change

- Keep the correct H64 MATE 0.2.4 model1 kernel, but write directly into the
  caller-owned DSV4 output.
- Gate the private adapter shim on the exact DSV4 TP8 MTP contract, MUSA device,
  non-capture execution, tensor shape/dtype/layout, disjoint storage, dry-run
  semantics, and the validated TVM-FFI ABI. Every pre-launch mismatch uses the
  public path; launch failures are not retried.
- Reserve the exact transient H64 workspace before automatic KV-cache sizing:
  `max_num_batched_tokens * 64 * 512 * 2` bytes. For the PR configuration this
  is 537,067,520 bytes (0.5002 GiB). User `gpu_memory_utilization` is unchanged.
  Explicit `kv_cache_memory_bytes` remains authoritative and emits a warning.
- Fix contract drift seen in real workers: accept normalized `fp8_ds_mla`, and
  let the FlashMLA owner fill a missing backend hint without overriding an
  explicit conflicting backend.

## Evidence

Environment: 8x MTT S5000 80 GiB, driver 5.2.0-server, Python 3.10.12,
torch/torch_musa 2.9.1.post1+musa5.2.0s5000, torchada 0.1.76, MATE 0.2.4,
flash_mla 0.2.4+musa, flash_attn_3 0.2.4+musa, image
`v0.24.0-ph1-5.2.0-torch2.9.1.post1-20260725`.
Install was skipped for this Python/build-patch-only delta; the source overlay
used the exact #174 native extension artifact
`sha256:94bf688d4b720111cef4e4df7184f59dd9271d3d41303f8255565948852d8cdc`.

BS4, TP8, MTP4, FlashMLA, FP8 KV, 4K input / 1K output, five warmups followed
by 4 requests:

| Metric | Control | Candidate |
|---|---:|---:|
| Successful requests | 4/4 | 4/4 |
| KV-cache tokens | 67,772 | 66,827 |
| Sampled peak memory | 80,932 MiB | 80,082 MiB |
| Output throughput | 36.72 tok/s | 38.00 tok/s |
| Mean TTFT | 3,288.5 ms | 3,231.3 ms |
| Mean TPOT | 23.50 ms | 20.97 ms |
| Mean ITL | 76.39 ms | 76.08 ms |

The latency row is not a standalone performance claim: speculative acceptance
differed between the two single runs (55.9% vs 65.3%). It shows no observed
regression. The KV/memory deltas and request success are direct observations.

Numerics on S5000:

- direct vs public H64 output/max/LSE: bitwise equal;
- direct vs reference output max abs: 0.0078125;
- direct vs reference LSE max abs: 0.00000143.

Tests:

- focused contract/direct-output/source tests: `66 passed`;
- `tests/test_patches.py`: `71 passed, 2 skipped`;
- all 108 build patches apply cleanly to pinned vLLM. The verifier's remaining
  postcondition failure is the pre-existing `flash_attn.py` tripwire drift.

## Draft limitations

- Runs used `--disable-custom-all-reduce` because the default custom-AR path
  independently hangs during graph capture on the available 35.88/35.93
  hosts. All causal arms used the same setting.
- BS2, BS16/64, Qwen regression smokes, and repeated seeded A-R-A performance
  runs are not complete yet.
- Rebase onto `v0.24.0-dev` after #174 merges.
